### PR TITLE
Introduce fixture helper module

### DIFF
--- a/test/fixtures/minimal/components/sales/app/models/order.rb
+++ b/test/fixtures/minimal/components/sales/app/models/order.rb
@@ -1,0 +1,5 @@
+# typed: ignore
+# frozen_string_literal: true
+
+class Order
+end

--- a/test/fixtures/minimal/components/sales/app/models/sales/order.rb
+++ b/test/fixtures/minimal/components/sales/app/models/sales/order.rb
@@ -1,0 +1,7 @@
+# typed: ignore
+# frozen_string_literal: true
+
+module Sales
+  class Order
+  end
+end

--- a/test/fixtures/minimal/components/sales/app/public/sales/record_new_order.rb
+++ b/test/fixtures/minimal/components/sales/app/public/sales/record_new_order.rb
@@ -1,0 +1,7 @@
+# typed: ignore
+# frozen_string_literal: true
+
+module Sales
+  module RecordNewOrder
+  end
+end

--- a/test/fixtures/minimal/components/sales/package.yml
+++ b/test/fixtures/minimal/components/sales/package.yml
@@ -1,0 +1,8 @@
+---
+enforce_privacy: true
+
+metadata:
+  stewards:
+  - "@Shopify/sales"
+  slack_channels:
+  - "#sales"

--- a/test/fixtures/minimal/packwerk.yml
+++ b/test/fixtures/minimal/packwerk.yml
@@ -1,0 +1,4 @@
+include:
+  - "**/*.rb"
+load_paths:
+  - components/sales/app/models

--- a/test/support/application_fixture_helper.rb
+++ b/test/support/application_fixture_helper.rb
@@ -1,0 +1,67 @@
+# typed: ignore
+# frozen_string_literal: true
+
+module ApplicationFixtureHelper
+  TEMP_FIXTURE_DIR = ROOT.join("tmp", "fixtures").to_s
+  DEFAULT_TEMPLATE = :minimal
+
+  def setup_application_fixture
+    @old_working_dir = Dir.pwd
+  end
+
+  def teardown_application_fixture
+    Dir.chdir(@old_working_dir)
+    FileUtils.remove_entry(@app_dir, true) if using_template?
+  end
+
+  def use_template(template)
+    raise "use_template may only be called once per test" if using_template?
+    copy_dir("test/fixtures/#{template}")
+    Dir.chdir(app_dir)
+  end
+
+  def app_dir
+    unless using_template?
+      raise "You need to set up an application fixture by calling `use_template(:the_template)`."
+    end
+
+    @app_dir
+  end
+
+  def config
+    @config ||= Packwerk::Configuration.from_path(app_dir)
+  end
+
+  def to_app_path(relative_path)
+    File.join(app_dir, relative_path)
+  end
+
+  def to_app_paths(*relative_paths)
+    relative_paths.map { |path| to_app_path(path) }
+  end
+
+  def merge_into_app_yaml_file(relative_path, hash)
+    path = to_app_path(relative_path)
+    YamlFile.new(path).merge(hash)
+  end
+
+  def remove_app_entry(relative_path)
+    FileUtils.remove_entry(to_app_path(relative_path))
+  end
+
+  private
+
+  def using_template?
+    defined? @app_dir
+  end
+
+  def copy_dir(path)
+    root = FileUtils.mkdir_p(fixture_path).last
+    FileUtils.cp_r("#{path}/.", root)
+    @app_dir = root
+  end
+
+  def fixture_path
+    File.join(TEMP_FIXTURE_DIR, "#{name}-#{Time.now.strftime('%Y_%m_%d_%H_%M_%S')}")
+  end
+end

