### PR TITLE
Pass the file path to the formatter

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -130,7 +130,7 @@ module Packwerk
       all_offenses = T.let([], T.untyped)
       execution_time = Benchmark.realtime do
         all_offenses = files.flat_map do |path|
-          @run_context.file_processor.call(path).tap { |offenses| mark_progress(offenses) }
+          @run_context.file_processor.call(path).tap { |offenses| mark_progress(path, offenses) }
         end
 
         updating_deprecated_references.dump_deprecated_references_files
@@ -153,7 +153,7 @@ module Packwerk
       execution_time = Benchmark.realtime do
         files.each do |path|
           @run_context.file_processor.call(path).tap do |offenses|
-            mark_progress(offenses)
+            mark_progress(path, offenses)
             all_offenses.concat(offenses)
           end
         end
@@ -176,11 +176,11 @@ module Packwerk
       files
     end
 
-    def mark_progress(offenses)
+    def mark_progress(path, offenses)
       if offenses.empty?
-        @progress_formatter.mark_as_inspected
+        @progress_formatter.mark_as_inspected(path)
       else
-        @progress_formatter.mark_as_failed
+        @progress_formatter.mark_as_failed(path)
       end
     end
 

--- a/lib/packwerk/formatters/progress_formatter.rb
+++ b/lib/packwerk/formatters/progress_formatter.rb
@@ -29,11 +29,11 @@ module Packwerk
         @out.puts("✅ Packages are valid. Use `packwerk check` to run static checks.")
       end
 
-      def mark_as_inspected
+      def mark_as_inspected(_path)
         @out.print(".")
       end
 
-      def mark_as_failed
+      def mark_as_failed(_path)
         @out.print("#{@style.error}E#{@style.reset}")
       end
 

--- a/test/unit/formatters/progress_formatter_test.rb
+++ b/test/unit/formatters/progress_formatter_test.rb
@@ -37,12 +37,12 @@ module Packwerk
       end
 
       test "#mark_as_inspected prints a dot" do
-        @progress_formatter.mark_as_inspected
+        @progress_formatter.mark_as_inspected("/foo/bar.rb")
         assert_equal ".", @string_io.string
       end
 
       test "#mark_as_failed prints an E" do
-        @progress_formatter.mark_as_failed
+        @progress_formatter.mark_as_failed("/foo/bar.rb")
         assert_equal "E", @string_io.string
       end
 


### PR DESCRIPTION
## What are you trying to accomplish?
I can't get the `check` to finish on our repo because there are parsing errors (on both packwerk and our code). But when it errors, I can't tell where it's at. I've been adding `puts` to the cli. While I was there, I thought it'd make sense for the cli to pass along the path to the formatter in case someone wants to make a document-style formatter.

## What approach did you choose and why?
This is similar to how RSpec (and others) formatter works.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] It is safe to simply rollback this change.
