### PR TITLE
Turn expected and actual inflections into a set.

### DIFF
--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -170,8 +170,8 @@ module Packwerk
       Packwerk::Inflections::Custom.new(inflections_file).apply_to(test_inflections)
 
       results = %i(plurals singulars uncountables humans acronyms).map do |type|
-        expected = ActiveSupport::Inflector.inflections.public_send(type).to_a
-        actual = test_inflections.public_send(type).to_a
+        expected = ActiveSupport::Inflector.inflections.public_send(type).to_set
+        actual = test_inflections.public_send(type).to_set
 
         if expected == actual
           Result.new(true)


### PR DESCRIPTION
## What are you trying to accomplish?
Fix a bug in the `bin/packwerk validate` that incorrectly reports a mismatch in inflections. This scenario seems to occur when the inflection has been previously defined from a gem.

For example:
graphql-rails gem [defines a GraphiQL acronym here](https://github.com/rmosolgo/graphiql-rails/blob/0dee95827c5f1661238290f5873f70ea2bae413a/lib/graphiql/rails.rb#L6). The following inflection config will fail

```ruby
acronym:
  - "OAuth"
  - "GraphiQL" # <- this needs to come first.
```

## What approach did you choose and why?
Convert inflections into a set instead of an array to avoid false validation errors. Sorting the array won't work due to its heterogeneous nature.

## What should reviewers focus on?
Testing this is a little tricky. One simple but I think bad idea is to load a [second fixture file](https://github.com/Shopify/packwerk/blob/master/test/unit/application_validator_test.rb#L63) that contains the same acronyms in a different order.

A better but more involved approach is to break down the [application validator into individual validators ](https://github.com/Shopify/packwerk/blob/master/lib/packwerk/application_validator.rb#L26) which can help us write unit  tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] It is safe to simply rollback this change.