--- a/test/support/yaml_file.rb
+++ b/test/support/yaml_file.rb
@@ -1,0 +1,39 @@
+# typed: ignore
+# frozen_string_literal: true
+
+class YamlFile
+  def initialize(path)
+    @path = path
+  end
+
+  def merge(hash)
+    merged_data = recursive_merge(read_or_create, hash)
+    write(merged_data)
+  end
+
+  private
+
+  attr_reader :path
+
+  def read_or_create
+    FileUtils.mkpath(File.dirname(path))
+    FileUtils.touch(path)
+    YAML.load_file(path) || {}
+  end
+
+  def write(data)
+    File.open(path, "w") { |f| YAML.dump(data, f) }
+  end
+
+  def recursive_merge(hash, other_hash)
+    hash.merge(other_hash) do |_, old_value, new_value|
+      if old_value.is_a?(Hash) && new_value.is_a?(Hash)
+        recursive_merge(old_value, new_value)
+      elsif old_value.is_a?(Array)
+        old_value + Array(new_value)
+      else
+        new_value
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,17 +4,18 @@
 ENV["RAILS_ENV"] = "test"
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+ROOT = Pathname.new(__dir__).join("..").expand_path
+
 require "constant_resolver"
 require "packwerk"
 
 require "minitest/autorun"
 require "minitest/focus"
+require "mocha/minitest"
+require "support/application_fixture_helper"
 require "support/test_macro"
 require "support/test_assertions"
-
-require "mocha/minitest"
-
-ROOT = Pathname.new(__dir__).join("..").expand_path
+require "support/yaml_file"
 
 Minitest::Test.extend(TestMacro)
 Minitest::Test.include(TestAssertions)

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -5,6 +5,16 @@ require "test_helper"
 
 module Packwerk
   class ConfigurationTest < Minitest::Test
+    include ApplicationFixtureHelper
+
+    setup do
+      setup_application_fixture
+    end
+
+    teardown do
+      teardown_application_fixture
+    end
+
     test ".from_path raises ArgumentError if path does not exist" do
       File.expects(:exist?).with("foo").returns(false)
       error = assert_raises ArgumentError do
@@ -15,8 +25,8 @@ module Packwerk
     end
 
     test ".from_path uses packwerk config when it exists" do
-      File.expects(:exist?).with(".").returns(true)
-      File.expects(:file?).with("./packwerk.yml").returns(true)
+      use_template(:minimal)
+      remove_app_entry("packwerk.yml")
 
       configuration_hash = {
         "include" => ["xyz/*.rb"],
@@ -26,32 +36,32 @@ module Packwerk
         "custom_associations" => ["custom_association"],
         "inflections_file" => "custom_inflections.yml",
       }
-      YAML.expects(:load_file).with("./packwerk.yml").returns(configuration_hash)
+      merge_into_app_yaml_file("packwerk.yml", configuration_hash)
 
-      configuration = Configuration.from_path(".")
+      configuration = Configuration.from_path(app_dir)
 
       assert_equal ["xyz/*.rb"], configuration.include
       assert_equal ["{exclude_dir,bin,tmp}/**/*"], configuration.exclude
-      assert_equal File.expand_path("."), configuration.root_path
+      assert_equal app_dir, configuration.root_path
       assert_equal ["app/models"], configuration.load_paths
       assert_equal "**/*/", configuration.package_paths
       assert_equal ["custom_association"], configuration.custom_associations
-      assert_equal File.expand_path("custom_inflections.yml"), configuration.inflections_file
+      assert_equal to_app_path("custom_inflections.yml"), configuration.inflections_file
     end
 
     test ".from_path falls back to some default config when no existing config exists" do
-      File.expects(:exist?).with(Dir.pwd).returns(true)
-      File.expects(:file?).with(File.join(Dir.pwd, "packwerk.yml")).returns(false)
+      use_template(:minimal)
+      remove_app_entry("packwerk.yml")
 
       configuration = Configuration.from_path
 
       assert_equal ["**/*.{rb,rake,erb}"], configuration.include
       assert_equal ["{bin,node_modules,script,tmp,vendor}/**/*"], configuration.exclude
-      assert_equal File.expand_path("."), configuration.root_path
+      assert_equal app_dir, configuration.root_path
       assert_empty configuration.load_paths
       assert_equal "**/", configuration.package_paths
       assert_empty configuration.custom_associations
-      assert_equal File.expand_path("config/inflections.yml"), configuration.inflections_file
+      assert_equal to_app_path("config/inflections.yml"), configuration.inflections_file
     end
   end
 end


