### PR TITLE
Refactor CLI: update-deprecations

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -144,6 +144,7 @@ module Packwerk
         progress_formatter: @progress_formatter
       )
       result = update_deprecations.run
+      @out.puts
       @out.puts(result.message)
       result.status
     end
@@ -166,8 +167,9 @@ module Packwerk
         @out.puts("Manually interrupted. Violations caught so far are listed below:")
       end
 
-      offenses_formatter.show_offenses(all_offenses)
       @progress_formatter.finished(execution_time)
+      @out.puts
+      @out.puts(offenses_formatter.show_offenses(all_offenses))
 
       all_offenses.empty?
     end
@@ -229,7 +231,7 @@ module Packwerk
     end
 
     def offenses_formatter
-      @offenses_formatter ||= Formatters::OffensesFormatter.new(@out, style: @style)
+      @offenses_formatter ||= Formatters::OffensesFormatter.new(style: @style)
     end
   end
 end

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -173,7 +173,7 @@ module Packwerk
     end
 
     def detect_stale_violations(paths)
-      detect_stale_violations = DetectStaleViolationsCommand.new(
+      detect_stale_violations = Commands::DetectStaleViolationsCommand.new(
         files: fetch_files_to_process(paths),
         configuration: @configuration,
         progress_formatter: @progress_formatter

--- a/lib/packwerk/commands/detect_stale_violations_command.rb
+++ b/lib/packwerk/commands/detect_stale_violations_command.rb
@@ -5,14 +5,13 @@ require "benchmark"
 require "packwerk/run_context"
 require "packwerk/detect_stale_deprecated_references"
 require "packwerk/commands/offense_progress_marker"
+require "packwerk/commands/result"
 
 module Packwerk
   module Commands
     class DetectStaleViolationsCommand
       extend T::Sig
       include OffenseProgressMarker
-      Result = Struct.new(:message, :status)
-
       def initialize(files:, configuration:, run_context: nil, progress_formatter: nil, reference_lister: nil)
         @configuration = configuration
         @run_context = run_context
@@ -54,7 +53,7 @@ module Packwerk
         if result_status
           message = "No stale violations detected"
         end
-        Result.new(message, result_status)
+        Result.new(message: message, status: result_status)
       end
     end
   end

--- a/lib/packwerk/commands/detect_stale_violations_command.rb
+++ b/lib/packwerk/commands/detect_stale_violations_command.rb
@@ -7,53 +7,55 @@ require "packwerk/detect_stale_deprecated_references"
 require "packwerk/commands/offense_progress_marker"
 
 module Packwerk
-  class DetectStaleViolationsCommand
-    extend T::Sig
-    include OffenseProgressMarker
-    Result = Struct.new(:message, :status)
+  module Commands
+    class DetectStaleViolationsCommand
+      extend T::Sig
+      include OffenseProgressMarker
+      Result = Struct.new(:message, :status)
 
-    def initialize(files:, configuration:, run_context: nil, progress_formatter: nil, reference_lister: nil)
-      @configuration = configuration
-      @run_context = run_context
-      @reference_lister = reference_lister
-      @progress_formatter = progress_formatter
-      @files = files
-    end
+      def initialize(files:, configuration:, run_context: nil, progress_formatter: nil, reference_lister: nil)
+        @configuration = configuration
+        @run_context = run_context
+        @reference_lister = reference_lister
+        @progress_formatter = progress_formatter
+        @files = files
+      end
 
-    sig { returns(Result) }
-    def run
-      @progress_formatter.started(@files)
+      sig { returns(Result) }
+      def run
+        @progress_formatter.started(@files)
 
-      execution_time = Benchmark.realtime do
-        @files.flat_map do |path|
-          run_context.process_file(file: path).tap do |offenses|
-            mark_progress(offenses: offenses, progress_formatter: @progress_formatter)
+        execution_time = Benchmark.realtime do
+          @files.flat_map do |path|
+            run_context.process_file(file: path).tap do |offenses|
+              mark_progress(offenses: offenses, progress_formatter: @progress_formatter)
+            end
           end
         end
+
+        @progress_formatter.finished(execution_time)
+        calculate_result
       end
 
-      @progress_formatter.finished(execution_time)
-      calculate_result
-    end
+      private
 
-    private
-
-    def run_context
-      @run_context ||= Packwerk::RunContext.from_configuration(@configuration, reference_lister: reference_lister)
-    end
-
-    def reference_lister
-      @reference_lister ||= ::Packwerk::DetectStaleDeprecatedReferences.new(@configuration.root_path)
-    end
-
-    sig { returns Result }
-    def calculate_result
-      result_status = !reference_lister.stale_violations?
-      message = "There were stale violations found, please run `packwerk update`"
-      if result_status
-        message = "No stale violations detected"
+      def run_context
+        @run_context ||= Packwerk::RunContext.from_configuration(@configuration, reference_lister: reference_lister)
       end
-      Result.new(message, result_status)
+
+      def reference_lister
+        @reference_lister ||= ::Packwerk::DetectStaleDeprecatedReferences.new(@configuration.root_path)
+      end
+
+      sig { returns(Result) }
+      def calculate_result
+        result_status = !reference_lister.stale_violations?
+        message = "There were stale violations found, please run `packwerk update`"
+        if result_status
+          message = "No stale violations detected"
+        end
+        Result.new(message, result_status)
+      end
     end
   end
 end

--- a/lib/packwerk/commands/result.rb
+++ b/lib/packwerk/commands/result.rb
@@ -1,0 +1,13 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Packwerk
+  module Commands
+    class Result < T::Struct
+      prop :message, String
+      prop :status, T::Boolean
+    end
+  end
+end

--- a/lib/packwerk/commands/update_deprecations_command.rb
+++ b/lib/packwerk/commands/update_deprecations_command.rb
@@ -1,10 +1,11 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "sorbet-runtime"
 require "benchmark"
 
 require "packwerk/commands/offense_progress_marker"
+require "packwerk/commands/result"
 require "packwerk/run_context"
 require "packwerk/updating_deprecated_references"
 
@@ -13,8 +14,14 @@ module Packwerk
     class UpdateDeprecationsCommand
       extend T::Sig
       include OffenseProgressMarker
-      Result = Struct.new(:message, :status)
-
+      sig do
+        params(
+          files: T::Enumerable[String],
+          configuration: Configuration,
+          offenses_formatter: Formatters::OffensesFormatter,
+          progress_formatter: Formatters::ProgressFormatter
+        ).void
+      end
       def initialize(files:, configuration:, offenses_formatter:, progress_formatter:)
         @files = files
         @configuration = configuration
@@ -44,14 +51,20 @@ module Packwerk
 
       private
 
+      sig { returns RunContext }
       def run_context
+        @run_context = T.let(@run_context, T.nilable(RunContext))
         @run_context ||= RunContext.from_configuration(
           @configuration,
           reference_lister: updating_deprecated_references
         )
       end
 
+      sig { returns UpdatingDeprecatedReferences }
       def updating_deprecated_references
+        @updating_deprecated_references = T.let(
+          @updating_deprecated_references, T.nilable(UpdatingDeprecatedReferences)
+        )
         @updating_deprecated_references ||= UpdatingDeprecatedReferences.new(@configuration.root_path)
       end
 
@@ -60,7 +73,7 @@ module Packwerk
         result_status = all_offenses.empty?
         message = "✅ `deprecated_references.yml` has been updated."
 
-        Result.new(message, result_status)
+        Result.new(message: message, status: result_status)
       end
     end
   end

--- a/lib/packwerk/commands/update_deprecations_command.rb
+++ b/lib/packwerk/commands/update_deprecations_command.rb
@@ -1,0 +1,67 @@
+# typed: true
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "benchmark"
+
+require "packwerk/commands/offense_progress_marker"
+require "packwerk/run_context"
+require "packwerk/updating_deprecated_references"
+
+module Packwerk
+  module Commands
+    class UpdateDeprecationsCommand
+      extend T::Sig
+      include OffenseProgressMarker
+      Result = Struct.new(:message, :status)
+
+      def initialize(files:, configuration:, offenses_formatter:, progress_formatter:)
+        @files = files
+        @configuration = configuration
+        @progress_formatter = progress_formatter
+        @offenses_formatter = offenses_formatter
+      end
+
+      sig { returns(Result) }
+      def run
+        @progress_formatter.started(@files)
+
+        all_offenses = T.let([], T.untyped)
+        execution_time = Benchmark.realtime do
+          all_offenses = @files.flat_map do |path|
+            run_context.process_file(file: path).tap do |offenses|
+              mark_progress(offenses: offenses, progress_formatter: @progress_formatter)
+            end
+          end
+
+          updating_deprecated_references.dump_deprecated_references_files
+        end
+
+        @offenses_formatter.show_offenses(all_offenses)
+        @progress_formatter.finished(execution_time)
+        calculate_result(all_offenses)
+      end
+
+      private
+
+      def run_context
+        @run_context ||= RunContext.from_configuration(
+          @configuration,
+          reference_lister: updating_deprecated_references
+        )
+      end
+
+      def updating_deprecated_references
+        @updating_deprecated_references ||= UpdatingDeprecatedReferences.new(@configuration.root_path)
+      end
+
+      sig { params(all_offenses: T::Array[T.nilable(::Packwerk::Offense)]).returns(Result) }
+      def calculate_result(all_offenses)
+        result_status = all_offenses.empty?
+        message = "✅ `deprecated_references.yml` has been updated."
+
+        Result.new(message, result_status)
+      end
+    end
+  end
+end

--- a/lib/packwerk/commands/update_deprecations_command.rb
+++ b/lib/packwerk/commands/update_deprecations_command.rb
@@ -14,6 +14,7 @@ module Packwerk
     class UpdateDeprecationsCommand
       extend T::Sig
       include OffenseProgressMarker
+
       sig do
         params(
           files: T::Enumerable[String],
@@ -27,6 +28,8 @@ module Packwerk
         @configuration = configuration
         @progress_formatter = progress_formatter
         @offenses_formatter = offenses_formatter
+        @updating_deprecated_references = T.let(nil, T.nilable(UpdatingDeprecatedReferences))
+        @run_context = T.let(nil, T.nilable(RunContext))
       end
 
       sig { returns(Result) }
@@ -50,20 +53,16 @@ module Packwerk
 
       private
 
-      sig { returns RunContext }
+      sig { returns(RunContext) }
       def run_context
-        @run_context = T.let(@run_context, T.nilable(RunContext))
         @run_context ||= RunContext.from_configuration(
           @configuration,
           reference_lister: updating_deprecated_references
         )
       end
 
-      sig { returns UpdatingDeprecatedReferences }
+      sig { returns(UpdatingDeprecatedReferences) }
       def updating_deprecated_references
-        @updating_deprecated_references = T.let(
-          @updating_deprecated_references, T.nilable(UpdatingDeprecatedReferences)
-        )
         @updating_deprecated_references ||= UpdatingDeprecatedReferences.new(@configuration.root_path)
       end
 

--- a/lib/packwerk/commands/update_deprecations_command.rb
+++ b/lib/packwerk/commands/update_deprecations_command.rb
@@ -44,7 +44,6 @@ module Packwerk
           updating_deprecated_references.dump_deprecated_references_files
         end
 
-        @offenses_formatter.show_offenses(all_offenses)
         @progress_formatter.finished(execution_time)
         calculate_result(all_offenses)
       end
@@ -71,7 +70,10 @@ module Packwerk
       sig { params(all_offenses: T::Array[T.nilable(::Packwerk::Offense)]).returns(Result) }
       def calculate_result(all_offenses)
         result_status = all_offenses.empty?
-        message = "✅ `deprecated_references.yml` has been updated."
+        message = <<~EOS
+          #{@offenses_formatter.show_offenses(all_offenses)}
+          ✅ `deprecated_references.yml` has been updated.
+        EOS
 
         Result.new(message: message, status: result_status)
       end

--- a/lib/packwerk/formatters/offenses_formatter.rb
+++ b/lib/packwerk/formatters/offenses_formatter.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "benchmark"
@@ -12,6 +12,12 @@ module Packwerk
     class OffensesFormatter
       extend T::Sig
 
+      sig do
+        params(
+          out: StringIO,
+          style: T.any(T.class_of(OutputStyles::Plain), T.class_of(OutputStyles::Coloured))
+        ).void
+      end
       def initialize(out, style: OutputStyles::Plain)
         @out = out
         @style = style

--- a/lib/packwerk/formatters/offenses_formatter.rb
+++ b/lib/packwerk/formatters/offenses_formatter.rb
@@ -1,0 +1,36 @@
+# typed: true
+# frozen_string_literal: true
+
+require "benchmark"
+require "sorbet-runtime"
+
+require "packwerk/inflector"
+require "packwerk/output_styles"
+
+module Packwerk
+  module Formatters
+    class OffensesFormatter
+      extend T::Sig
+
+      def initialize(out, style: OutputStyles::Plain)
+        @out = out
+        @style = style
+      end
+
+      sig { params(offenses: T::Array[T.nilable(Offense)]).void }
+      def show_offenses(offenses)
+        @out.puts # put a new line after the progress dots
+        if offenses.empty?
+          @out.puts("No offenses detected 🎉")
+        else
+          offenses.each do |offense|
+            @out.puts(offense.to_s(@style)) if offense
+          end
+
+          offenses_string = Inflector.default.pluralize("offense", offenses.length)
+          @out.puts("#{offenses.length} #{offenses_string} detected")
+        end
+      end
+    end
+  end
+end

--- a/test/integration/custom_executable_test.rb
+++ b/test/integration/custom_executable_test.rb
@@ -54,10 +54,18 @@ module Packwerk
         assert_successful_run("update-deprecations")
 
         deprecated_reference_content_after_update = read_deprecated_references
+        expected_output = <<~EOS
+          📦 Packwerk is inspecting 12 files
+          ............
+          📦 Finished in \\d+\\.\\d+ seconds
+
+          No offenses detected 🎉
+          ✅ `deprecated_references.yml` has been updated.
+        EOS
 
         assert_equal(deprecated_reference_content, deprecated_reference_content_after_update,
           "expected no updates to any deprecated references file")
-        assert_match(/`deprecated_references.yml` has been updated./, captured_output)
+        assert_match(/#{expected_output}/, captured_output)
       end
 
       test "'packwerk update-deprecations' with violations succeeds and updates relevant deprecated_references" do
@@ -81,11 +89,18 @@ module Packwerk
 
           deprecated_reference_content_after_update =
             read_deprecated_references.reject { |k, _v| k.match?(timeline_deprecated_reference_path) }
+          expected_output = <<~EOS
+            📦 Packwerk is inspecting 13 files
+            .............
+            📦 Finished in \\d+\\.\\d+ seconds
+
+            No offenses detected 🎉
+            ✅ `deprecated_references.yml` has been updated.
+          EOS
 
           assert_equal(deprecated_reference_content, deprecated_reference_content_after_update,
             "expected no updates to any deprecated references files besides timeline/deprecated_references.yml")
-
-          assert_match(/`deprecated_references.yml` has been updated./, captured_output)
+          assert_match(/#{expected_output}/, captured_output)
         ensure
           File.delete(timeline_deprecated_reference_path) if File.exist?(timeline_deprecated_reference_path)
         end

--- a/test/unit/commands/detect_stale_violations_command_test.rb
+++ b/test/unit/commands/detect_stale_violations_command_test.rb
@@ -2,41 +2,42 @@
 require "test_helper"
 require "rails_test_helper"
 require "packwerk/commands/detect_stale_violations_command"
-require "byebug"
 
 module Packwerk
-  class DetectStaleViolationsCommandTest < Minitest::Test
-    test "#execute_command with the subcommand detect-stale-violations returns status code 1 if stale violations" do
-      stale_violations_message = "There were stale violations found, please run `packwerk update`"
-      offense = stub
-      detect_stale_deprecated_references = stub
-      detect_stale_deprecated_references.stubs(:stale_violations?).returns(true)
+  module Commands
+    class DetectStaleViolationsCommandTest < Minitest::Test
+      test "#run returns status code 1 if stale violations" do
+        stale_violations_message = "There were stale violations found, please run `packwerk update`"
+        offense = stub
+        detect_stale_deprecated_references = stub
+        detect_stale_deprecated_references.stubs(:stale_violations?).returns(true)
 
-      progress_formatter = stub
-      progress_formatter.stubs(:started)
+        progress_formatter = stub
+        progress_formatter.stubs(:started)
 
-      progress_formatter.stubs(:finished)
+        progress_formatter.stubs(:finished)
 
-      run_context = stub
-      run_context.stubs(:process_file).returns(offense)
+        run_context = stub
+        run_context.stubs(:process_file).returns(offense)
 
-      ::Packwerk::FilesForProcessing.stubs(fetch: ["path/of/exile.rb"])
-      ::Packwerk::RunContext.stubs(from_configuration: run_context)
+        FilesForProcessing.stubs(fetch: ["path/of/exile.rb"])
+        RunContext.stubs(from_configuration: run_context)
 
-      detect_stale_violations_command = ::Packwerk::DetectStaleViolationsCommand.new(
-        files: ["path/of/exile.rb"],
-        configuration: Configuration.from_path,
-        run_context: run_context,
-        reference_lister: detect_stale_deprecated_references,
-        progress_formatter: progress_formatter
-      )
+        detect_stale_violations_command = Commands::DetectStaleViolationsCommand.new(
+          files: ["path/of/exile.rb"],
+          configuration: Configuration.from_path,
+          run_context: run_context,
+          reference_lister: detect_stale_deprecated_references,
+          progress_formatter: progress_formatter
+        )
 
-      detect_stale_violations_command.stubs(:mark_progress)
+        detect_stale_violations_command.stubs(:mark_progress)
 
-      no_stale_violations = detect_stale_violations_command.run
+        no_stale_violations = detect_stale_violations_command.run
 
-      assert_equal no_stale_violations.message, stale_violations_message
-      refute no_stale_violations.status
+        assert_equal no_stale_violations.message, stale_violations_message
+        refute no_stale_violations.status
+      end
     end
   end
 end

--- a/test/unit/commands/update_deprecations_command_test.rb
+++ b/test/unit/commands/update_deprecations_command_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require "test_helper"
+require "rails_test_helper"
+require "packwerk/commands/update_deprecations_command"
+
+module Packwerk
+  module Commands
+    class UpdateDeprecationsCommandTest < Minitest::Test
+      test "#run returns success when there are no offenses" do
+        run_context = stub
+        run_context.stubs(:process_file).returns([])
+
+        string_io = StringIO.new
+        style = OutputStyles::Plain
+
+        RunContext.stubs(from_configuration: run_context)
+
+        update_deprecations_command = Commands::UpdateDeprecationsCommand.new(
+          configuration: Configuration.from_path,
+          files: ["path/of/exile.rb"],
+          offenses_formatter: Formatters::OffensesFormatter.new(string_io, style: style),
+          progress_formatter: Formatters::ProgressFormatter.new(string_io, style: style),
+        )
+        result = update_deprecations_command.run
+
+        assert_equal result.message, "✅ `deprecated_references.yml` has been updated."
+        assert result.status
+      end
+
+      test "#run returns exit code 1 when there are offenses" do
+        offense = Offense.new(file: "path/of/exile.rb", message: "something")
+        run_context = stub
+        run_context.stubs(:process_file).returns([offense])
+
+        string_io = StringIO.new
+        style = OutputStyles::Plain
+
+        RunContext.stubs(from_configuration: run_context)
+
+        update_deprecations_command = Commands::UpdateDeprecationsCommand.new(
+          configuration: Configuration.from_path,
+          files: ["path/of/exile.rb"],
+          offenses_formatter: Formatters::OffensesFormatter.new(string_io, style: style),
+          progress_formatter: Formatters::ProgressFormatter.new(string_io, style: style),
+        )
+        result = update_deprecations_command.run
+
+        assert_equal result.message, "✅ `deprecated_references.yml` has been updated."
+        refute result.status
+      end
+    end
+  end
+end

--- a/test/unit/commands/update_deprecations_command_test.rb
+++ b/test/unit/commands/update_deprecations_command_test.rb
@@ -7,7 +7,7 @@ module Packwerk
   module Commands
     class UpdateDeprecationsCommandTest < Minitest::Test
       test "#run returns success when there are no offenses" do
-        run_context = stub
+        run_context = RunContext.new(root_path: ".", load_paths: ".", reference_lister: nil)
         run_context.stubs(:process_file).returns([])
 
         string_io = StringIO.new
@@ -29,7 +29,7 @@ module Packwerk
 
       test "#run returns exit code 1 when there are offenses" do
         offense = Offense.new(file: "path/of/exile.rb", message: "something")
-        run_context = stub
+        run_context = RunContext.new(root_path: ".", load_paths: ".", reference_lister: nil)
         run_context.stubs(:process_file).returns([offense])
 
         string_io = StringIO.new

--- a/test/unit/commands/update_deprecations_command_test.rb
+++ b/test/unit/commands/update_deprecations_command_test.rb
@@ -18,12 +18,15 @@ module Packwerk
         update_deprecations_command = Commands::UpdateDeprecationsCommand.new(
           configuration: Configuration.from_path,
           files: ["path/of/exile.rb"],
-          offenses_formatter: Formatters::OffensesFormatter.new(string_io, style: style),
+          offenses_formatter: Formatters::OffensesFormatter.new(style: style),
           progress_formatter: Formatters::ProgressFormatter.new(string_io, style: style),
         )
         result = update_deprecations_command.run
 
-        assert_equal result.message, "✅ `deprecated_references.yml` has been updated."
+        assert_equal result.message, <<~EOS
+          No offenses detected 🎉
+          ✅ `deprecated_references.yml` has been updated.
+        EOS
         assert result.status
       end
 
@@ -40,12 +43,19 @@ module Packwerk
         update_deprecations_command = Commands::UpdateDeprecationsCommand.new(
           configuration: Configuration.from_path,
           files: ["path/of/exile.rb"],
-          offenses_formatter: Formatters::OffensesFormatter.new(string_io, style: style),
+          offenses_formatter: Formatters::OffensesFormatter.new(style: style),
           progress_formatter: Formatters::ProgressFormatter.new(string_io, style: style),
         )
         result = update_deprecations_command.run
 
-        assert_equal result.message, "✅ `deprecated_references.yml` has been updated."
+        assert_equal result.message, <<~EOS
+          path/of/exile.rb
+          something
+
+          1 offense detected
+
+          ✅ `deprecated_references.yml` has been updated.
+        EOS
         refute result.status
       end
     end

--- a/test/unit/formatters/offenses_formatter_test.rb
+++ b/test/unit/formatters/offenses_formatter_test.rb
@@ -7,28 +7,24 @@ module Packwerk
   module Formatters
     class OffensesFormatterTest < Minitest::Test
       setup do
-        @string_io = StringIO.new
-        @offenses_formatter = OffensesFormatter.new(@string_io)
+        @offenses_formatter = OffensesFormatter.new
       end
 
       test "#show_offenses prints No offenses detected when there are no offenses" do
-        @offenses_formatter.show_offenses([])
-        assert_match "No offenses detected 🎉", @string_io.string
+        assert_match "No offenses detected 🎉", @offenses_formatter.show_offenses([])
       end
 
       test "#show_offenses prints the amount of files when there are offenses" do
         offense = Offense.new(file: "first_file.rb", message: "an offense")
         another_offense = Offense.new(file: "second_file.rb", message: "another offense")
-        @offenses_formatter.show_offenses([offense, another_offense])
-        assert_match "2 offenses detected", @string_io.string
+        assert_match "2 offenses detected", @offenses_formatter.show_offenses([offense, another_offense])
       end
 
       test "#show_offenses prints the files with offenses" do
         offense = Offense.new(file: "first_file.rb", message: "an offense")
         another_offense = Offense.new(file: "second_file.rb", message: "another offense")
-        @offenses_formatter.show_offenses([offense, another_offense])
-        assert_match offense.to_s, @string_io.string
-        assert_match another_offense.to_s, @string_io.string
+        assert_match offense.to_s, @offenses_formatter.show_offenses([offense, another_offense])
+        assert_match another_offense.to_s, @offenses_formatter.show_offenses([offense, another_offense])
       end
     end
   end

--- a/test/unit/formatters/offenses_formatter_test.rb
+++ b/test/unit/formatters/offenses_formatter_test.rb
@@ -1,0 +1,35 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Packwerk
+  module Formatters
+    class OffensesFormatterTest < Minitest::Test
+      setup do
+        @string_io = StringIO.new
+        @offenses_formatter = OffensesFormatter.new(@string_io)
+      end
+
+      test "#show_offenses prints No offenses detected when there are no offenses" do
+        @offenses_formatter.show_offenses([])
+        assert_match "No offenses detected 🎉", @string_io.string
+      end
+
+      test "#show_offenses prints the amount of files when there are offenses" do
+        offense = Offense.new(file: "first_file.rb", message: "an offense")
+        another_offense = Offense.new(file: "second_file.rb", message: "another offense")
+        @offenses_formatter.show_offenses([offense, another_offense])
+        assert_match "2 offenses detected", @string_io.string
+      end
+
+      test "#show_offenses prints the files with offenses" do
+        offense = Offense.new(file: "first_file.rb", message: "an offense")
+        another_offense = Offense.new(file: "second_file.rb", message: "another offense")
+        @offenses_formatter.show_offenses([offense, another_offense])
+        assert_match offense.to_s, @string_io.string
+        assert_match another_offense.to_s, @string_io.string
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What are you trying to accomplish?
Partially solves issue #70 by extracting `update-deprecations` command.

Notes:
- First commit: Extracts `update-deprecations` command logic. I introduced an `OffensesFormatter` so I'm able to print offenses somewhere within the command without the need to pass `out` and `style` (following what was done with `ProgressFormatter`). Otherwise we'll need to return something more complex as part of the `Result` of the command: offenses + execution time + message, which doesn't look good to me.
- Second commit: Adds a namespace to an existing command. I usually like it this way and I saw that for example the `Formatters` was a namespace so I think adding `Commands` would make the code more consistent. I can revert the commit if you don't like it.

## What approach did you choose and why?
The one suggested in the referenced issue above, because it was previously accepted by maintainers and to keep consistency with existing code.

## What should reviewers focus on?
Making sure they are good with the boundaries set and that I didn't break the command by mistake.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [X] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] It is safe to rollback this change.
