### PR TITLE
Fix CLI init by defining default load path value

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -3,6 +3,7 @@
 require "benchmark"
 require "sorbet-runtime"
 
+require "packwerk/application_load_paths"
 require "packwerk/application_validator"
 require "packwerk/configuration"
 require "packwerk/files_for_processing"
@@ -101,7 +102,7 @@ module Packwerk
 
     def generate_configs
       configuration_file = Packwerk::Generators::ConfigurationFile.generate(
-        load_paths: @configuration.load_paths,
+        load_paths: Packwerk::ApplicationLoadPaths.extract_relevant_paths,
         root: @configuration.root_path,
         out: @out
       )

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -42,7 +42,7 @@ module Packwerk
       @root_path = File.expand_path(root)
       @package_paths = configs["package_paths"] || "**/"
       @custom_associations = configs["custom_associations"] || []
-      @load_paths = configs["load_paths"]
+      @load_paths = configs["load_paths"] || []
       @inflections_file = File.expand_path(configs["inflections_file"] || "config/inflections.yml", @root_path)
 
       @config_path = config_path

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -48,6 +48,7 @@ module Packwerk
       assert_equal ["**/*.{rb,rake,erb}"], configuration.include
       assert_equal ["{bin,node_modules,script,tmp,vendor}/**/*"], configuration.exclude
       assert_equal File.expand_path("."), configuration.root_path
+      assert_empty configuration.load_paths
       assert_equal "**/", configuration.package_paths
       assert_empty configuration.custom_associations
       assert_equal File.expand_path("config/inflections.yml"), configuration.inflections_file


### PR DESCRIPTION
## What are you trying to accomplish?
Resolves #76.

`ConfigurationFile#initialize` is expecting an Array value for `load_paths`, yet when called via the `packwerk init` CLI command, it was being passed as `nil` and thus throwing a Sorbet type violation.

## What approach did you choose and why?
I've just provided an empty array as a fallback if no `load_paths` value is defined, which is the case when running the config generator. Seemed like the most logical solution and matches the approach used for `custom_associations`.

## What should reviewers focus on?
I assume an empty array is the desired fallback here, although I guess `ApplicationLoadPaths.extract_relevant_paths` could also be an option.

## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] It is safe to rollback this change.
