### PR TITLE
add node processor factory

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -138,7 +138,7 @@ module Packwerk
       all_offenses = T.let([], T.untyped)
       execution_time = Benchmark.realtime do
         all_offenses = files.flat_map do |path|
-          @run_context.file_processor.call(path).tap { |offenses| mark_progress(offenses) }
+          @run_context.process_file(file: path).tap { |offenses| mark_progress(offenses) }
         end
 
         updating_deprecated_references.dump_deprecated_references_files
@@ -160,7 +160,7 @@ module Packwerk
       all_offenses = T.let([], T.untyped)
       execution_time = Benchmark.realtime do
         files.each do |path|
-          @run_context.file_processor.call(path).tap do |offenses|
+          @run_context.process_file(file: path).tap do |offenses|
             mark_progress(offenses)
             all_offenses.concat(offenses)
           end

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -11,6 +11,7 @@ require "packwerk/inflector"
 require "packwerk/output_styles"
 require "packwerk/run_context"
 require "packwerk/updating_deprecated_references"
+require "packwerk/checking_deprecated_references"
 
 module Packwerk
   class Cli
@@ -21,7 +22,10 @@ module Packwerk
       @err_out = err_out
       @style = style
       @configuration = configuration || Configuration.from_path
-      @run_context = run_context || Packwerk::RunContext.from_configuration(@configuration)
+      @run_context = run_context || Packwerk::RunContext.from_configuration(
+        @configuration,
+        reference_lister: ::Packwerk::CheckingDeprecatedReferences.new(@configuration.root_path),
+      )
       @progress_formatter = Formatters::ProgressFormatter.new(@out, style: style)
     end
 

--- a/lib/packwerk/file_processor.rb
+++ b/lib/packwerk/file_processor.rb
@@ -15,8 +15,8 @@ module Packwerk
       end
     end
 
-    def initialize(run_context:, parser_factory: nil)
-      @run_context = run_context
+    def initialize(node_processor_factory:, parser_factory: nil)
+      @node_processor_factory = node_processor_factory
       @parser_factory = parser_factory || Packwerk::Parsers::Factory.instance
     end
 
@@ -32,8 +32,8 @@ module Packwerk
 
       result = []
       if node
-        @node_processor = @run_context.node_processor_for(filename: file_path, ast_node: node)
-        node_visitor = Packwerk::NodeVisitor.new(node_processor: @node_processor)
+        node_processor = @node_processor_factory.for(filename: file_path, node: node)
+        node_visitor = Packwerk::NodeVisitor.new(node_processor: node_processor)
 
         node_visitor.visit(node, ancestors: [], result: result)
       end

