### PR TITLE
Support providing a custom ERB parser class

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -67,6 +67,27 @@ Packwerk reads from the `packwerk.yml` configuration file in the root directory.
 | load_paths           | All application autoload paths            | list of load paths |
 | custom_associations  | N/A                                       | list of custom associations, if any |
 
+### Using a custom ERB parser
+
+You can specify a custom ERB parser if needed. For example, if you're using `<%graphql>` tags from https://github.com/github/graphql-client in your ERBs, you can use a custom parser subclass to comment them out so that Packwerk can parse the rest of the file:
+
+```ruby
+class CustomParser < Packwerk::Parsers::Erb
+  def parse_buffer(buffer, file_path:)
+    preprocessed_source = buffer.source
+
+    # Comment out <%graphql ... %> tags. They won't contain any object
+    # references anyways.
+    preprocessed_source = preprocessed_source.gsub(/<%graphql/, "<%#")
+
+    preprocessed_buffer = Parser::Source::Buffer.new(file_path)
+    preprocessed_buffer.source = preprocessed_source
+    super(preprocessed_buffer, file_path: file_path)
+  end
+end
+
+Packwerk::Parsers::Factory.instance.erb_parser_class = CustomParser
+```
 
 ### Inflections
 

--- a/lib/packwerk/parsers/erb.rb
+++ b/lib/packwerk/parsers/erb.rb
@@ -19,6 +19,10 @@ module Packwerk
       def call(io:, file_path: "<unknown>")
         buffer = Parser::Source::Buffer.new(file_path)
         buffer.source = io.read
+        parse_buffer(buffer, file_path: file_path)
+      end
+
+      def parse_buffer(buffer, file_path:)
         parser = @parser_class.new(buffer, template_language: :html)
         to_ruby_ast(parser.ast, file_path)
       rescue EncodingError => e

--- a/lib/packwerk/parsers/factory.rb
+++ b/lib/packwerk/parsers/factory.rb
@@ -26,8 +26,17 @@ module Packwerk
         when RUBY_REGEX
           @ruby_parser ||= Ruby.new
         when ERB_REGEX
-          @erb_parser ||= Erb.new
+          @erb_parser ||= erb_parser_class.new
         end
+      end
+
+      def erb_parser_class
+        @erb_parser_class || Erb
+      end
+
+      def erb_parser_class=(klass)
+        @erb_parser_class = klass
+        @erb_parser = nil
       end
     end
   end

--- a/test/unit/parsers/factory_test.rb
+++ b/test/unit/parsers/factory_test.rb
@@ -23,6 +23,11 @@ module Packwerk
         assert_instance_of(Parsers::Erb, factory.for_path("foo.html.erb"))
         assert_instance_of(Parsers::Erb, factory.for_path("foo.md.erb"))
         assert_instance_of(Parsers::Erb, factory.for_path("/sub/directory/foo.erb"))
+
+        fake_class = Class.new
+        with_erb_parser_class(fake_class) do
+          assert_instance_of(fake_class, factory.for_path("foo.html.erb"))
+        end
       end
 
       test "#for_path gives nil for unknown path" do
@@ -32,6 +37,13 @@ module Packwerk
       end
 
       private
+
+      def with_erb_parser_class(klass)
+        factory.erb_parser_class = klass
+        yield
+      ensure
+        factory.erb_parser_class = nil
+      end
 
       def factory
         Parsers::Factory.instance


### PR DESCRIPTION
## What are you trying to accomplish?

Fixes https://github.com/Shopify/packwerk/issues/66

This allows users to specify a custom ERB parser to support non-standard tags. For example, we can use it to comment out `<%graphql>` tags from https://github.com/github/graphql-client so that Packwerk can parse the rest of the file:

```ruby
class CustomParser < Packwerk::Parsers::Erb
  def parse_buffer(buffer, file_path:)
    preprocessed_source = buffer.source

    # Comment out <%graphql ... %> tags. They won't contain any object
    # references anyways.
    preprocessed_source = preprocessed_source.gsub(/<%graphql/, "<%#")

    preprocessed_buffer = Parser::Source::Buffer.new(file_path)
    preprocessed_buffer.source = preprocessed_source
    super(preprocessed_buffer, file_path: file_path)
  end
end

Packwerk::Parsers::Factory.instance.erb_parser_class = CustomParser
```

## What approach did you choose and why?

This is similar to how graphql-client handles this same problem for Erubi itself: https://github.com/github/graphql-client/blob/master/lib/graphql/client/erubi_enhancer.rb

## What should reviewers focus on?

Is this the appropriate way to set a global configuration value? Should it be set in `Configuration` instead?

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Users can now specify a custom ERB parser:

```ruby
Packwerk::Parsers::Factory.instance.erb_parser_class = YourCustomParserClass
```

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
