### PR TITLE
Fix inflections bug that resulted in missed constant associations violations 

### DIFF
--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -170,14 +170,12 @@ module Packwerk
     def check_inflection_file
       inflections_file = @configuration.inflections_file
 
-      test_inflections = ActiveSupport::Inflector::Inflections.new
-
-      Packwerk::Inflections::Default.apply_to(test_inflections)
-      Packwerk::Inflections::Custom.new(inflections_file).apply_to(test_inflections)
+      application_inflections = ActiveSupport::Inflector.inflections
+      packwerk_inflections = Packwerk::Inflector.from_file(inflections_file).inflections
 
       results = %i(plurals singulars uncountables humans acronyms).map do |type|
-        expected = ActiveSupport::Inflector.inflections.public_send(type).to_set
-        actual = test_inflections.public_send(type).to_set
+        expected = application_inflections.public_send(type).to_set
+        actual = packwerk_inflections.public_send(type).to_set
 
         if expected == actual
           Result.new(true)

--- a/lib/packwerk/association_inspector.rb
+++ b/lib/packwerk/association_inspector.rb
@@ -16,7 +16,7 @@ module Packwerk
       has_and_belongs_to_many
     ).to_set
 
-    def initialize(inflector: Inflector.new, custom_associations: Set.new)
+    def initialize(inflector:, custom_associations: Set.new)
       @inflector = inflector
       @associations = RAILS_ASSOCIATIONS + custom_associations
     end

--- a/lib/packwerk/inflector.rb
+++ b/lib/packwerk/inflector.rb
@@ -8,20 +8,31 @@ require "packwerk/inflections/custom"
 module Packwerk
   class Inflector
     class << self
+      extend T::Sig
+
       def default
         @default ||= new
       end
+
+      sig { params(inflections_file: String).returns(::Packwerk::Inflector) }
+      def from_file(inflections_file)
+        new(custom_inflector: Inflections::Custom.new(inflections_file))
+      end
     end
 
-    # For #camelize, #classify, #pluralize, #singularize
-    include ::ActiveSupport::Inflector
+    extend T::Sig
+    include ::ActiveSupport::Inflector # For #camelize, #classify, #pluralize, #singularize
 
-    def initialize(custom_inflection_file: nil)
+    sig do
+      params(
+        custom_inflector: Inflections::Custom
+      ).void
+    end
+    def initialize(custom_inflector: Inflections::Custom.new)
       @inflections = ::ActiveSupport::Inflector::Inflections.new
 
       Inflections::Default.apply_to(@inflections)
-
-      Inflections::Custom.new(custom_inflection_file).apply_to(@inflections)
+      custom_inflector.apply_to(@inflections)
     end
 
     def pluralize(word, count = nil)

--- a/lib/packwerk/inflector.rb
+++ b/lib/packwerk/inflector.rb
@@ -43,8 +43,6 @@ module Packwerk
       end
     end
 
-    private
-
     def inflections(_ = nil)
       @inflections
     end

--- a/lib/packwerk/inflector.rb
+++ b/lib/packwerk/inflector.rb
@@ -11,7 +11,7 @@ module Packwerk
       extend T::Sig
 
       def default
-        @default ||= new
+        @default ||= new(custom_inflector: Inflections::Custom.new)
       end
 
       sig { params(inflections_file: String).returns(::Packwerk::Inflector) }
@@ -28,7 +28,7 @@ module Packwerk
         custom_inflector: Inflections::Custom
       ).void
     end
-    def initialize(custom_inflector: Inflections::Custom.new)
+    def initialize(custom_inflector:)
       @inflections = ::ActiveSupport::Inflector::Inflections.new
 
       Inflections::Default.apply_to(@inflections)

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "active_support/inflector"
 require "constant_resolver"
 
 require "packwerk/association_inspector"
@@ -10,6 +9,7 @@ require "packwerk/constant_discovery"
 require "packwerk/const_node_inspector"
 require "packwerk/dependency_checker"
 require "packwerk/file_processor"
+require "packwerk/inflector"
 require "packwerk/node_processor"
 require "packwerk/package_set"
 require "packwerk/privacy_checker"
@@ -36,11 +36,13 @@ module Packwerk
       def from_configuration(configuration, reference_lister: nil)
         default_reference_lister = reference_lister ||
           ::Packwerk::CheckingDeprecatedReferences.new(configuration.root_path)
+        inflector = ::Packwerk::Inflector.from_file(configuration.inflections_file)
+
         new(
           root_path: configuration.root_path,
           load_paths: configuration.load_paths,
           package_paths: configuration.package_paths,
-          inflector: ActiveSupport::Inflector,
+          inflector: inflector,
           custom_associations: configuration.custom_associations,
           reference_lister: default_reference_lister,
         )

--- a/test/fixtures/skeleton/components/sales/app/models/payment_details.rb
+++ b/test/fixtures/skeleton/components/sales/app/models/payment_details.rb
@@ -1,0 +1,4 @@
+# typed: ignore
+# frozen_string_literal: true
+
+class PaymentDetails; end

