### PR TITLE
Correct Referenced Constant

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -70,7 +70,7 @@ Packwerk reads from the `packwerk.yml` configuration file in the root directory.
 
 ### Inflections
 
-Packwerk requires custom inflections to be defined in `inflections.yml` instead of the traditional `inflections.rb`. This is because Packwerk accounts for custom inflections, such as acronyms, when resolving constants. Additionally, Packwerk interprets Active Record associations as references to constants. For example, `has_many :birds` is a reference to the `Birds` constant.
+Packwerk requires custom inflections to be defined in `inflections.yml` instead of the traditional `inflections.rb`. This is because Packwerk accounts for custom inflections, such as acronyms, when resolving constants. Additionally, Packwerk interprets Active Record associations as references to constants. For example, `has_many :birds` is a reference to the `Bird` constant.
 
 In order to make your custom inflections compatible with Active Support and Packwerk, you must create a `config/inflections.yml` file and point `ActiveSupport::Inflector` to that file.
 


### PR DESCRIPTION
`has_many :birds` should look up the `Bird` constant, not `Birds`

## What are you trying to accomplish?
Update Documentation

## What approach did you choose and why?
Read Usage, found something wrong, fixed it.

## What should reviewers focus on?
The correctness of my change.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Additional Release Notes

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x ] It is safe to simply rollback this change.
