### PR TITLE
Simplify public interface of the Node class

### DIFF
--- a/lib/packwerk/node.rb
+++ b/lib/packwerk/node.rb
@@ -10,7 +10,7 @@ module Packwerk
 
     class << self
       def class_or_module_name(class_or_module_node)
-        case type(class_or_module_node)
+        case type_of(class_or_module_node)
         when CLASS, MODULE
           # (class (const nil :Foo) (const nil :Bar) (nil))
           #   "class Foo < Bar; end"
@@ -24,7 +24,7 @@ module Packwerk
       end
 
       def constant_name(constant_node)
-        case type(constant_node)
+        case type_of(constant_node)
         when CONSTANT_ROOT_NAMESPACE
           ""
         when CONSTANT, CONSTANT_ASSIGNMENT
@@ -62,19 +62,19 @@ module Packwerk
       end
 
       def enclosing_namespace_path(starting_node, ancestors:)
-        ancestors.select { |n| [CLASS, MODULE].include?(type(n)) }
+        ancestors.select { |n| [CLASS, MODULE].include?(type_of(n)) }
           .each_with_object([]) do |node, namespace|
           # when evaluating `class Child < Parent`, the const node for `Parent` is a child of the class
           # node, so it'll be an ancestor, but `Parent` is not evaluated in the namespace of `Child`, so
           # we need to skip it here
-          next if type(node) == CLASS && parent_class(node) == starting_node
+          next if type_of(node) == CLASS && parent_class(node) == starting_node
 
           namespace.prepend(class_or_module_name(node))
         end
       end
 
       def literal_value(string_or_symbol_node)
-        case type(string_or_symbol_node)
+        case type_of(string_or_symbol_node)
         when STRING, SYMBOL
           # (str "foo")
           #   "'foo'"
@@ -92,31 +92,31 @@ module Packwerk
       end
 
       def constant?(node)
-        type(node) == CONSTANT
+        type_of(node) == CONSTANT
       end
 
       def constant_assignment?(node)
-        type(node) == CONSTANT_ASSIGNMENT
+        type_of(node) == CONSTANT_ASSIGNMENT
       end
 
       def class?(node)
-        type(node) == CLASS
+        type_of(node) == CLASS
       end
 
       def method_call?(node)
-        type(node) == METHOD_CALL
+        type_of(node) == METHOD_CALL
       end
 
       def hash?(node)
-        type(node) == HASH
+        type_of(node) == HASH
       end
 
       def string?(node)
-        type(node) == STRING
+        type_of(node) == STRING
       end
 
       def symbol?(node)
-        type(node) == SYMBOL
+        type_of(node) == SYMBOL
       end
 
       def method_arguments(method_call_node)
@@ -136,7 +136,7 @@ module Packwerk
       end
 
       def module_name_from_definition(node)
-        case type(node)
+        case type_of(node)
         when CLASS, MODULE
           # "class My::Class; end"
           # "module My::Module; end"
@@ -146,7 +146,7 @@ module Packwerk
           # "My::Module = ..."
           rvalue = node.children.last
 
-          case type(rvalue)
+          case type_of(rvalue)
           when METHOD_CALL
             # "Class.new"
             # "Module.new"
@@ -169,7 +169,7 @@ module Packwerk
       end
 
       def parent_class(class_node)
-        raise TypeError unless type(class_node) == CLASS
+        raise TypeError unless type_of(class_node) == CLASS
 
         # (class (const nil :Foo) (const nil :Bar) (nil))
         #   "class Foo < Bar; end"
@@ -178,7 +178,7 @@ module Packwerk
 
       def parent_module_name(ancestors:)
         definitions = ancestors
-          .select { |n| [CLASS, MODULE, CONSTANT_ASSIGNMENT, BLOCK].include?(type(n)) }
+          .select { |n| [CLASS, MODULE, CONSTANT_ASSIGNMENT, BLOCK].include?(type_of(n)) }
 
         names = definitions.map do |definition|
           name_part_from_definition(definition)
@@ -212,12 +212,12 @@ module Packwerk
         :MODULE, :STRING, :SYMBOL,
       )
 
