### PR TITLE
Ignore package.yml found inside vendored gems

### DIFF
--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -325,7 +325,7 @@ module Packwerk
     end
 
     def package_manifests(glob_pattern)
-      Dir.glob(File.join(glob_pattern, Packwerk::PackageSet::PACKAGE_CONFIG_FILENAME)).map { |f| File.realpath(f) }
+      PackageSet.package_paths(@configuration.root_path, glob_pattern).map(&:to_s)
     end
 
     def relative_paths(paths)

--- a/lib/packwerk/package_set.rb
+++ b/lib/packwerk/package_set.rb
@@ -25,12 +25,14 @@ module Packwerk
         new(packages)
       end
 
-      private
-
       def package_paths(root_path, package_pathspec)
+        bundle_path_match = Bundler.bundle_path.join("**").to_s
+
         Dir.glob(File.join(root_path, package_pathspec, PACKAGE_CONFIG_FILENAME))
-          .map! { |path| Pathname.new(path) }
+          .map { |path| Pathname.new(path) }.reject { |path| path.realpath.fnmatch(bundle_path_match) }
       end
+
+      private
 
       def create_root_package_if_none_in(packages)
         return if packages.any?(&:root?)

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -39,6 +39,7 @@ module Packwerk
         new(
           root_path: configuration.root_path,
           load_paths: configuration.load_paths,
+          package_paths: configuration.package_paths,
           inflector: ActiveSupport::Inflector,
           custom_associations: configuration.custom_associations,
           reference_lister: default_reference_lister,

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -113,7 +113,12 @@ module Packwerk
 
     test "#execute_command with init subcommand runs application validation generator for non-Rails app" do
       string_io = StringIO.new
-      configuration = stub(root_path: @temp_dir, load_paths: ["path"], package_paths: "**/", custom_associations: ["cached_belongs_to"])
+      configuration = stub(
+        root_path: @temp_dir,
+        load_paths: ["path"],
+        package_paths: "**/",
+        custom_associations: ["cached_belongs_to"]
+      )
       cli = ::Packwerk::Cli.new(configuration: configuration, out: string_io)
 
       Packwerk::Generators::ApplicationValidation.expects(:generate).returns(true)
@@ -125,7 +130,12 @@ module Packwerk
 
     test "#execute_command with init subcommand runs application validation generator, fails and prints error" do
       string_io = StringIO.new
-      configuration = stub(root_path: @temp_dir, load_paths: ["path"], package_paths: "**/", custom_associations: ["cached_belongs_to"])
+      configuration = stub(
+        root_path: @temp_dir,
+        load_paths: ["path"],
+        package_paths: "**/",
+        custom_associations: ["cached_belongs_to"]
+      )
       cli = ::Packwerk::Cli.new(configuration: configuration, out: string_io)
 
       Packwerk::Generators::ApplicationValidation.expects(:generate).returns(false)

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -113,7 +113,7 @@ module Packwerk
 
     test "#execute_command with init subcommand runs application validation generator for non-Rails app" do
       string_io = StringIO.new
-      configuration = stub(root_path: @temp_dir, load_paths: ["path"], custom_associations: ["cached_belongs_to"])
+      configuration = stub(root_path: @temp_dir, load_paths: ["path"], package_paths: "**/", custom_associations: ["cached_belongs_to"])
       cli = ::Packwerk::Cli.new(configuration: configuration, out: string_io)
 
       Packwerk::Generators::ApplicationValidation.expects(:generate).returns(true)
@@ -125,7 +125,7 @@ module Packwerk
 
     test "#execute_command with init subcommand runs application validation generator, fails and prints error" do
       string_io = StringIO.new
-      configuration = stub(root_path: @temp_dir, load_paths: ["path"], custom_associations: ["cached_belongs_to"])
+      configuration = stub(root_path: @temp_dir, load_paths: ["path"], package_paths: "**/", custom_associations: ["cached_belongs_to"])
       cli = ::Packwerk::Cli.new(configuration: configuration, out: string_io)
 
       Packwerk::Generators::ApplicationValidation.expects(:generate).returns(false)

--- a/test/unit/package_set_test.rb
+++ b/test/unit/package_set_test.rb
@@ -31,5 +31,16 @@ module Packwerk
     test "#fetch returns nil for unknown package name" do
       assert_nil(@package_set.fetch("components/unknown"))
     end
+
+    test ".package_paths excludes paths inside the gem directory" do
+      vendor_package_path = Pathname.new("test/fixtures/skeleton/vendor/cache/gems/example/package.yml")
+
+      package_paths = PackageSet.package_paths("test/fixtures/skeleton", "**")
+      assert_includes(package_paths, vendor_package_path)
+
+      Bundler.expects(:bundle_path).returns(Rails.root.join("vendor/cache/gems"))
+      package_paths = PackageSet.package_paths("test/fixtures/skeleton", "**")
+      refute_includes(package_paths, vendor_package_path)
+    end
   end
 end


### PR DESCRIPTION
## What are you trying to accomplish?

Following up on my previous PR (https://github.com/Shopify/packwerk/pull/21), which prevented loading of paths inside the `vendor/cache` directory, the `packwerk validate` command can still fail due to the presence of `package.yml` files inside gems.

Searching for `package.yml` files should follow the same rules, and ignore anything inside the Bundler gem directory.

## What approach did you choose and why?

I made `PackageSet.package_paths` public so it could be shared with `ApplicationValidator` to avoid duplication. Then made sure that any paths inside `Bundler.bundle_path` are excluded from the set of package file paths.

I also noticed that `RunContext` was not correctly passing along the `package_paths` configuration option. So there is a one-line fix for that, plus 2 test stub changes to support it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] It is safe to simply rollback this change.
