### PR TITLE
Update TROUBLESHOOT.md

### DIFF
--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -16,7 +16,7 @@ You can specify folders or packages in Packwerk commands for a shorter run time:
 
      bundle exec packwerk check components/your_package
 
-     bundle exec packwerk update-deprecations components/your_package
+     bundle exec packwerk update components/your_package
 
 _Note: You cannot specify folders or packages for `packwerk validate` because the command runs for the entire application._
 


### PR DESCRIPTION
Updating documentation
```bash
bundle exec packwerk update-deprecations
# => 'update-deprecations' is not a packwerk command. See `packwerk help`.
```
The command has been replaced with `bundle exec packwerk update`

```bash
packwerk help

#=> Subcommands:
        init - set up packwerk
        check - run all checks
        update - update deprecated references
        validate - verify integrity of packwerk and package configuration
```
## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change ~requires~ is a documentation update

## Checklist

- [x] It is safe to simply rollback this change.