-      def type(node)
+      def type_of(node)
         node.type
       end
 
       def hash_pair_key(hash_pair_node)
-        raise TypeError unless type(hash_pair_node) == HASH_PAIR
+        raise TypeError unless type_of(hash_pair_node) == HASH_PAIR
 
         # (pair (int 1) (int 2))
         #   "1 => 2"
@@ -227,7 +227,7 @@ module Packwerk
       end
 
       def hash_pair_value(hash_pair_node)
-        raise TypeError unless type(hash_pair_node) == HASH_PAIR
+        raise TypeError unless type_of(hash_pair_node) == HASH_PAIR
 
         # (pair (int 1) (int 2))
         #   "1 => 2"
@@ -241,11 +241,11 @@ module Packwerk
 
         # (hash (pair (int 1) (int 2)) (pair (int 3) (int 4)))
         #   "{1 => 2, 3 => 4}"
-        hash_node.children.select { |n| type(n) == HASH_PAIR }
+        hash_node.children.select { |n| type_of(n) == HASH_PAIR }
       end
 
       def method_call_node(block_node)
-        raise TypeError unless type(block_node) == BLOCK
+        raise TypeError unless type_of(block_node) == BLOCK
 
         # (block (send (lvar :foo) :bar) (args) (int 42))
         #   "foo.bar do 42 end"
@@ -269,7 +269,7 @@ module Packwerk
       end
 
       def name_part_from_definition(node)
-        case type(node)
+        case type_of(node)
         when CLASS, MODULE, CONSTANT_ASSIGNMENT
           module_name_from_definition(node)
         when BLOCK
@@ -278,7 +278,7 @@ module Packwerk
       end
 
       def receiver(method_call_or_block_node)
-        case type(method_call_or_block_node)
+        case type_of(method_call_or_block_node)
         when METHOD_CALL
           method_call_or_block_node.children[0]
         when BLOCK

--- a/lib/packwerk/node.rb
+++ b/lib/packwerk/node.rb
@@ -5,18 +5,6 @@ require "parser/ast/node"
 
 module Packwerk
   module Node
-    BLOCK = :block
-    CLASS = :class
-    CONSTANT = :const
-    CONSTANT_ASSIGNMENT = :casgn
-    CONSTANT_ROOT_NAMESPACE = :cbase
-    HASH = :hash
-    HASH_PAIR = :pair
-    METHOD_CALL = :send
-    MODULE = :module
-    STRING = :str
-    SYMBOL = :sym
-
     class TypeError < ArgumentError; end
     Location = Struct.new(:line, :column)
 
@@ -199,10 +187,6 @@ module Packwerk
         names.empty? ? "Object" : names.reverse.join("::")
       end
 
-      def type(node)
-        node.type
-      end
-
       def value_from_hash(hash_node, key)
         raise TypeError unless hash?(hash_node)
         pair = hash_pairs(hash_node).detect { |pair_node| literal_value(hash_pair_key(pair_node)) == key }
@@ -210,6 +194,27 @@ module Packwerk
       end
 
       private
+
+      BLOCK = :block
+      CLASS = :class
+      CONSTANT = :const
+      CONSTANT_ASSIGNMENT = :casgn
+      CONSTANT_ROOT_NAMESPACE = :cbase
+      HASH = :hash
+      HASH_PAIR = :pair
+      METHOD_CALL = :send
+      MODULE = :module
+      STRING = :str
+      SYMBOL = :sym
+
+      private_constant(
+        :BLOCK, :CLASS, :CONSTANT, :CONSTANT_ASSIGNMENT, :CONSTANT_ROOT_NAMESPACE, :HASH, :HASH_PAIR, :METHOD_CALL,
+        :MODULE, :STRING, :SYMBOL,
+      )
+
+      def type(node)
+        node.type
+      end
 
       def hash_pair_key(hash_pair_node)
         raise TypeError unless type(hash_pair_node) == HASH_PAIR

--- a/lib/packwerk/node.rb
+++ b/lib/packwerk/node.rb
@@ -107,6 +107,10 @@ module Packwerk
         type(node) == CONSTANT
       end
 