--- a/lib/packwerk/node_processor.rb
+++ b/lib/packwerk/node_processor.rb
@@ -42,7 +42,7 @@ module Packwerk
 
       Packwerk::Offense.new(
         location: Node.location(node),
-        file: @filename,
+        file: reference.relative_path,
         message: <<~EOS
           #{message}
           Inference details: this is a reference to #{constant.name} which seems to be defined in #{constant.location}.

--- a/lib/packwerk/node_processor_factory.rb
+++ b/lib/packwerk/node_processor_factory.rb
@@ -1,0 +1,40 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "packwerk/constant_name_inspector"
+require "packwerk/checker"
+
+module Packwerk
+  class NodeProcessorFactory < T::Struct
+    extend T::Sig
+
+    const :root_path, String
+    const :reference_lister, ReferenceLister
+    const :node_processor_class, T.class_of(NodeProcessor)
+    const :context_provider, Packwerk::ConstantDiscovery
+    const :constant_name_inspectors, T::Array[ConstantNameInspector]
+    const :checkers, T::Array[Checker]
+
+    sig { params(filename: String, node: AST::Node).returns(NodeProcessor) }
+    def for(filename:, node:)
+      node_processor_class.new(
+        reference_extractor: reference_extractor(node: node),
+        reference_lister: reference_lister,
+        filename: filename,
+        checkers: checkers,
+      )
+    end
+
+    private
+
+    sig { params(node: AST::Node).returns(::Packwerk::ReferenceExtractor) }
+    def reference_extractor(node:)
+      ::Packwerk::ReferenceExtractor.new(
+        context_provider: context_provider,
+        constant_name_inspectors: constant_name_inspectors,
+        root_node: node,
+        root_path: root_path,
+      )
+    end
+  end
+end

--- a/lib/packwerk/node_processor_factory.rb
+++ b/lib/packwerk/node_processor_factory.rb
@@ -10,14 +10,13 @@ module Packwerk
 
     const :root_path, String
     const :reference_lister, ReferenceLister
-    const :node_processor_class, T.class_of(NodeProcessor)
     const :context_provider, Packwerk::ConstantDiscovery
     const :constant_name_inspectors, T::Array[ConstantNameInspector]
     const :checkers, T::Array[Checker]
 
     sig { params(filename: String, node: AST::Node).returns(NodeProcessor) }
     def for(filename:, node:)
-      node_processor_class.new(
+      ::Packwerk::NodeProcessor.new(
         reference_extractor: reference_extractor(node: node),
         reference_lister: reference_lister,
         filename: filename,

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -10,7 +10,6 @@ require "packwerk/const_node_inspector"
 require "packwerk/dependency_checker"
 require "packwerk/file_processor"
 require "packwerk/inflector"
-require "packwerk/node_processor"
 require "packwerk/package_set"
 require "packwerk/privacy_checker"
 require "packwerk/reference_extractor"
@@ -27,7 +26,6 @@ module Packwerk
       :inflector,
       :custom_associations,
       :checker_classes,
-      :node_processor_class,
       :reference_lister,
     )
 
@@ -59,7 +57,6 @@ module Packwerk
       inflector: nil,
       custom_associations: [],
       checker_classes: DEFAULT_CHECKERS,
-      node_processor_class: NodeProcessor,
       reference_lister: nil
     )
       @root_path = root_path
@@ -68,7 +65,6 @@ module Packwerk
       @inflector = inflector
       @custom_associations = custom_associations
       @checker_classes = checker_classes
-      @node_processor_class = node_processor_class
       @reference_lister = reference_lister || ::Packwerk::CheckingDeprecatedReferences.new(@root_path)
     end
 
@@ -87,7 +83,6 @@ module Packwerk
     sig { returns(NodeProcessorFactory) }
     def node_processor_factory
       NodeProcessorFactory.new(
-        node_processor_class: node_processor_class,
         context_provider: context_provider,
         checkers: checkers,
         root_path: root_path,

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -17,12 +17,13 @@ require "packwerk/reference_extractor"
 
 module Packwerk
   class RunContext
+    extend T::Sig
+
     attr_reader(
       :checkers,
       :constant_name_inspectors,
       :context_provider,
       :root_path,
-      :file_processor,
       :node_processor_class,
       :reference_lister
     )
@@ -84,7 +85,11 @@ module Packwerk
       ]
 
       @node_processor_class = node_processor_class
-      @file_processor = FileProcessor.new(run_context: self)
+    end
+
+    sig { params(file: String).returns(T::Array[T.nilable(::Packwerk::Offense)]) }
+    def process_file(file:)
+      file_processor.call(file)
     end
 
     def node_processor_for(filename:, ast_node:)
@@ -101,6 +106,13 @@ module Packwerk
         filename: filename,
         checkers: checkers,
       )
+    end
+
+    private
+
+    sig { returns(FileProcessor) }
+    def file_processor
+      @file_processor ||= FileProcessor.new(run_context: self)
     end
   end
 end

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -60,7 +60,7 @@ module Packwerk
       node_processor_class: NodeProcessor,
       reference_lister: nil
     )
-      @root_path = File.expand_path(root_path)
+      @root_path = root_path
 
       resolver = ConstantResolver.new(
         root_path: @root_path,

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -39,7 +39,6 @@ module Packwerk
         default_reference_lister = reference_lister ||
           ::Packwerk::CheckingDeprecatedReferences.new(configuration.root_path)
         inflector = ::Packwerk::Inflector.from_file(configuration.inflections_file)
-
         new(
           root_path: configuration.root_path,
           load_paths: configuration.load_paths,

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -4,7 +4,6 @@
 require "constant_resolver"
 
 require "packwerk/association_inspector"
-require "packwerk/checking_deprecated_references"
 require "packwerk/constant_discovery"
 require "packwerk/const_node_inspector"
 require "packwerk/dependency_checker"
@@ -35,9 +34,7 @@ module Packwerk
     ]
 
     class << self
-      def from_configuration(configuration, reference_lister: nil)
-        default_reference_lister = reference_lister ||
-          ::Packwerk::CheckingDeprecatedReferences.new(configuration.root_path)
+      def from_configuration(configuration, reference_lister:)
         inflector = ::Packwerk::Inflector.from_file(configuration.inflections_file)
         new(
           root_path: configuration.root_path,
@@ -45,7 +42,7 @@ module Packwerk
           package_paths: configuration.package_paths,
           inflector: inflector,
           custom_associations: configuration.custom_associations,
-          reference_lister: default_reference_lister,
+          reference_lister: reference_lister,
         )
       end
     end
@@ -57,7 +54,7 @@ module Packwerk
       inflector: nil,
       custom_associations: [],
       checker_classes: DEFAULT_CHECKERS,
-      reference_lister: nil
+      reference_lister:
     )
       @root_path = root_path
       @load_paths = load_paths
@@ -65,7 +62,7 @@ module Packwerk
       @inflector = inflector
       @custom_associations = custom_associations
       @checker_classes = checker_classes