### PR DESCRIPTION
## What are you trying to accomplish?
In [proof-of-concept PR #59](https://github.com/Shopify/packwerk/pull/59), I fleshed out a way to set up certain Packwerk tests by copying a template folder into a temporary directory, modifying those configuration fixtures, running the test, and then cleaning up the temporary artifacts.  In this PR, I will introduce the first of two helper modules to support that: ApplicationFixtureHelper.

## What approach did you choose and why?
**Note that I updated my code examples to use the new method names which came from the review process.**

Most test classes in Packwerk do not require a whole application directory to test their functionality.  There is no need for ApplicationFixtureHelper's methods to be available in every test.  Instead, the module simply needs to be included when it is needed.
```ruby
class YourThingyThatNeedsToBeRunningAgainstAnAppTest < Minitest::Test
  include ApplicationFixtureHelper
```
As mentioned in the POC PR, Packwerk uses the host application's current working directory to find its configuration artifacts and to inspect the application code.  Before the helper module copies the application directory into a temporary location, it needs to cache some state from the test process.
```ruby
  setup do
    setup_application_fixture  # caches current working directory
    # other setup logic...
  end
```
The test class needs to call the module's teardown method as well.  This method restores the old application state and deletes temporary artifacts.
```ruby
  teardown do
    # other teardown logic...
    teardown_application_fixture
  end
```
To copy an application fixture and change the current working directory, call `ApplicationFixtureHelper#use_template(:the_template)`:

![image](https://user-images.githubusercontent.com/33674553/99838766-9fda1f80-2b37-11eb-9b7e-0664614a9a67.png)

Calling `use_template` as part of the `setup` method allows every test to have its own isolated copy of the same application fixture.
```ruby
  setup do
    setup_application_fixture  # caches current working directory
    use_template(:skeleton)
    # other setup logic...
  end

  teardown do
    # other teardown logic...
    teardown_application_fixture
  end

  test "wrecking my application's packwerk.yml causes pretty sparks to fly" do
    # ...
  end

  test "i'm with stupid :arrow_up: but I'm ok" do
    # assert things about the skeleton app
  end
```
Calling `use_template` inside a test is preferable when only some tests require a temporary application sandbox, or if the sandbox varies by test.
```ruby
  test "something using the minimal application" do
    use_template(:minimal)
    # assert things about the minimal app
  end
```

The module adds a few helper methods to work with the temporary application:
### `app_dir`
returns the root of the temporary application.  ~~It will first copy the `:minimal` template unless this has already occured for the test.~~ It will raise unless `use_template` has been called for this test.

### `config`
returns a `Configuration` object for the temporary application.

### `to_app_path(relative_path)`
### `to_app_paths(*relative_paths)`
Converts relative paths into absolute paths rooted in the temporary application.

### `merge_into_app_yaml_file(relative_path, hash)`
Either create a new yaml file at the indicated path, or update the existing one by treating its contents as a hash and merging in the new hash.

Consider the existing array values for `b` and `c`,
```yml
# path/to/file.yml
a: some_value
b:
- 1
- 2
c:
- hi
```
Then calling 
```ruby
merge_into_app_yaml_file("path/to/file.yml", { b: [3,4], c: "bye" })
```
Will result in this yml
```yml
# path/to/file.yml
a: some_value
b:
- 1
- 2
- 3
- 4
c:
- hi
- bye
```

### `remove_app_entry(relative_path)`
Delete the file if it exists. 

## What should reviewers focus on?
I chose to implement the module and update a single existing suite to showcase its use.  I decided not to update other suites that already create temporary directories; I didn't see a clear benefit in changing them.  I also don't want to make this PR bigger than it already is.

Most of the new files make up the new `test/fixtures/minimal` application fixture, which is a slimmed down counterpart to `skeleton`, while still being a non-trivial one.  I would really like some feedback on what should go into this new, simple application.  I don't want another "everything and the kitchen sink" application like `skeleton`, but I also want `minimal` to be fleshed out enough to be useful without having to constantly add to it in most tests.

I do think it could be even slimmer than it already is, and I welcome @Shopify/packwerk veterans' suggestions for what should be left out.  After a quick settling period, `minimal` should not change very often.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
