### PR TITLE
Add missing .realpath checks that was causing validation error

### DIFF
--- a/lib/packwerk/application_load_paths.rb
+++ b/lib/packwerk/application_load_paths.rb
@@ -48,7 +48,9 @@ module Packwerk
 
       sig { params(paths: T::Array[Pathname], rails_root: Pathname).returns(T::Array[String]) }
       def relative_path_strings(paths, rails_root: Rails.root)
-        paths.map { |path| path.relative_path_from(rails_root).to_s }
+        paths
+          .map { |path| path.relative_path_from(rails_root).to_s }
+          .uniq
       end
 
       sig { params(paths: T::Array[T.untyped]).void }

--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -329,7 +329,8 @@ module Packwerk
     end
 
     def package_manifests(glob_pattern)
-      PackageSet.package_paths(@configuration.root_path, glob_pattern).map(&:to_s)
+      PackageSet.package_paths(@configuration.root_path, glob_pattern)
+        .map { |f| File.realpath(f) }
     end
 
     def relative_paths(paths)

--- a/lib/packwerk/package_set.rb
+++ b/lib/packwerk/package_set.rb
@@ -29,7 +29,8 @@ module Packwerk
         bundle_path_match = Bundler.bundle_path.join("**").to_s
 
         Dir.glob(File.join(root_path, package_pathspec, PACKAGE_CONFIG_FILENAME))
-          .map { |path| Pathname.new(path) }.reject { |path| path.realpath.fnmatch(bundle_path_match) }
+          .map { |path| Pathname.new(path) }
+          .reject { |path| path.realpath.fnmatch(bundle_path_match) }
       end
 
       private

--- a/test/unit/application_load_paths_test.rb
+++ b/test/unit/application_load_paths_test.rb
@@ -46,5 +46,12 @@ module Packwerk
       ApplicationLoadPaths.expects(:filter_relevant_paths).once.returns([Pathname.new("/fake_path")])
       ApplicationLoadPaths.extract_relevant_paths
     end
+
+    test ".extract_relevant_paths returns unique load paths" do
+      path = Pathname.new("/application/app/models")
+      ApplicationLoadPaths.expects(:filter_relevant_paths).once.returns([path, path])
+
+      assert_equal 1, ApplicationLoadPaths.extract_relevant_paths.count
+    end
   end
 end


### PR DESCRIPTION
## What are you trying to accomplish?

There are two bugs in `v1.0.1` that results in `packwerk validate` failure because the paths were not real paths as it was [recently removed](https://github.com/Shopify/packwerk/pull/38/files#diff-5ca9dcd54fd0b9eeef94e00ba6adc7822dc83e5dd2bfb9e8d96fd3c356de8b8aR328). Because there was no test to catch it, this ended up in a release. 

## What approach did you choose and why?

There are two fixes in this PR. I have linked the appropriate PRs / line change that caused the bug. 

## What should reviewers focus on?

We should get this change out ASAP. 

You can help by confirming this change with the steps below: 

1. checkout a master branch of Core with a local version of Packwerk v1.0.1 linked 
2. run `bin/spring packwerk validate` - this will fail
3. checkout this branch and run validate again - this should pass

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
