### PR TITLE
ignore .byebug_history in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 /.bundle/
 /tmp/
 .rubocop-*
+.byebug_history
 sorbet/rbi/hidden-definitions/errors.txt


### PR DESCRIPTION
## What are you trying to accomplish?

I was looking into the code with byebug and accidentally committed the .byebug_history on another branch. Since it is pretty common to use byebug to debug code I think it makes sense to add the `.byebug_history` file to the `.gitignore` list.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Configuration Change

## Checklist

- [x] It is safe to simply rollback this change.