+      def constant_assignment?(node)
+        type(node) == CONSTANT_ASSIGNMENT
+      end
+
       def class?(node)
         type(node) == CLASS
       end

--- a/lib/packwerk/node.rb
+++ b/lib/packwerk/node.rb
@@ -107,6 +107,10 @@ module Packwerk
         type(node) == CONSTANT
       end
 
+      def class?(node)
+        type(node) == CLASS
+      end
+
       def method_call?(node)
         type(node) == METHOD_CALL
       end

--- a/lib/packwerk/node_processor.rb
+++ b/lib/packwerk/node_processor.rb
@@ -26,8 +26,7 @@ module Packwerk
     end
 
     def call(node, ancestors:)
-      case Node.type(node)
-      when Node::METHOD_CALL, Node::CONSTANT
+      if Node.method_call?(node) || Node.constant?(node)
         reference = @reference_extractor.reference_from_node(node, ancestors: ancestors, file_path: @filename)
         check_reference(reference, node) if reference
       end

--- a/lib/packwerk/parsed_constant_definitions.rb
+++ b/lib/packwerk/parsed_constant_definitions.rb
@@ -38,7 +38,7 @@ module Packwerk
     private
 
     def collect_local_definitions_from_root(node, current_namespace_path = [])
-      if Node.type(node) == Node::CONSTANT_ASSIGNMENT
+      if Node.constant_assignment?(node)
         add_definition(Node.constant_name(node), current_namespace_path, Node.name_location(node))
       elsif Node.module_name_from_definition(node)
         # handle compact constant nesting (e.g. "module Sales::Order")

--- a/lib/packwerk/parsed_constant_definitions.rb
+++ b/lib/packwerk/parsed_constant_definitions.rb
@@ -43,7 +43,7 @@ module Packwerk
       elsif Node.module_name_from_definition(node)
         # handle compact constant nesting (e.g. "module Sales::Order")
         tempnode = node
-        while (tempnode = Node.each_child(tempnode).find { |n| Node.type(n) == Node::CONSTANT })
+        while (tempnode = Node.each_child(tempnode).find { |n| Node.constant?(n) })
           add_definition(Node.constant_name(tempnode), current_namespace_path, Node.name_location(tempnode))
         end
 

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -205,36 +205,32 @@ module Packwerk
       assert_equal "A::B", Node.parent_module_name(ancestors: [parent, grandparent])
     end
 
-    test ".type can identify a class node" do
-      assert_equal Node::CLASS, Node.type(parse("class Fruit; end"))
+    test ".class? can identify a class node" do
+      assert Node.class?(parse("class Fruit; end"))
     end
 
-    test ".type can identify a constant node" do
-      assert_equal Node::CONSTANT, Node.type(parse("Oranges"))
+    test ".constant? can identify a constant node" do
+      assert Node.constant?(parse("Oranges"))
     end
 
-    test ".type can identify a constant assignment node" do
-      assert_equal Node::CONSTANT_ASSIGNMENT, Node.type(parse("Apples = 13"))
+    test ".constant_assignment? can identify a constant assignment node" do
+      assert Node.constant_assignment?(parse("Apples = 13"))
     end
 
-    test ".type can identify a hash node" do
-      assert_equal Node::HASH, Node.type(parse("{ pears: 3, bananas: 6 }"))
+    test ".hash? can identify a hash node" do
+      assert Node.hash?(parse("{ pears: 3, bananas: 6 }"))
     end
 
-    test ".type can identify a method call node" do
-      assert_equal Node::METHOD_CALL, Node.type(parse("quantity(bananas)"))
+    test ".method_call? can identify a method call node" do
+      assert Node.method_call?(parse("quantity(bananas)"))
     end
 
-    test ".type can identify a module node" do
-      assert_equal Node::MODULE, Node.type(parse("module Food; end"))
+    test ".string? can identify a string node" do
+      assert Node.string?(parse("'cashew apple'"))
     end
 
