### PR TITLE
Fix warnings

### DIFF
--- a/lib/packwerk/commands/detect_stale_violations_command.rb
+++ b/lib/packwerk/commands/detect_stale_violations_command.rb
@@ -1,10 +1,7 @@
 # typed: true
 # frozen_string_literal: true
-require "packwerk/cli"
 require "sorbet-runtime"
 require "benchmark"
-require "packwerk/configuration"
-require "packwerk/formatters/progress_formatter"
 require "packwerk/run_context"
 require "packwerk/detect_stale_deprecated_references"
 require "packwerk/commands/offense_progress_marker"
@@ -27,9 +24,8 @@ module Packwerk
     def run
       @progress_formatter.started(@files)
 
-      all_offenses = T.let([], T.untyped)
       execution_time = Benchmark.realtime do
-        all_offenses = @files.flat_map do |path|
+        @files.flat_map do |path|
           run_context.process_file(file: path).tap do |offenses|
             mark_progress(offenses: offenses, progress_formatter: @progress_formatter)
           end

--- a/lib/packwerk/parsers/factory.rb
+++ b/lib/packwerk/parsers/factory.rb
@@ -31,7 +31,7 @@ module Packwerk
       end
 
       def erb_parser_class
-        @erb_parser_class || Erb
+        @erb_parser_class ||= Erb
       end
 
       def erb_parser_class=(klass)


### PR DESCRIPTION
## What are you trying to accomplish?
Fixing warnings that I found when running the tests. When running `bundle exec rake` I get lot of Ruby warnings (I'm in Ruby 2.6.6). Some aren't fixable because they are in gems (`sorbet-runtime` I'm looking at you), but the following were fixed:
 
unused variable
> /Users/santib/dev/packwerk/lib/packwerk/commands/detect_stale_violations_command.rb:30: warning: assigned but unused variable - all_offenses

circular require
>/Users/santib/dev/packwerk/lib/packwerk/commands/detect_stale_violations_command.rb:3: warning: /Users/santib/dev/packwerk/lib/packwerk/commands/detect_stale_violations_command.rb:3: warning: loading in progress, circular require considered harmful - /Users/santib/dev/packwerk/lib/packwerk/cli.rb
	from /Users/santib/.gem/ruby/2.6.6/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in  `<main>'
	from /Users/santib/.gem/ruby/2.6.6/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in  `select'
	from /Users/santib/.gem/ruby/2.6.6/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:17:in  `block in <main>'
	from /Users/santib/.gem/ruby/2.6.6/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:17:in  `require'
	from /Users/santib/dev/packwerk/test/const_node_inspector_test.rb:4:in  `<top (required)>'
	from /Users/santib/dev/packwerk/test/const_node_inspector_test.rb:4:in  `require'
	from /Users/santib/dev/packwerk/test/test_helper.rb:10:in  `<top (required)>'
	from /Users/santib/dev/packwerk/test/test_helper.rb:10:in  `require'
	from /Users/santib/dev/packwerk/lib/packwerk.rb:13:in  `<top (required)>'
	from /Users/santib/dev/packwerk/lib/packwerk.rb:13:in  `require'
	from /Users/santib/dev/packwerk/lib/packwerk/cli.rb:16:in  `<top (required)>'
	from /Users/santib/dev/packwerk/lib/packwerk/cli.rb:16:in  `require'
	from /Users/santib/dev/packwerk/lib/packwerk/commands/detect_stale_violations_command.rb:3:in  `<top (required)>'
	from /Users/santib/dev/packwerk/lib/packwerk/commands/detect_stale_violations_command.rb:3:in  `require'

instance variable not initialized
>/Users/santib/dev/packwerk/lib/packwerk/parsers/factory.rb:34: warning: instance variable @erb_parser_class not initialized

## What approach did you choose and why?
I tried to fix them in the simplest possible way without affecting behavior.

## What should reviewers focus on?
Specially focus on this change since now it assigns the instance variable with the default value.
![image](https://user-images.githubusercontent.com/6373536/100544123-5cb43680-3232-11eb-8afb-618d9c3a1ac0.png)

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [X] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] It is safe to rollback this change.
