### PR TITLE
Improve coverage for ApplicationValidator

### DIFF
--- a/test/unit/application_validator_test.rb
+++ b/test/unit/application_validator_test.rb
@@ -30,6 +30,79 @@ module Packwerk
       assert result.ok?, result.error_value
     end
 
+    test "check_autoload_path_cache fails on extraneous config load paths" do
+      use_template(:minimal)
+      ApplicationLoadPaths.expects(:extract_relevant_paths).returns([])
+
+      result = validator.check_autoload_path_cache
+
+      refute result.ok?, result.error_value
+      assert_match %r{Extraneous load paths in file:.*components/sales/app/models}m, result.error_value
+    end
+
+    test "check_autoload_path_cache fails on missing config load paths" do
+      use_template(:minimal)
+      ApplicationLoadPaths
+        .expects(:extract_relevant_paths)
+        .returns(["components/sales/app/models", "components/timeline/app/models"])
+
+      result = validator.check_autoload_path_cache
+
+      refute result.ok?, result.error_value
+      assert_match %r{Paths missing from file:.*components/timeline/app/models}m, result.error_value
+    end
+
+    test "check_package_manifest_syntax returns an error for unknown package keys" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("package.yml", { "enforce_correctness" => false })
+
+      result = validator.check_package_manifest_syntax
+
+      refute result.ok?
+      assert_match(/Unknown keys/, result.error_value)
+    end
+
+    test "check_package_manifest_syntax returns an error for invalid enforce_privacy value" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("package.yml", { "enforce_privacy" => "yes, please." })
+
+      result = validator.check_package_manifest_syntax
+
+      refute result.ok?
+      assert_match(/Invalid 'enforce_privacy' option/, result.error_value)
+    end
+
+    test "check_package_manifest_syntax returns an error for invalid enforce_dependencies value" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("package.yml", { "enforce_dependencies" => "components/sales" })
+
+      result = validator.check_package_manifest_syntax
+
+      refute result.ok?
+      assert_match(/Invalid 'enforce_dependencies' option/, result.error_value)
+    end
+
+    test "check_package_manifest_syntax returns an error for invalid public_path value" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("package.yml", { "public_path" => [] })
+
+      result = validator.check_package_manifest_syntax
+
+      refute result.ok?
+      assert_match(/'public_path' option must be a string/, result.error_value)
+    end
+
+    test "check_package_manifest_syntax returns error for invalid dependencies value" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("components/timeline/package.yml", {})
+      merge_into_app_yaml_file("components/sales/package.yml", { "dependencies" => "components/timeline" })
+
+      result = validator.check_package_manifest_syntax
+
+      refute result.ok?
+      assert_match(/Invalid 'dependencies' option/, result.error_value)
+    end
+
     test "check_package_manifests_for_privacy returns an error for unresolvable privatized constants" do
       use_template(:skeleton)
       ConstantResolver.expects(:new).returns(stub("resolver", resolve: nil))
@@ -37,6 +110,10 @@ module Packwerk
       result = validator.check_package_manifests_for_privacy
 
       refute result.ok?, result.error_value
+      assert_match(
+        /::PrivateThing, listed in \"#{to_app_path('components\/timeline\/package.yml')}\", could not be resolved/,
+        result.error_value
+      )
     end
 
     test "check_inflection_file returns error for mismatched inflections.yml file" do
@@ -65,6 +142,50 @@ module Packwerk
       result = validator.check_inflection_file
 
       assert result.ok?, result.error_value
+    end
+
+    test "check_acyclic_graph returns error when package set contains circular dependencies" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("components/sales/package.yml", { "dependencies" => ["components/timeline"] })
+      merge_into_app_yaml_file("components/timeline/package.yml", { "dependencies" => ["components/sales"] })
+
+      result = validator.check_acyclic_graph
+
+      refute result.ok?
+      assert_match(/Expected the package dependency graph to be acyclic/, result.error_value)
+      assert_match %r{components/sales → components/timeline → components/sales}, result.error_value
+    end
+
+    test "check_package_manifest_paths returns error when config only declares partial list of packages" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("components/timeline/package.yml", {})
+      merge_into_app_yaml_file("packwerk.yml", { "package_paths" => ["components/sales", "."] })
+
+      result = validator.check_package_manifest_paths
+
+      refute result.ok?
+      assert_match(/Expected package paths for all package.ymls to be specified/, result.error_value)
+      assert_match %r{manifests:\n\ncomponents/timeline/package.yml$}m, result.error_value
+    end
+
+    test "check_valid_package_dependencies returns error when config contains invalid package dependency" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("components/sales/package.yml", { "dependencies" => ["components/timeline"] })
+
+      result = validator.check_valid_package_dependencies
+
+      refute result.ok?
+      assert_match(/These dependencies do not point to valid packages:/, result.error_value)
+      assert_match %r{\n\ncomponents/sales/package.yml:\n  - components/timeline\n\n$}m, result.error_value
+    end
+
+    test "check_root_package_exists returns error when root directory is missing a package.yml file" do
+      use_template(:minimal)
+      remove_app_entry("package.yml")
+
+      result = validator.check_root_package_exists
+      refute result.ok?
+      assert_match(/A root package does not exist./, result.error_value)
     end
 
     def validator


### PR DESCRIPTION
## What are you trying to accomplish?
Fix for #17.  Now that packwerk supports temporary application fixtures that can be modified for individual tests, we can test more of ApplicationValidator's functionality without resorting to extensive mocking/stubbing.

## What approach did you choose and why?
The ApplicationValidator class invokes much of packwerk's functionality as part of its broad public interface, especially in #validate.  The class is responsible for generating user-facing violations, yet the test suite does not cover many of them.

This PR focuses on exercising those edge conditions resulting in error responses. 

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
