### PR TITLE
Add support for minitest-focus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,5 @@ gem("tapioca", require: false)
 
 group :development do
   gem("byebug", require: false)
+  gem("minitest-focus", require: false)
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
+    minitest-focus (1.2.1)
+      minitest (>= 4, < 6)
     mocha (1.11.2)
     nio4r (2.5.2)
     nokogiri (1.10.9)
@@ -220,6 +222,7 @@ DEPENDENCIES
   byebug
   constant_resolver
   m
+  minitest-focus
   mocha
   packwerk!
   rails!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require "constant_resolver"
 require "packwerk"
 
 require "minitest/autorun"
+require "minitest/focus"
 require "support/test_macro"
 require "support/test_assertions"
 


### PR DESCRIPTION
## What are you trying to accomplish?
I would like to be able to use [minitest-focus](https://github.com/seattlerb/minitest-focus) as I develop tests and debug issues.  I can mark a few tests of interest with the `focus` method and then run `dev test`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] It is safe to simply rollback this change.

## 🎩 
Call the `focus` method on a line that preceeds a test you wish to run, e.g.
```ruby
# test/unit/application_validator_test.rb
    focus
    test "validity" do
    # ...
    end

    test "returns an error for unresolvable privatized constants" do
    # ...
    end
```
Only that test will run when `rake test` or `dev test` is run:
```
➜  packwerk git:(add-minitest-focus-gem) dev test
👩‍💻  Running if [[ "$*" =~ ":"[0-9]+ ]];... from dev.yml
[ ... ]
# Running:

.

Finished in 0.030783s, 32.4855 runs/s, 32.4855 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
➜  packwerk git:(add-minitest-focus-gem) ✗
```