### PR TITLE
Packwerk checks for stale violations

### DIFF
--- a/lib/packwerk/cache_deprecated_references.rb
+++ b/lib/packwerk/cache_deprecated_references.rb
@@ -1,0 +1,45 @@
+# typed: true
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "packwerk/deprecated_references"
+require "packwerk/reference"
+require "packwerk/reference_lister"
+require "packwerk/violation_type"
+
+module Packwerk
+  class CacheDeprecatedReferences
+    extend T::Sig
+    include ReferenceLister
+
+    def initialize(root_path, deprecated_references = {})
+      @root_path = root_path
+      @deprecated_references = deprecated_references
+    end
+
+    sig do
+      params(reference: Packwerk::Reference, violation_type: ViolationType)
+        .returns(T::Boolean)
+        .override
+    end
+    def listed?(reference, violation_type:)
+      deprecated_references = deprecated_references_for(reference.source_package)
+      deprecated_references.add_entries(reference, violation_type.serialize)
+      true
+    end
+
+    private
+
+    def deprecated_references_for(package)
+      @deprecated_references[package] ||= Packwerk::DeprecatedReferences.new(
+        package,
+        deprecated_references_file_for(package),
+      )
+    end
+
+    def deprecated_references_file_for(package)
+      File.join(@root_path, package.name, "deprecated_references.yml")
+    end
+  end
+end

--- a/lib/packwerk/cache_deprecated_references.rb
+++ b/lib/packwerk/cache_deprecated_references.rb
@@ -11,11 +11,13 @@ require "packwerk/violation_type"
 module Packwerk
   class CacheDeprecatedReferences
     extend T::Sig
+    extend T::Helpers
     include ReferenceLister
+    abstract!
 
     def initialize(root_path, deprecated_references = {})
       @root_path = root_path
-      @deprecated_references = deprecated_references
+      @deprecated_references = T.let(deprecated_references, T::Hash[String, Packwerk::DeprecatedReferences])
     end
 
     sig do

--- a/lib/packwerk/commands/detect_stale_violations_command.rb
+++ b/lib/packwerk/commands/detect_stale_violations_command.rb
@@ -1,0 +1,63 @@
+# typed: true
+# frozen_string_literal: true
+require "packwerk/cli"
+require "sorbet-runtime"
+require "benchmark"
+require "packwerk/configuration"
+require "packwerk/formatters/progress_formatter"
+require "packwerk/run_context"
+require "packwerk/detect_stale_deprecated_references"
+require "packwerk/commands/offense_progress_marker"
+
+module Packwerk
+  class DetectStaleViolationsCommand
+    extend T::Sig
+    include OffenseProgressMarker
+    Result = Struct.new(:message, :status)
+
+    def initialize(files:, configuration:, run_context: nil, progress_formatter: nil, reference_lister: nil)
+      @configuration = configuration
+      @run_context = run_context
+      @reference_lister = reference_lister
+      @progress_formatter = progress_formatter
+      @files = files
+    end
+
+    sig { returns(Result) }
+    def run
+      @progress_formatter.started(@files)
+
+      all_offenses = T.let([], T.untyped)
+      execution_time = Benchmark.realtime do
+        all_offenses = @files.flat_map do |path|
+          run_context.process_file(file: path).tap do |offenses|
+            mark_progress(offenses: offenses, progress_formatter: @progress_formatter)
+          end
+        end
+      end
+
+      @progress_formatter.finished(execution_time)
+      calculate_result
+    end
+
+    private
+
+    def run_context
+      @run_context ||= Packwerk::RunContext.from_configuration(@configuration, reference_lister: reference_lister)
+    end
+
+    def reference_lister
+      @reference_lister ||= ::Packwerk::DetectStaleDeprecatedReferences.new(@configuration.root_path)
+    end
+
+    sig { returns Result }
+    def calculate_result
+      result_status = !reference_lister.stale_violations?
+      message = "There were stale violations found, please run `packwerk update`"
+      if result_status
+        message = "No stale violations detected"
+      end
+      Result.new(message, result_status)
+    end
+  end
+end

--- a/lib/packwerk/commands/offense_progress_marker.rb
+++ b/lib/packwerk/commands/offense_progress_marker.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# typed: strict
+require "sorbet-runtime"
+require "packwerk/formatters/progress_formatter"
+
+module Packwerk
+  module OffenseProgressMarker
+    extend T::Sig
+
+    sig do
+      params(
+        offenses: T::Array[T.nilable(::Packwerk::Offense)],
+        progress_formatter: ::Packwerk::Formatters::ProgressFormatter
+      ).void
+    end
+    def mark_progress(offenses:, progress_formatter:)
+      if offenses.empty?
+        progress_formatter.mark_as_inspected
+      else
+        progress_formatter.mark_as_failed
+      end
+    end
+  end
+end

