### PR TITLE
Make load path extraction logic testable

### DIFF
--- a/lib/packwerk/application_load_paths.rb
+++ b/lib/packwerk/application_load_paths.rb
@@ -1,0 +1,65 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "bundler"
+
+module Packwerk
+  module ApplicationLoadPaths
+    class << self
+      extend T::Sig
+
+      sig { returns(T::Array[String]) }
+      def extract_relevant_paths
+        assert_application_booted
+        all_paths = extract_application_autoload_paths
+        relevant_paths = filter_relevant_paths(all_paths)
+        assert_load_paths_present(relevant_paths)
+        relative_path_strings(relevant_paths)
+      end
+
+      sig { void }
+      def assert_application_booted
+        raise "The application needs to be booted to extract load paths" unless defined?(::Rails)
+      end
+
+      sig { returns(T::Array[String]) }
+      def extract_application_autoload_paths
+        Rails.application.railties
+          .select { |railtie| railtie.is_a?(Rails::Engine) }
+          .push(Rails.application)
+          .flat_map do |engine|
+          (engine.config.autoload_paths + engine.config.eager_load_paths + engine.config.autoload_once_paths).uniq
+        end
+      end
+
+      sig do
+        params(all_paths: T::Array[String], bundle_path: Pathname, rails_root: Pathname)
+          .returns(T::Array[Pathname])
+      end
+      def filter_relevant_paths(all_paths, bundle_path: Bundler.bundle_path, rails_root: Rails.root)
+        bundle_path_match = bundle_path.join("**")
+        rails_root_match = rails_root.join("**")
+
+        all_paths
+          .map { |path| Pathname.new(path).expand_path }
+          .select { |path| path.fnmatch(rails_root_match.to_s) } # path needs to be in application directory
+          .reject { |path| path.fnmatch(bundle_path_match.to_s) } # reject paths from vendored gems
+      end
+
+      sig { params(paths: T::Array[Pathname], rails_root: Pathname).returns(T::Array[String]) }
+      def relative_path_strings(paths, rails_root: Rails.root)
+        paths.map { |path| path.relative_path_from(rails_root).to_s }
+      end
+
+      sig { params(paths: T::Array[T.untyped]).void }
+      def assert_load_paths_present(paths)
+        if paths.empty?
+          raise <<~EOS
+            We could not extract autoload paths from your Rails app. This is likely a configuration error.
+            Packwerk will not work correctly without any autoload paths.
+          EOS
+        end
+      end
+    end
+  end
+end

--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -9,15 +9,15 @@ require "yaml"
 require "packwerk/package_set"
 require "packwerk/graph"
 require "packwerk/inflector"
+require "packwerk/application_load_paths"
 
 module Packwerk
   class ApplicationValidator
-    def initialize(config_file_path:, application_load_paths:, configuration:)
+    def initialize(config_file_path:, configuration:)
       @config_file_path = config_file_path
       @configuration = configuration
 
-      # Load paths should be from the application
-      @application_load_paths = application_load_paths.sort.uniq
+      @application_load_paths = ApplicationLoadPaths.extract_relevant_paths
     end
 
     Result = Struct.new(:ok?, :error_value)

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -204,7 +204,6 @@ module Packwerk
       @progress_formatter.started_validation do
         checker = Packwerk::ApplicationValidator.new(
           config_file_path: @configuration.config_path,
-          application_load_paths: @configuration.all_application_autoload_paths,
           configuration: @configuration
         )
         result = checker.check_all

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -42,45 +42,10 @@ module Packwerk
       @root_path = File.expand_path(root)
       @package_paths = configs["package_paths"] || "**/"
       @custom_associations = configs["custom_associations"] || []
-      @load_paths = configs["load_paths"] || all_application_autoload_paths
+      @load_paths = configs["load_paths"]
       @inflections_file = File.expand_path(configs["inflections_file"] || "config/inflections.yml", @root_path)
 
       @config_path = config_path
-    end
-
-    def all_application_autoload_paths
-      return [] unless defined?(::Rails)
-
-      all_paths = Rails.application.railties
-        .select { |railtie| railtie.is_a?(Rails::Engine) }
-        .push(Rails.application)
-        .flat_map do |engine|
-        (engine.config.autoload_paths + engine.config.eager_load_paths + engine.config.autoload_once_paths).uniq
-      end
-
-      bundle_path_match = Bundler.bundle_path.join("**").to_s
-
-      all_paths = all_paths.each_with_object([]) do |path_string, paths|
-        # ignore paths inside gems
-        path = Pathname.new(path_string)
-
-        next unless path.exist?
-        next if path.realpath.fnmatch(bundle_path_match)
-
-        paths << path.relative_path_from(Rails.root).to_s
-      end
-
-      all_paths.tap do |paths|
-        if paths.empty?
-          raise <<~EOS
-            No autoload paths have been set up in your Rails app. This is likely a bug, and
-            packwerk is unlikely to work correctly without any autoload paths.
-
-            You can follow the Rails guides on setting up load paths, or manually configure
-            them in `packwerk.yml` with `load_paths`.
-          EOS
-        end
-      end
     end
   end
 end