-    test ".type can identify a string node" do
-      assert_equal Node::STRING, Node.type(parse("'cashew apple'"))
-    end
-
-    test ".type can identify a symbol node" do
-      assert_equal Node::SYMBOL, Node.type(parse(":papaya"))
+    test ".symbol? can identify a symbol node" do
+      assert Node.symbol?(parse(":papaya"))
     end
 
     test ".value_from_hash looks up the node for a key in a hash" do

--- a/test/unit/file_processor_test.rb
+++ b/test/unit/file_processor_test.rb
@@ -47,7 +47,7 @@ module Packwerk
       offense = mock
       @node_processor_factory.expects(:for).returns(@node_processor)
       @node_processor.expects(:call).with do |node, ancestors:|
-        Node.type(node) == Node::CLASS && # class Hello; world; end
+        Node.class?(node) && # class Hello; world; end
           Node.class_or_module_name(node) == "Hello" &&
           ancestors.empty?
       end
@@ -56,7 +56,7 @@ module Packwerk
         Node.type(node) == Node::CONSTANT && # Hello
           Node.constant_name(node) == "Hello" &&
           ancestors.length == 1 &&
-          Node.type(parent) == Node::CLASS &&
+          Node.class?(parent) &&
           Node.class_or_module_name(parent) == "Hello"
       end
       @node_processor.expects(:call).with do |node, ancestors:|
@@ -64,7 +64,7 @@ module Packwerk
         Node.type(node) == Node::METHOD_CALL && # world
           Node.method_name(node) == :world &&
           ancestors.length == 1 &&
-          Node.type(parent) == Node::CLASS &&
+          Node.class?(parent) &&
           Node.class_or_module_name(parent) == "Hello"
       end.returns(offense)
 

--- a/test/unit/file_processor_test.rb
+++ b/test/unit/file_processor_test.rb
@@ -53,7 +53,7 @@ module Packwerk
       end
       @node_processor.expects(:call).with do |node, ancestors:|
         parent = ancestors.first # class Hello; world; end
-        Node.type(node) == Node::CONSTANT && # Hello
+        Node.constant?(node) && # Hello
           Node.constant_name(node) == "Hello" &&
           ancestors.length == 1 &&
           Node.class?(parent) &&
@@ -61,7 +61,7 @@ module Packwerk
       end
       @node_processor.expects(:call).with do |node, ancestors:|
         parent = ancestors.first # class Hello; world; end
-        Node.type(node) == Node::METHOD_CALL && # world
+        Node.method_call?(node) && # world
           Node.method_name(node) == :world &&
           ancestors.length == 1 &&
           Node.class?(parent) &&

--- a/test/unit/parsed_constant_definitions_test.rb
+++ b/test/unit/parsed_constant_definitions_test.rb
@@ -106,7 +106,7 @@ module Packwerk
     test "doesn't count definition as reference" do
       ast = parse_code("class HelloWorld; end")
 
-      const_node = Node.each_child(ast).find { |n| Node.type(n) == Node::CONSTANT }
+      const_node = Node.each_child(ast).find { |n| Node.constant?(n) }
 
       definitions = ParsedConstantDefinitions.new(
         root_node: ast

--- a/test/unit/reference_extractor_test.rb
+++ b/test/unit/reference_extractor_test.rb
@@ -208,7 +208,7 @@ module Packwerk
 
       def constant_name_from_node(node, ancestors:)
         return nil unless @association
-        return nil unless Node.type(node) == Node::METHOD_CALL
+        return nil unless Node.method_call?(node)
 
         args = Node.method_arguments(node)
         if @expected_args && @expected_args != args


### PR DESCRIPTION
## What are you trying to accomplish?

We started using predicate methods for the Node class to make the code easier to read and less error-prone. This change introduced a new interface to the Node class, which has now two ways of checking for node types. This PR aims to simplify the Interface of the Node class by changing the `Node.type` class method and `Node::Type` constants to private. The constants and `Node.type` class method is only used in the Node class so making it private reflects better how the Node module should be used.

This PR is a followup on this PR review comment, which has a bit more context: https://github.com/Shopify/packwerk/pull/39#discussion_r513322686

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code refactor (non-breaking change that doesn't add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Additional Release Notes

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] It is safe to simply rollback this change.
