### PR TITLE
Correct path to inflections.yml in USAGE.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -51,7 +51,7 @@ Here is a list of files generated:
 | Root package                | package.yml  | A package for the root folder |
 | Bin script                  | bin/packwerk | For Rails applications to run Packwerk validation on CI, see [Validating the package system](#Validating-the-package-system) |
 | Validation test             | test/packwerk_validator_test.rb | For Ruby projects to run Packwerk validation using tests, see [Validating the package system](#Validating-the-package-system) |
-| Custom inflections          | configs/inflections.yml | A custom inflections file is only required if you have custom inflections in `inflections.rb`, see [Inflections](#Inflections) |
+| Custom inflections          | config/inflections.yml | A custom inflections file is only required if you have custom inflections in `inflections.rb`, see [Inflections](#Inflections) |
 
 After that, you may begin creating packages for your application. See [Defining packages](#Defining-packages)
 
@@ -72,7 +72,7 @@ Packwerk reads from the `packwerk.yml` configuration file in the root directory.
 
 Packwerk requires custom inflections to be defined in `inflections.yml` instead of the traditional `inflections.rb`. This is because Packwerk accounts for custom inflections, such as acronyms, when resolving constants. Additionally, Packwerk interprets Active Record associations as references to constants. For example, `has_many :birds` is reference to the `Birds` constant.
 
-In order to make your custom inflections compatible with Active Support and Packwerk, you must create an `inflections.yml` file and point `ActiveSupport::Inflector` to that file.
+In order to make your custom inflections compatible with Active Support and Packwerk, you must create a `config/inflections.yml` file and point `ActiveSupport::Inflector` to that file.
 
 In `inflections.rb`, add:
 
@@ -80,12 +80,12 @@ In `inflections.rb`, add:
 ActiveSupport::Inflector.inflections do |inflect|
   # please add all custom inflections in the file below.
   Packwerk::Inflections::Custom.new(
-    Rails.root.join("inflections.yml")
+    Rails.root.join("config", "inflections.yml")
   ).apply_to(inflect)
 end
 ```
 
-Next, move your existing custom inflections into `inflections.yml`:
+Next, move your existing custom inflections into `config/inflections.yml`:
 
 ```yaml
 acronym:
@@ -99,7 +99,7 @@ uncountable:
   - 'payment_details'
 ```
 
-Any new inflectors should be added to `inflections.yml`.
+Any new inflectors should be added to `config/inflections.yml`.
 
 ## Validating the package system
 


### PR DESCRIPTION
The inflections.rb file wasn't reading the config/infections.yml file, leading
to problems loading the project, since the file path is inconsistent in the
documentation and the example Packwerk::Inflections::Custom call.

With Rails, inflections.yml is stored in the `config` directory, and the
example in the USAGE.md would look in the top level Rails.root directory.

## What are you trying to accomplish?

Make it easier to start using the tool

## What approach did you choose and why?

Only adjust documentation

## What should reviewers focus on?

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist

- [x] It is safe to simply rollback this change.
