### PR TITLE
Add the ability to specify a custom public path for a package

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -181,7 +181,7 @@ You may prefer to override the default public folder, you can do so on a per-pac
 Example:
 
 ```yaml
-public_path: my/custom/path
+public_path: my/custom/path/
 ```
 
 #### Enforcing dependency boundary

--- a/USAGE.md
+++ b/USAGE.md
@@ -172,7 +172,17 @@ enforce_privacy:
 It will be a privacy violation when a file outside of the `components/merchandising` package tries to reference `Merchandising::Product`.
 
 ##### Using public folders
-You may enforce privacy either way mentioned above and still expose a public API for your package by placing constants in the `app/public` folder. The constants in the public folder will be made available for use by the rest of the application.
+You may enforce privacy either way mentioned above and still expose a public API for your package by placing constants in the public folder, which by default is `app/public`. The constants in the public folder will be made available for use by the rest of the application.
+
+##### Defining your own public folder
+
+You may prefer to override the default public folder, you can do so on a per-package basis by defining a `public_path`.
+
+Example:
+
+```yaml
+public_path: my/custom/path
+```
 
 #### Enforcing dependency boundary
 A package's dependency boundary is violated whenever it references a constant in some package that has not been declared as a dependency.

--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -113,7 +113,7 @@ module Packwerk
         hash = YAML.load_file(f)
         next unless hash
 
-        known_keys = %w(enforce_privacy enforce_dependencies dependencies metadata)
+        known_keys = %w(enforce_privacy enforce_dependencies public_path dependencies metadata)
         unknown_keys = hash.keys - known_keys
 
         unless unknown_keys.empty?
@@ -131,6 +131,16 @@ module Packwerk
         if hash.key?("enforce_dependencies")
           unless [TrueClass, FalseClass].include?(hash["enforce_dependencies"].class)
             errors << "Invalid 'enforce_dependencies' option in #{f.inspect}: #{hash['enforce_dependencies'].inspect}"
+          end
+        end
+
+        if hash.key?("public_path")
+          unless hash["public_path"].is_a?(String)
+            errors << "'public_path' option must be a string in #{f.inspect}: #{hash['public_path'].inspect}"
+          end
+
+          unless hash["public_path"].try(:last) == "/"
+            errors << "'public_path' option must end with a forward slash #{f.inspect}: #{hash['public_path'].inspect}"
           end
         end
 

--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -138,10 +138,6 @@ module Packwerk
           unless hash["public_path"].is_a?(String)
             errors << "'public_path' option must be a string in #{f.inspect}: #{hash['public_path'].inspect}"
           end
-
-          unless hash["public_path"].try(:last) == "/"
-            errors << "'public_path' option must end with a forward slash #{f.inspect}: #{hash['public_path'].inspect}"
-          end
         end
 
         next unless hash.key?("dependencies")

--- a/lib/packwerk/generators/templates/package.yml
+++ b/lib/packwerk/generators/templates/package.yml
@@ -13,7 +13,7 @@ enforce_privacy: false
 
 # By default the public path will be app/public/, however this may not suit all applications' architecture so
 # this allows you to modify what your package's public path is.
-public_path: app/public/
+# public_path: app/public/
 
 # A list of this package's dependencies
 # Note that packages in this list require their own `package.yml` file

--- a/lib/packwerk/generators/templates/package.yml
+++ b/lib/packwerk/generators/templates/package.yml
@@ -11,6 +11,10 @@ enforce_dependencies: true
 # We recommend enabling this for any new packages you create to aid with encapsulation.
 enforce_privacy: false
 
+# By default the public path will be app/public/, however this may not suit all applications' architecture so
+# this allows you to modify what your package's public path is.
+public_path: app/public/
+
 # A list of this package's dependencies
 # Note that packages in this list require their own `package.yml` file
 # dependencies:

--- a/lib/packwerk/package.rb
+++ b/lib/packwerk/package.rb
@@ -41,7 +41,10 @@ module Packwerk
     end
 
     def user_defined_public_path
-      @config["public_path"]
+      return unless @config["public_path"]
+      return @config["public_path"] if @config["public_path"].end_with?("/")
+
+      @config["public_path"] + "/"
     end
 
     def <=>(other)

--- a/lib/packwerk/package.rb
+++ b/lib/packwerk/package.rb
@@ -33,11 +33,15 @@ module Packwerk
     end
 
     def public_path
-      @public_path ||= File.join(@name, "app/public/")
+      @public_path ||= File.join(@name, user_defined_public_path || "app/public/")
     end
 
     def public_path?(path)
       path.start_with?(public_path)
+    end
+
+    def user_defined_public_path
+      @config["public_path"]
     end
 
     def <=>(other)

--- a/test/unit/package_test.rb
+++ b/test/unit/package_test.rb
@@ -26,8 +26,14 @@ module Packwerk
       assert_equal(true, root_package.package_path?("components/unknown"))
     end
 
-    test "#public_path returns expected path" do
+    test "#public_path returns expected path when using the default public path" do
       assert_equal("components/timeline/app/public/", @package.public_path)
+    end
+
+    test "#public_path returns expected path when using a user defined public path" do
+      package = Package.new(name: "components/timeline", config: { "public_path" => "my/path/" })
+
+      assert_equal("components/timeline/my/path/", package.public_path)
     end
 
     test "#package_path? returns true for path under the package's public path" do
@@ -47,6 +53,16 @@ module Packwerk
     test "#<=> does not compare against different class" do
       assert_nil(@package <=> "boop")
       assert_nil(@package <=> Hash.new(name: "boop"))
+    end
+
+    test "#user_defined_public_path returns nil when not set in the configuration" do
+      assert_nil(@package.user_defined_public_path)
+    end
+
+    test "#user_defined_public_path returns the same value as in the config when set" do
+      package = Package.new(name: "components/timeline", config: { "public_path" => "my/path" })
+
+      assert_equal("my/path", package.user_defined_public_path)
     end
   end
 end

--- a/test/unit/package_test.rb
+++ b/test/unit/package_test.rb
@@ -60,9 +60,15 @@ module Packwerk
     end
 
     test "#user_defined_public_path returns the same value as in the config when set" do
+      package = Package.new(name: "components/timeline", config: { "public_path" => "my/path/" })
+
+      assert_equal("my/path/", package.user_defined_public_path)
+    end
+
+    test "#user_defined_public_path adds a trailing forward slash to the path if it does not exist" do
       package = Package.new(name: "components/timeline", config: { "public_path" => "my/path" })
 
-      assert_equal("my/path", package.user_defined_public_path)
+      assert_equal("my/path/", package.user_defined_public_path)
     end
   end
 end


### PR DESCRIPTION
## What are you trying to accomplish?

See [this issue](https://github.com/Shopify/packwerk/issues/36) for details.

tl;dr I would like to be able to configure what a package's public path is.

## What approach did you choose and why?

The config was already available in the Package class, so I've simply added the documentation for that, amended the validator for this new parameter, and then used the user-defined public path if it's set, else the default.

## What should reviewers focus on?

Have I fully covered the tests required?

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] It is safe to simply rollback this change.