--- a/test/unit/application_load_paths_test.rb
+++ b/test/unit/application_load_paths_test.rb
@@ -1,0 +1,50 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_helper"
+require "rails_test_helper"
+
+module Packwerk
+  class ApplicationLoadPathsTest < Minitest::Test
+    test ".relative_path_strings makes paths relative" do
+      rails_root = Pathname.new("/application/")
+      relative_path = "app/models"
+      absolute_path = rails_root.join(relative_path)
+      relative_path_strings = ApplicationLoadPaths.relative_path_strings(
+        [absolute_path],
+        rails_root: rails_root
+      )
+
+      assert_equal [relative_path], relative_path_strings
+    end
+
+    test ".filter_relevant_paths excludes paths outside of the application root" do
+      valid_paths = ["/application/app/models"]
+      paths = valid_paths + ["/users/tobi/.gems/something/app/models", "/application/../something/"]
+      filtered_paths = ApplicationLoadPaths.filter_relevant_paths(
+        paths,
+        bundle_path: Pathname.new("/application/vendor/"),
+        rails_root: Pathname.new("/application/")
+      )
+
+      assert_equal valid_paths, filtered_paths.map(&:to_s)
+    end
+
+    test ".filter_relevant_paths excludes paths from vendored gems" do
+      valid_paths = ["/application/app/models"]
+      paths = valid_paths + ["/application/vendor/something/app/models"]
+      filtered_paths = ApplicationLoadPaths.filter_relevant_paths(
+        paths,
+        bundle_path: Pathname.new("/application/vendor/"),
+        rails_root: Pathname.new("/application/")
+      )
+
+      assert_equal valid_paths, filtered_paths.map(&:to_s)
+    end
+
+    test ".extract_relevant_paths calls out to filter the paths" do
+      ApplicationLoadPaths.expects(:filter_relevant_paths).once.returns([Pathname.new("/fake_path")])
+      ApplicationLoadPaths.extract_relevant_paths
+    end
+  end
+end

--- a/test/unit/application_validator_test.rb
+++ b/test/unit/application_validator_test.rb
@@ -21,7 +21,6 @@ module Packwerk
     test "validity" do
       application_validator = Packwerk::ApplicationValidator.new(
         config_file_path: @configuration.config_path,
-        application_load_paths: @configuration.all_application_autoload_paths,
         configuration: @configuration
       )
       result = application_validator.check_all
@@ -32,7 +31,6 @@ module Packwerk
     test "returns an error for unresolvable privatized constants" do
       application_validator = Packwerk::ApplicationValidator.new(
         config_file_path: @configuration.config_path,
-        application_load_paths: @configuration.all_application_autoload_paths,
         configuration: @configuration
       )
       ConstantResolver.expects(:new).returns(stub("resolver", resolve: nil))
@@ -51,7 +49,6 @@ module Packwerk
 
       application_validator = Packwerk::ApplicationValidator.new(
         config_file_path: configuration.config_path,
-        application_load_paths: configuration.all_application_autoload_paths,
         configuration: configuration
       )
 
@@ -76,7 +73,6 @@ module Packwerk
 
       application_validator = Packwerk::ApplicationValidator.new(
         config_file_path: configuration.config_path,
-        application_load_paths: configuration.all_application_autoload_paths,
         configuration: configuration
       )
 

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "rails_test_helper"
 
 module Packwerk
   class ConfigurationTest < Minitest::Test
@@ -49,35 +48,9 @@ module Packwerk
       assert_equal ["**/*.{rb,rake,erb}"], configuration.include
       assert_equal ["{bin,node_modules,script,tmp,vendor}/**/*"], configuration.exclude
       assert_equal File.expand_path("."), configuration.root_path
-      assert_equal default_autoloads, configuration.load_paths.sort
       assert_equal "**/", configuration.package_paths
       assert_empty configuration.custom_associations
       assert_equal File.expand_path("config/inflections.yml"), configuration.inflections_file
-    end
-
-    test ".from_path doesn't include load paths from vendored gems" do
-      File.expects(:exist?).with(Dir.pwd).returns(true)
-      File.expects(:file?).with(File.join(Dir.pwd, "packwerk.yml")).returns(false)
-      Bundler.expects(:bundle_path).returns(Rails.root.join("vendor/cache/gems"))
-
-      configuration = Configuration.from_path
-      expected_autoloads = default_autoloads - ["vendor/cache/gems/example/models"]
-
-      assert_equal expected_autoloads, configuration.load_paths.sort
-    end
-
-    private
-
-    # TODO: this isn't great, so let's come back and refactor so that we're in more control
-    #       of the initial state.
-    def default_autoloads
-      [
-        "components/platform/app/models",
-        "components/sales/app/models",
-        "components/timeline/app/models",
-        "components/timeline/app/models/concerns",
-        "vendor/cache/gems/example/models",
-      ]
     end
   end
 end


### PR DESCRIPTION
## What are you trying to accomplish?

Pre-requisite refactor for #65

We want to move the Rails loading logic out of Configuration and into `ApplicationValidator`, which is the only place we need to load/require files from Rails. 

## What approach did you choose and why?

More specifically, we are breaking down `Configuration#all_application_autoload_paths` and moving it to `ApplicationLoadPaths`, which can be extracted within `ApplicationValidator`.  

## What should reviewers focus on?


## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