--- a/lib/packwerk/deprecated_references.rb
+++ b/lib/packwerk/deprecated_references.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 require "yaml"
+require "sorbet-runtime"
 
 require "packwerk/reference"
 require "packwerk/reference_lister"
@@ -47,6 +48,7 @@ module Packwerk
       @new_entries[reference.constant.package.name] = package_violations
     end
 
+    sig { returns(T::Boolean) }
     def stale_violations?
       prepare_entries_for_dump
       deprecated_references.any? do |package, package_violations|

--- a/lib/packwerk/detect_stale_deprecated_references.rb
+++ b/lib/packwerk/detect_stale_deprecated_references.rb
@@ -1,0 +1,12 @@
+# typed: true
+# frozen_string_literal: true
+
+require "packwerk/cache_deprecated_references"
+
+module Packwerk
+  class DetectStaleDeprecatedReferences < CacheDeprecatedReferences
+    def stale_violations?
+      @deprecated_references.values.any?(&:stale_violations?)
+    end
+  end
+end

--- a/lib/packwerk/detect_stale_deprecated_references.rb
+++ b/lib/packwerk/detect_stale_deprecated_references.rb
@@ -1,10 +1,12 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "packwerk/cache_deprecated_references"
 
 module Packwerk
   class DetectStaleDeprecatedReferences < CacheDeprecatedReferences
+    extend T::Sig
+    sig { returns(T::Boolean) }
     def stale_violations?
       @deprecated_references.values.any?(&:stale_violations?)
     end

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -25,8 +25,9 @@ module Packwerk
       :inflector,
       :custom_associations,
       :checker_classes,
-      :reference_lister,
     )
+
+    attr_accessor :reference_lister
 
     DEFAULT_CHECKERS = [
       ::Packwerk::DependencyChecker,

--- a/lib/packwerk/updating_deprecated_references.rb
+++ b/lib/packwerk/updating_deprecated_references.rb
@@ -1,51 +1,14 @@
 # typed: true
 # frozen_string_literal: true
 
-require "sorbet-runtime"
-
-require "packwerk/deprecated_references"
-require "packwerk/reference"
-require "packwerk/reference_lister"
-require "packwerk/violation_type"
+require "packwerk/cache_deprecated_references"
 
 module Packwerk
-  class UpdatingDeprecatedReferences
-    extend T::Sig
-    include ReferenceLister
-
-    def initialize(root_path, deprecated_references = {})
-      @root_path = root_path
-      @deprecated_references = deprecated_references
-    end
-
-    sig do
-      params(reference: Packwerk::Reference, violation_type: ViolationType)
-        .returns(T::Boolean)
-        .override
-    end
-    def listed?(reference, violation_type:)
-      deprecated_references = deprecated_references_for(reference.source_package)
-      deprecated_references.add_entries(reference, violation_type.serialize)
-      true
-    end
-
+  class UpdatingDeprecatedReferences < CacheDeprecatedReferences
     def dump_deprecated_references_files
       @deprecated_references.each do |_, deprecated_references_file|
         deprecated_references_file.dump
       end
-    end
-
-    private
-
-    def deprecated_references_for(package)
-      @deprecated_references[package] ||= Packwerk::DeprecatedReferences.new(
-        package,
-        deprecated_references_file_for(package),
-      )
-    end
-
-    def deprecated_references_file_for(package)
-      File.join(@root_path, package.name, "deprecated_references.yml")
     end
   end
 end

--- a/test/unit/cache_deprecated_references_test.rb
+++ b/test/unit/cache_deprecated_references_test.rb
@@ -4,12 +4,12 @@
 require "test_helper"
 
 module Packwerk
-  class UpdatingDeprecatedReferencesTest < Minitest::Test
+  class CacheDeprecatedReferencesTest < Minitest::Test
     setup do
-      @updating_deprecated_references = UpdatingDeprecatedReferences.new(".")
+      @updating_deprecated_references = CacheDeprecatedReferences.new(".")
     end
 
-    test "#listed? returns true when constant has been added to file" do
+    test "#listed? adds entry and returns true" do
       File.stubs(:open)
 
       source_package = Package.new(name: "source_package", config: {})

--- a/test/unit/commands/detect_stale_violations_command_test.rb
+++ b/test/unit/commands/detect_stale_violations_command_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require "test_helper"
+require "rails_test_helper"
+require "packwerk/commands/detect_stale_violations_command"
+require "byebug"
+
+module Packwerk
+  class DetectStaleViolationsCommandTest < Minitest::Test
+    test "#execute_command with the subcommand detect-stale-violations returns status code 1 if stale violations" do
+      stale_violations_message = "There were stale violations found, please run `packwerk update`"
+      offense = stub
+      detect_stale_deprecated_references = stub
+      detect_stale_deprecated_references.stubs(:stale_violations?).returns(true)
+
+      progress_formatter = stub
+      progress_formatter.stubs(:started)
+
+      progress_formatter.stubs(:finished)
+
+      run_context = stub
+      run_context.stubs(:process_file).returns(offense)
+
+      ::Packwerk::FilesForProcessing.stubs(fetch: ["path/of/exile.rb"])
+      ::Packwerk::RunContext.stubs(from_configuration: run_context)
+
+      detect_stale_violations_command = ::Packwerk::DetectStaleViolationsCommand.new(
+        files: ["path/of/exile.rb"],
+        configuration: Configuration.from_path,
+        run_context: run_context,
+        reference_lister: detect_stale_deprecated_references,
+        progress_formatter: progress_formatter
+      )
+
+      detect_stale_violations_command.stubs(:mark_progress)
+
+      no_stale_violations = detect_stale_violations_command.run
+
+      assert_equal no_stale_violations.message, stale_violations_message
+      refute no_stale_violations.status
+    end
+  end
+end

--- a/test/unit/deprecated_references_test.rb
+++ b/test/unit/deprecated_references_test.rb
@@ -25,6 +25,111 @@ module Packwerk
       )
     end
 