--- a/test/fixtures/skeleton/config/environment.rb
+++ b/test/fixtures/skeleton/config/environment.rb
@@ -1,0 +1,7 @@
+require "packwerk/inflections/custom"
+
+ActiveSupport::Inflector.inflections do |inflect|
+  Packwerk::Inflections::Custom.new(
+    Rails.root.join("custom_inflections.yml")
+  ).apply_to(inflect)
+end

--- a/test/fixtures/skeleton/different_inflections.yml
+++ b/test/fixtures/skeleton/different_inflections.yml
@@ -1,0 +1,4 @@
+acronym:
+  - 'TLA'
+  - 'WTF'
+  - 'LOL'

--- a/test/fixtures/skeleton/packwerk.yml
+++ b/test/fixtures/skeleton/packwerk.yml
@@ -9,3 +9,4 @@ load_paths:
   - components/timeline/app/models
   - components/timeline/app/models/concerns
   - vendor/cache/gems/example/models
+inflections_file: "custom_inflections.yml"

--- a/test/integration/custom_executable_test.rb
+++ b/test/integration/custom_executable_test.rb
@@ -35,6 +35,19 @@ module Packwerk
         assert_match(/1 offense detected/, captured_output)
       end
 
+      test "'packwerk check' with violations accounts for custom inflections, fails and displays violations" do
+        Tempfile.create(["timeline_comment", ".rb"], timeline_path("app", "models")) do |file|
+          # payment_details is an uncountable inflection
+          file.write("class TimelineComment; has_one :payment_details; end")
+          file.flush
+
+          refute_successful_run("check")
+        end
+
+        assert_match(/Privacy violation: '::PaymentDetails'/, captured_output)
+        assert_match(/1 offense detected/, captured_output)
+      end
+
       test "'packwerk update-deprecations' with no violations succeeds and updates no files" do
         deprecated_reference_content = read_deprecated_references
 

--- a/test/unit/application_validator_test.rb
+++ b/test/unit/application_validator_test.rb
@@ -42,7 +42,7 @@ module Packwerk
     test "returns error for mismatched inflections.yml file" do
       config_path = "test/fixtures/skeleton/packwerk.yml"
       configs = YAML.load_file(config_path)
-      configs["inflections_file"] = "custom_inflections.yml"
+      configs["inflections_file"] = "different_inflections.yml"
 
       configuration = Packwerk::Configuration.new(configs, config_path: config_path)
 

--- a/test/unit/application_validator_test.rb
+++ b/test/unit/application_validator_test.rb
@@ -9,6 +9,9 @@ require "packwerk/application_validator"
 # make sure PrivateThing.constantize succeeds to pass the privacy validity check
 require "fixtures/skeleton/components/timeline/app/models/private_thing.rb"
 
+# make sure the application has a chance to load its inflections
+require "fixtures/skeleton/config/environment"
+
 module Packwerk
   class ApplicationValidatorTest < Minitest::Test
     setup do

--- a/test/unit/association_inspector_test.rb
+++ b/test/unit/association_inspector_test.rb
@@ -6,51 +6,55 @@ require "parser_test_helper"
 
 module Packwerk
   class AssociationInspectorTest < Minitest::Test
+    setup do
+      @inflector = Inflector.new(custom_inflector: Inflections::Custom.new)
+    end
+
     test "#association? understands custom associations" do
       node = parse("has_lots :order")
-      inspector = AssociationInspector.new(custom_associations: [:has_lots])
+      inspector = AssociationInspector.new(inflector: @inflector, custom_associations: [:has_lots])
 
       assert_equal "Order", inspector.constant_name_from_node(node, ancestors: [])
     end
 
     test "finds target constant for simple association" do
       node = parse("has_one :order")
-      inspector = AssociationInspector.new
+      inspector = AssociationInspector.new(inflector: @inflector)
 
       assert_equal "Order", inspector.constant_name_from_node(node, ancestors: [])
     end
 
     test "finds target constant for association that pluralizes" do
       node = parse("has_many :orders")
-      inspector = AssociationInspector.new
+      inspector = AssociationInspector.new(inflector: @inflector)
 
       assert_equal "Order", inspector.constant_name_from_node(node, ancestors: [])
     end
 
     test "finds target constant for association if explicitly specified" do
       node = parse("has_one :cool_order, { class_name: 'Order' }")
-      inspector = AssociationInspector.new
+      inspector = AssociationInspector.new(inflector: @inflector)
 
       assert_equal "Order", inspector.constant_name_from_node(node, ancestors: [])
     end
 
     test "rejects method calls that are not associations" do
       node = parse('puts "Hello World"')
-      inspector = AssociationInspector.new
+      inspector = AssociationInspector.new(inflector: @inflector)
 
       assert_nil inspector.constant_name_from_node(node, ancestors: [])
     end
 
     test "gives up on metaprogrammed associations" do
       node = parse("has_one association_name")
-      inspector = AssociationInspector.new
+      inspector = AssociationInspector.new(inflector: @inflector)
 
       assert_nil inspector.constant_name_from_node(node, ancestors: [])
     end
 
     test "gives up on dynamic class name" do
       node = parse("has_one :order, class_name: Order.name")