-      @reference_lister = reference_lister || ::Packwerk::CheckingDeprecatedReferences.new(@root_path)
+      @reference_lister = reference_lister
     end
 
     sig { params(file: String).returns(T::Array[T.nilable(::Packwerk::Offense)]) }

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -14,6 +14,7 @@ require "packwerk/node_processor"
 require "packwerk/package_set"
 require "packwerk/privacy_checker"
 require "packwerk/reference_extractor"
+require "packwerk/node_processor_factory"
 
 module Packwerk
   class RunContext
@@ -92,27 +93,23 @@ module Packwerk
       file_processor.call(file)
     end
 
-    def node_processor_for(filename:, ast_node:)
-      reference_extractor = ::Packwerk::ReferenceExtractor.new(
-        context_provider: context_provider,
-        constant_name_inspectors: constant_name_inspectors,
-        root_node: ast_node,
-        root_path: root_path,
-      )
-
-      node_processor_class.new(
-        reference_extractor: reference_extractor,
-        reference_lister: @reference_lister,
-        filename: filename,
-        checkers: checkers,
-      )
-    end
-
     private
 
     sig { returns(FileProcessor) }
     def file_processor
-      @file_processor ||= FileProcessor.new(run_context: self)
+      @file_processor ||= FileProcessor.new(node_processor_factory: node_processor_factory)
+    end
+
+    sig { returns(NodeProcessorFactory) }
+    def node_processor_factory
+      NodeProcessorFactory.new(
+        node_processor_class: node_processor_class,
+        context_provider: context_provider,
+        checkers: checkers,
+        root_path: root_path,
+        constant_name_inspectors: constant_name_inspectors,
+        reference_lister: reference_lister
+      )
     end
   end
 end

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -22,8 +22,13 @@ module Packwerk
 
     attr_reader(
       :root_path,
+      :load_paths,
+      :package_paths,
+      :inflector,
+      :custom_associations,
+      :checker_classes,
       :node_processor_class,
-      :reference_lister
+      :reference_lister,
     )
 
     DEFAULT_CHECKERS = [
@@ -102,27 +107,27 @@ module Packwerk
     sig { returns(ConstantResolver) }
     def resolver
       ConstantResolver.new(
-        root_path: @root_path,
-        load_paths: @load_paths,
-        inflector: @inflector,
+        root_path: root_path,
+        load_paths: load_paths,
+        inflector: inflector,
       )
     end
 
     sig { returns(PackageSet) }
     def package_set
-      ::Packwerk::PackageSet.load_all_from(@root_path, package_pathspec: @package_paths)
+      ::Packwerk::PackageSet.load_all_from(root_path, package_pathspec: package_paths)
     end
 
     sig { returns(T::Array[Checker]) }
     def checkers
-      @checker_classes.map(&:new)
+      checker_classes.map(&:new)
     end
 
     sig { returns(T::Array[ConstantNameInspector]) }
     def constant_name_inspectors
       [
         ::Packwerk::ConstNodeInspector.new,
-        ::Packwerk::AssociationInspector.new(inflector: @inflector, custom_associations: @custom_associations),
+        ::Packwerk::AssociationInspector.new(inflector: inflector, custom_associations: custom_associations),
       ]
     end
   end

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -22,15 +22,8 @@ module Packwerk
       violation_message = "This is a violation of code health."
       offense = stub(error?: true, to_s: violation_message)
 
-      file_processor = stub
-      file_processor
-        .stubs(:call)
-        .returns([offense])
-        .then
-        .returns([])
-
       run_context = stub
-      run_context.stubs(:file_processor).at_least_once.returns(file_processor)
+      run_context.stubs(:process_file).at_least_once.returns([offense])
 
       string_io = StringIO.new
 
@@ -52,17 +45,12 @@ module Packwerk
       violation_message = "This is a violation of code health."
       offense = stub(to_s: violation_message)
 
-      file_processor = stub
-      file_processor
-        .stubs(:call)
+      run_context = stub
+      run_context.stubs(:process_file)
+        .at_least(2)
         .returns([offense])
         .raises(Interrupt)
         .returns([offense])
-
-      run_context = stub
-      run_context
-        .stubs(:file_processor)
-        .at_least_once.returns(file_processor)
 
       string_io = StringIO.new
 


### PR DESCRIPTION
## What are you trying to accomplish?

When I was reading through the code, I got a bit confused about the `RunContext` class's responsibility. The particular issue I saw was that that class is used to build a NodeProcessor and a FileProcessor. This construction is a bit backward because the FileProcessor gets initialized with a RunContext, but is used in the CLI class.

## What approach did you choose, and why?

I did an initial stab at this problem in #44  but gave the CLI class too many responsibilities.
I paired with @exterm on this problem, but we approached it from another side. We decided to call the FillProcessor#call method from the RunContext class instead of exposing the FileProcessor class to the CLI class. 

After that, I changed the code to pass a NodeProcessorFactory to the
FileProcessor instead of a RunContext instance, which reduces how complected these classes are. 

There are some other minor cleanups in the PR, but those are described in the commit messages.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
