### PR TITLE
Support array of paths in PackageSet

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -63,7 +63,7 @@ Packwerk reads from the `packwerk.yml` configuration file in the root directory.
 |----------------------|-------------------------------------------|--------------|
 | include              | **/*.{rb,rake,erb}                        | list of patterns for folder paths to include |
 | exclude              | {bin,node_modules,script,tmp,vendor}/**/* | list of patterns for folder paths to exclude |
-| package_paths        | **/                                       | patterns to find package configuration files, see: Defining packages |
+| package_paths        | **/                                       | a single pattern or a list of patterns to find package configuration files, see: [Defining packages](#Defining-packages) |
 | load_paths           | All application autoload paths            | list of load paths |
 | custom_associations  | N/A                                       | list of custom associations, if any |
 

--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -32,7 +32,7 @@ module Packwerk
         check_acyclic_graph,
         check_package_manifest_paths,
         check_valid_package_dependencies,
-        check_root_package_exist,
+        check_root_package_exists,
       ]
 
       results.reject!(&:ok?)
@@ -297,7 +297,7 @@ module Packwerk
       end
     end
 
-    def check_root_package_exist
+    def check_root_package_exists
       root_package_path = File.join(@configuration.root_path, "package.yml")
       all_packages_manifests = package_manifests(package_glob)
 

--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -207,7 +207,7 @@ module Packwerk
     end
 
     def check_acyclic_graph
-      packages = Packwerk::PackageSet.load_all_from(".")
+      packages = Packwerk::PackageSet.load_all_from(@configuration.root_path)
 
       edges = packages.flat_map do |package|
         package.dependencies.map { |dependency| [package, packages.fetch(dependency)] }

--- a/lib/packwerk/package_set.rb
+++ b/lib/packwerk/package_set.rb
@@ -28,8 +28,12 @@ module Packwerk
       def package_paths(root_path, package_pathspec)
         bundle_path_match = Bundler.bundle_path.join("**").to_s
 
-        Dir.glob(File.join(root_path, package_pathspec, PACKAGE_CONFIG_FILENAME))
-          .map { |path| Pathname.new(path) }
+        glob_patterns = Array(package_pathspec).map do |pathspec|
+          File.join(root_path, pathspec, PACKAGE_CONFIG_FILENAME)
+        end
+
+        Dir.glob(glob_patterns)
+          .map { |path| Pathname.new(path).cleanpath }
           .reject { |path| path.realpath.fnmatch(bundle_path_match) }
       end
 

--- a/test/unit/package_set_test.rb
+++ b/test/unit/package_set_test.rb
@@ -32,6 +32,31 @@ module Packwerk
       assert_nil(@package_set.fetch("components/unknown"))
     end
 
+    test ".package_paths supports a path wildcard" do
+      package_paths = PackageSet.package_paths("test/fixtures/skeleton", "**")
+
+      assert_includes(package_paths, Pathname.new("test/fixtures/skeleton/components/sales/package.yml"))
+      assert_includes(package_paths, Pathname.new("test/fixtures/skeleton/package.yml"))
+    end
+
+    test ".package_paths supports a single path as a string" do
+      package_paths = PackageSet.package_paths("test/fixtures/skeleton", "components/sales")
+
+      assert_equal(package_paths, [Pathname.new("test/fixtures/skeleton/components/sales/package.yml")])
+    end
+
+    test ".package_paths supports many paths as an array" do
+      package_paths = PackageSet.package_paths("test/fixtures/skeleton", ["components/sales", "."])
+
+      assert_equal(
+        package_paths,
+        [
+          Pathname.new("test/fixtures/skeleton/components/sales/package.yml"),
+          Pathname.new("test/fixtures/skeleton/package.yml"),
+        ]
+      )
+    end
+
     test ".package_paths excludes paths inside the gem directory" do
       vendor_package_path = Pathname.new("test/fixtures/skeleton/vendor/cache/gems/example/package.yml")
 


### PR DESCRIPTION
## What are you trying to accomplish?
Packwerk integrators can set the scope of directories to search for package definitions by providing a `package_paths` in their packwerk.yml file.  The default value is `"**"`, which corresponds to the application's entire set of directories and subdirectories.

Although `package_paths` sounds likes one can specify more than one path (like in the `include`, `exclude`, and `load_paths` settings), this is not currently the case:
https://github.com/Shopify/packwerk/blob/6d89101f54a6d415938e852cae06f11833ccda32/lib/packwerk/package_set.rb#L28-L33
If someone were to configure `packwerk.yml` like so
```yml
# packyerk.yml
package_paths:
  - .
  - package/a/**
  - package/b
```
The they would wind up with
```ruby
# Dir.glob(File.join(root_path, package_pathspec, PACKAGE_CONFIG_FILENAME)) ==>
Dir.glob("/.../Shopify/packwerk/./package/a/**/package/b/package.yml") # oops
```
It's possible to describe the example package paths above with a single glob pattern
```yml
# packyerk.yml
package_paths: {.,package/a/**,package/b}
```
Nonetheless, an array format for listing paths is less surprising to me.

## What approach did you choose and why?
Support both array and string values in `package_paths` by using [`Array(the_value)`](https://ruby-doc.org/core-2.7.0/Kernel.html#method-i-Array), which ensures that everything going forward is an array.

## What should reviewers focus on?
All of it.

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