+    test "#stale_violations? returns true if deprecated references exist but no violations can be found in code" do
+      deprecated_references = DeprecatedReferences.new(destination_package, "test/fixtures/deprecated_references.yml")
+      assert deprecated_references.stale_violations?
+    end
+
+    test "#stale_violations? returns false if deprecated references does not exist but violations are found in code" do
+      deprecated_references = DeprecatedReferences.new(destination_package, "nonexistant_file_path")
+      reference =
+        Reference.new(
+          nil,
+          "some/path.rb",
+          ConstantDiscovery::ConstantContext.new(
+            "::Buyers::Wallet",
+            "autoload/buyers/wallet.rb",
+            destination_package,
+            false
+          )
+        )
+      deprecated_references.add_entries(reference, "dependency")
+      refute deprecated_references.stale_violations?
+    end
+
+    test "#stale_violations? returns false if deprecated references violation match violations found in code" do
+      package = Package.new(name: "buyers", config: { "enforce_dependencies" => true })
+
+      first_violated_reference =
+        Reference.new(
+          nil,
+          "orders/app/jobs/orders/sweepers/purge_old_document_rows_task.rb",
+          ConstantDiscovery::ConstantContext.new(
+            "::Buyers::Document",
+            "autoload/buyers/document.rb",
+            package,
+            false
+          )
+        )
+      second_violated_reference =
+        Reference.new(
+          nil,
+          "orders/app/models/orders/services/adjustment_engine.rb",
+          ConstantDiscovery::ConstantContext.new(
+            "::Buyers::Document",
+            "autoload/buyers/document.rb",
+            package,
+            false
+          )
+        )
+
+      deprecated_references = DeprecatedReferences.new(package, "test/fixtures/deprecated_references.yml")
+      deprecated_references.add_entries(first_violated_reference, "dependency")
+      deprecated_references.add_entries(second_violated_reference, "dependency")
+      refute deprecated_references.stale_violations?
+    end
+
+    test "#stale_violations? returns true if dependency deprecated references violation turns into privacy deprecated references violation" do
+      package = Package.new(name: "buyers", config: { "enforce_dependencies" => true })
+
+      first_violated_reference =
+        Reference.new(
+          nil,
+          "orders/app/jobs/orders/sweepers/purge_old_document_rows_task.rb",
+          ConstantDiscovery::ConstantContext.new(
+            "::Buyers::Document",
+            "autoload/buyers/document.rb",
+            package,
+            false
+          )
+        )
+      second_violated_reference =
+        Reference.new(
+          nil,
+          "orders/app/models/orders/services/adjustment_engine.rb",
+          ConstantDiscovery::ConstantContext.new(
+            "::Buyers::Document",
+            "autoload/buyers/document.rb",
+            package,
+            false
+          )
+        )
+
+      deprecated_references = DeprecatedReferences.new(package, "test/fixtures/deprecated_references.yml")
+      deprecated_references.add_entries(first_violated_reference, "privacy")
+      deprecated_references.add_entries(second_violated_reference, "privacy")
+      assert deprecated_references.stale_violations?
+    end
+
+    test "#stale_violations? returns true if violations in deprecated_references.yml exist but are not found when checking for violations" do
+      package = Package.new(name: "buyers", config: { "enforce_dependencies" => true })
+
+      violated_reference =
+        Reference.new(
+          nil,
+          "orders/app/jobs/orders/sweepers/purge_old_document_rows_task.rb",
+          ConstantDiscovery::ConstantContext.new(
+            "::Buyers::Document",
+            "autoload/buyers/document.rb",
+            package,
+            false
+          )
+        )
+      deprecated_references = DeprecatedReferences.new(package, "test/fixtures/deprecated_references.yml")
+      deprecated_references.add_entries(violated_reference, "dependency")
+      assert deprecated_references.stale_violations?
+    end
+
     test "#listed? returns false if constant is not violated" do
       reference =
         Reference.new(

--- a/test/unit/detect_stale_deprecated_references_test.rb
+++ b/test/unit/detect_stale_deprecated_references_test.rb
@@ -1,0 +1,45 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_helper"
+require "packwerk/detect_stale_deprecated_references"
+module Packwerk
+  class DetectStaleDeprecatedReferencesTest < Minitest::Test
+    setup do
+      package = Package.new(name: "buyers", config: {})
+      violated_reference =
+        Reference.new(
+          nil,
+          "orders/app/jobs/orders/sweepers/purge_old_document_rows_task.rb",
+          ConstantDiscovery::ConstantContext.new(
+            "::Buyers::Document",
+            "autoload/buyers/document.rb",
+            package,
+            false
+          )
+        )
+      deprecated_reference = DeprecatedReferences.new(package, "test/fixtures/deprecated_references.yml")
+      deprecated_reference.add_entries(violated_reference, "dependency")
+      @detect_stale_deprecated_references = DetectStaleDeprecatedReferences.new(
+        ".",
+        { package.name => deprecated_reference }
+      )
+    end
+
+    test "#stale_violations? returns true if there are stale violations" do
+      Packwerk::DeprecatedReferences.any_instance
+        .expects(:stale_violations?)
+        .returns(true)
+
+      assert @detect_stale_deprecated_references.stale_violations?
+    end
+
+    test "#stale_violations? returns false if no stale violations" do
+      Packwerk::DeprecatedReferences.any_instance
+        .expects(:stale_violations?)
+        .returns(false)
+
+      refute @detect_stale_deprecated_references.stale_violations?
+    end
+  end
+end


### PR DESCRIPTION
## What are you trying to accomplish?
Adding feature for Packwerk checking stale violations. This should be incorporated into CI in the future to make sure that PRs don't pass CI if there are stale violations. Linked issue here: https://github.com/Shopify/packwerk/issues/12

## What approach did you choose and why?

We had to refactor the code a bit to create this feature. We needed a lot of functionality in the UpdatingDeprecatedReferences.rb class but putting the change in that class didn't seem right. So CacheDeprecatingReferences.rb was created as a parent class that both UpdatingDeprecatedReferences.rb and DetectStaleDeprecatedReferences.rb now inherit from. Functionality common to both now belongs in CacheDeprecatingReferences.rb and functionality specific to updating vs detecting stale violations are now in their respective classes.

When executing the command, Packwerk will go through all the loaded files and check for violations in the files which it then stores in DetectStaleDeprecatedReferences.rb. At the end when all files were processed, we compare the deprecated_references.yml file of each component loaded to the actual violations generated. If there are references in deprecated_references.yml that aren't in the generated violations, then there are stale violations. The program will exits with status code 1. If there are no stale violations, program exits with status code 0.

## What should reviewers focus on?

Any issues with the code refactor? Are there stale violation cases we may have missed with this code change?

## Tophatting

My tophatting instructions use Packwerk in the shopify/shopify repo, but you can use another repo if you prefer

1) Pull this branch into local
2) Change the gemfile of local shopify/shopify repo to point to this branch
3) Modify dev.yml of shopify/shopify to include the detect-stale violations command like so:
<img width="1014" alt="Screen Shot 2020-11-03 at 5 46 32 PM" src="https://user-images.githubusercontent.com/59701253/98048848-84afa600-1dfc-11eb-9e37-9edfef09b12d.png">
4) Generate a stale violation in shopify/shopify. 

- You can do this by changing package.yml of a component, enforcing dependencies on it and run Packwerk update to generate a deprecated_references.yml for that component which has boundary violations. 

- After you have a list of dependency violations for that component, you can add the component which the violation is coming from as a dependency in the  package.yml of your component

5) Run `dev packages detect-stale-violations path\to\your\component`
6) Check that it outputs stale violations were made
7) Run `$?` to check status of last command (0 if no stale violations, 1 if there were stale violations)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Additional Release Notes

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [X] It is safe to simply rollback this change.
