### PR TITLE
Ignore paths from vendored gems inside the Rails root

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -61,13 +61,13 @@ After that, you may begin creating packages for your application. See [Defining 
 
 Packwerk reads from the `packwerk.yml` configuration file in the root directory. Packwerk will run with the default configuration if any of these settings are not specified.
 
-| Key                  | Default value                      | Description  |
-|----------------------|------------------------------------|--------------|
-| include              | **/*.{rb,rake,erb}                 | list of patterns for folder paths to include |
-| exclude              | {bin,node_modules,script,tmp}/**/* | list of patterns for folder paths to exclude |
-| package_paths        | **/                                | patterns to find package configuration files, see: Defining packages |
-| load_paths           | All application autoload paths     | list of load paths |
-| custom_associations  | N/A                                | list of custom associations, if any |
+| Key                  | Default value                             | Description  |
+|----------------------|-------------------------------------------|--------------|
+| include              | **/*.{rb,rake,erb}                        | list of patterns for folder paths to include |
+| exclude              | {bin,node_modules,script,tmp,vendor}/**/* | list of patterns for folder paths to exclude |
+| package_paths        | **/                                       | patterns to find package configuration files, see: Defining packages |
+| load_paths           | All application autoload paths            | list of load paths |
+| custom_associations  | N/A                                       | list of custom associations, if any |
 
 
 ### Inflections

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -28,7 +28,7 @@ module Packwerk
 
     DEFAULT_CONFIG_PATH = "packwerk.yml"
     DEFAULT_INCLUDE_GLOBS = ["**/*.{rb,rake,erb}"]
-    DEFAULT_EXCLUDE_GLOBS = ["{bin,node_modules,script,tmp}/**/*"]
+    DEFAULT_EXCLUDE_GLOBS = ["{bin,node_modules,script,tmp,vendor}/**/*"]
 
     attr_reader(
       :include, :exclude, :root_path, :package_paths, :custom_associations, :load_paths, :inflections_file,

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -58,10 +58,13 @@ module Packwerk
         (engine.config.autoload_paths + engine.config.eager_load_paths + engine.config.autoload_once_paths).uniq
       end
 
+      rails_root_match = Rails.root.join("**").to_s
+      bundle_path_match = Bundler.bundle_path.join("**").to_s
+
       all_paths = all_paths.map do |path_string|
-        # ignore paths outside of the Rails root
+        # ignore paths outside of the Rails root and gems
         path = Pathname.new(path_string)
-        if path.exist? && path.realpath.fnmatch(Rails.root.join("**").to_s)
+        if path.exist? && path.realpath.fnmatch(rails_root_match) && !path.realpath.fnmatch(bundle_path_match)
           path.relative_path_from(Rails.root).to_s
         end
       end

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -62,7 +62,7 @@ module Packwerk
       bundle_path_match = Bundler.bundle_path.join("**").to_s
 
       all_paths = all_paths.map do |path_string|
-        # ignore paths outside of the Rails root and gems
+        # ignore paths outside of the Rails root and vendored gems
         path = Pathname.new(path_string)
         if path.exist? && path.realpath.fnmatch(rails_root_match) && !path.realpath.fnmatch(bundle_path_match)
           path.relative_path_from(Rails.root).to_s

--- a/lib/packwerk/generators/templates/packwerk.yml.erb
+++ b/lib/packwerk/generators/templates/packwerk.yml.erb
@@ -7,7 +7,7 @@
 
 # List of patterns for folder paths to exclude
 # exclude:
-# - "{bin,node_modules,script,tmp}/**/*"
+# - "{bin,node_modules,script,tmp,vendor}/**/*"
 
 # Patterns to find package configuration files
 # package_paths: "**/"

--- a/test/fixtures/skeleton/packwerk.yml
+++ b/test/fixtures/skeleton/packwerk.yml
@@ -8,3 +8,4 @@ load_paths:
   - components/sales/app/models
   - components/timeline/app/models
   - components/timeline/app/models/concerns
+  - vendor/cache/gems/example/models

--- a/test/rails_test_helper.rb
+++ b/test/rails_test_helper.rb
@@ -13,6 +13,7 @@ class Dummy < Rails::Application
   config.autoload_once_paths = [
     skeleton("components", "timeline", "app", "models"),
     skeleton("components", "timeline", "app", "models", "concerns"),
+    skeleton("vendor", "cache", "gems", "example", "models"),
   ]
   config.root = skeleton(".")
 end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -61,8 +61,9 @@ module Packwerk
       Bundler.expects(:bundle_path).returns(Rails.root.join("vendor/cache/gems"))
 
       configuration = Configuration.from_path
+      expected_autoloads = default_autoloads - ["vendor/cache/gems/example/models"]
 
-      assert_equal default_autoloads, configuration.load_paths.sort
+      assert_equal expected_autoloads, configuration.load_paths.sort
     end
 
     private

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -47,7 +47,7 @@ module Packwerk
       configuration = Configuration.from_path
 
       assert_equal ["**/*.{rb,rake,erb}"], configuration.include
-      assert_equal ["{bin,node_modules,script,tmp}/**/*"], configuration.exclude
+      assert_equal ["{bin,node_modules,script,tmp,vendor}/**/*"], configuration.exclude
       assert_equal File.expand_path("."), configuration.root_path
       assert_equal default_autoloads, configuration.load_paths.sort
       assert_equal "**/", configuration.package_paths

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -55,6 +55,16 @@ module Packwerk
       assert_equal File.expand_path("config/inflections.yml"), configuration.inflections_file
     end
 
+    test ".from_path doesn't include load paths from vendored gems" do
+      File.expects(:exist?).with(Dir.pwd).returns(true)
+      File.expects(:file?).with(File.join(Dir.pwd, "packwerk.yml")).returns(false)
+      Bundler.expects(:bundle_path).returns(Rails.root.join("vendor/cache/gems"))
+
+      configuration = Configuration.from_path
+
+      assert_equal default_autoloads, configuration.load_paths.sort
+    end
+
     private
 
     # TODO: this isn't great, so let's come back and refactor so that we're in more control
@@ -65,6 +75,7 @@ module Packwerk
         "components/sales/app/models",
         "components/timeline/app/models",
         "components/timeline/app/models/concerns",
+        "vendor/cache/gems/example/models",
       ]
     end
   end


### PR DESCRIPTION
## What are you trying to accomplish?

Packwerk already ignores autoload paths outside of the Rails root directory, which means paths added by gems are usually ignored. However, when gems are packaged into the `vendor/cache` directory, this sits inside the Rails root, meaning that gem-added paths are not ignored. This change makes sure that these paths are ignored.

## What approach did you choose and why?

I have extended the code which selects paths in the Rails root directory to exclude paths which also match the load path returned by `Bundler.bundle_path`.

This is where the existing filtering was taking place, so it seems like a sensible place to add an additional check.

## What should reviewers focus on?

Testing this is not very simple, since it relies on building an app with vendored gems. The approach I have taken is to stub `Bundler.bundle_path` to return a path under the Rails root. I have tested this change against a real app with vendored gems and `Bundler.bundle_path` seems to be the correct method to use. But any thoughts on making the automated test more robust, and less reliant on stubbing Bundler, would be useful.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Additional Release Notes

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] It is safe to simply rollback this change.
