### PR TITLE
exclude static directory from gem

### DIFF
--- a/packwerk.gemspec
+++ b/packwerk.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables << "packwerk"
 
   spec.files = Dir.chdir(__dir__) do
-    %x(git ls-files -z).split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    %x(git ls-files -z).split("\x0").reject { |f| f.match(%r{^(test|spec|features|static)/}) }
   end
   spec.require_paths = %w(lib)
 


### PR DESCRIPTION
## What are you trying to accomplish?
The packwerk 1.0.1 gem file is 4,217,344 bytes in size. This seems rather large and upon further investigation appears to be due to the inclusion of a number of graphics files stored in the `static` subdirectory. Excluding these images resulted in shrinking the packwerk gem down to 634,368 bytes.

## What approach did you choose and why?
I chose to just add the `static` directory to the rejection list when computing the files for the gemspec. This was done because it is a small, safe change that is easy to read and understand.

## What should reviewers focus on?
Are these images actually needed for something in the runtime environment? Am I overlooking some longstanding gem convention of which I am unaware?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] It is safe to rollback this change.