-      inspector = AssociationInspector.new
+      inspector = AssociationInspector.new(inflector: @inflector)
 
       assert_nil inspector.constant_name_from_node(node, ancestors: [])
     end

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -117,7 +117,8 @@ module Packwerk
         root_path: @temp_dir,
         load_paths: ["path"],
         package_paths: "**/",
-        custom_associations: ["cached_belongs_to"]
+        custom_associations: ["cached_belongs_to"],
+        inflections_file: "config/inflections.yml"
       )
       cli = ::Packwerk::Cli.new(configuration: configuration, out: string_io)
 
@@ -134,7 +135,8 @@ module Packwerk
         root_path: @temp_dir,
         load_paths: ["path"],
         package_paths: "**/",
-        custom_associations: ["cached_belongs_to"]
+        custom_associations: ["cached_belongs_to"],
+        inflections_file: "config/inflections.yml"
       )
       cli = ::Packwerk::Cli.new(configuration: configuration, out: string_io)
 

--- a/test/unit/inflector_test.rb
+++ b/test/unit/inflector_test.rb
@@ -8,7 +8,7 @@ require "packwerk/inflector"
 module Packwerk
   class InflectorTest < Minitest::Test
     def setup
-      @inflector = Inflector.new
+      @inflector = inflector_for(file: "config/inflections.yml")
     end
 
     test "acts like activesupport inflector" do
@@ -37,6 +37,27 @@ module Packwerk
     test "#pluralize will singularize when count is 1" do
       assert_equal "thing", @inflector.pluralize("thing", 1)
       assert_equal "thing", @inflector.pluralize("things", 1)
+    end
+
+    test "#initialize will apply custom inflections from file" do
+      inflector = inflector_for(file: "test/fixtures/skeleton/custom_inflections.yml")
+
+      assert_equal "graphql", inflector.underscore("GraphQL")
+      assert_equal "payment_details", inflector.singularize("payment_details")
+    end
+
+    test "#initialize will not apply custom inflections if there aren't any" do
+      inflector = inflector_for(file: "no_inflections_here.yml")
+
+      assert_equal "graph_ql", inflector.underscore("GraphQL")
+      assert_equal "payment_detail", inflector.singularize("payment_details")
+    end
+
+    private
+
+    def inflector_for(file:)
+      custom_inflector = Packwerk::Inflections::Custom.new(file)
+      Inflector.new(custom_inflector: custom_inflector)
     end
   end
 end


### PR DESCRIPTION
## What are you trying to accomplish?

https://github.com/Shopify/packwerk/issues/48

**TL;DR:** 

Packwerk should be reading from the `inflections.yml` file (or whatever custom association file specified) of an application directly, even when Packwerk is run without any files loaded (i.e. via `bundle exec packwerk check`). 

Recently, we found that constant associations were not read properly, which resulted in missing violations in a shitlist. However, if you run it with the application files loaded (i.e. with `bin/packwerk` or `bin/spring`) you would get the expected behaviour. 


## What approach did you choose and why?

`RunContext` was using `ActiveSupport::Inflector`, which passes it along to the `AssociationInspector`. When the files are not loaded from the application, no custom associations gets registered because `ActiveSupport::Inflector` has no knowledge of any custom inflector. 

The bug was initially missed because when files are loaded from the application, `inflections.rb` runs `ActiveSupport::Inflector.inflections` to [apply the custom inflections to Packwerk](https://github.com/Shopify/shopify/blob/98237b83a87d2726b78b5844986b9c12dc225f46/config/initializers/004_inflections.rb#L8-L11). 

We should ensure Packwerk's run behaviour is the same whether or not the application files are loaded. In order to do that, we should be using `Packwerk::Inflector` in `RunContext`, which would read from the custom inflections file. 

Changes in this PR: 

- Some improvements to `Packwerk::Inflector` making it more testable. 
  - Add a constructor that takes in a file path and creates a `Packwerk::Inflections::Custom` object
  - Add test cases ensuring custom inflections are applied
- The changes to `RunContext` to fix the bug
  - Use `Packwerk::Inflector`'s constructor, so `RunContext` doesn't need to know about `Packwerk::Inflections::Custom`
  - Add integration test case that specifically tests the constant association bug we found
- Fix the broken `ApplicationValidator` check for inflections as it was also using `ActiveSupport::Inflector` 
  - Swap `ActiveSupport::Inflector` to `Packwerk::Inflector` in application validation check 
- Remove a test case in `ApplicationValidator` which I believes is now irrelevant as it was testing the incorrect behaviour of for custom inflections 

## What should reviewers focus on?

Everything. This change looks like a huge ass PR so I broke down the changes by commits. I believe it makes sense as a single PR though. 

I'll also add comments to guide your review.

Does this change make sense? Is there another test I can add?  

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Additional Release Notes

This bug fix may result in additional valid violations being found / recorded in applications with custom inflections, such as Core. 

## Checklist

- [x] It is safe to simply rollback this change.
