### PR TITLE
Convert more tests to using application fixture helpers

### DIFF
--- a/test/support/application_fixture_helper.rb
+++ b/test/support/application_fixture_helper.rb
@@ -49,6 +49,11 @@ module ApplicationFixtureHelper
     FileUtils.remove_entry(to_app_path(relative_path))
   end
 
+  def open_app_file(*path, mode: "w+")
+    expanded_path = to_app_path(File.join(*path))
+    File.open(expanded_path, mode) { |file| yield file }
+  end
+
   private
 
   def using_template?

--- a/test/unit/dependency_checker_test.rb
+++ b/test/unit/dependency_checker_test.rb
@@ -5,6 +5,8 @@ require "test_helper"
 
 module Packwerk
   class DependencyCheckerTest < Minitest::Test
+    include ApplicationFixtureHelper
+
     class CheckingDeprecatedReferencesStub
       include ReferenceLister
 
@@ -14,15 +16,14 @@ module Packwerk
     end
 
     setup do
-      @temp_dir = Dir.mktmpdir
-      FileUtils.cp_r("test/fixtures/skeleton", @temp_dir)
-      @root_path = File.join(@temp_dir, "skeleton/")
+      setup_application_fixture
+      use_template(:skeleton)
       @destination_package = Package.new(name: "destination_package", config: {})
-      @reference_lister = CheckingDeprecatedReferences.new(@root_path)
+      @reference_lister = CheckingDeprecatedReferences.new(app_dir)
     end
 
     teardown do
-      FileUtils.remove_entry(@temp_dir)
+      teardown_application_fixture
     end
 
     test "recognizes simple cross package reference" do

--- a/test/unit/package_set_test.rb
+++ b/test/unit/package_set_test.rb
@@ -5,8 +5,16 @@ require "test_helper"
 
 module Packwerk
   class PackageSetTest < Minitest::Test
+    include RailsApplicationFixtureHelper
+
     setup do
-      @package_set = PackageSet.load_all_from("test/fixtures/skeleton/")
+      setup_application_fixture
+      use_template(:skeleton)
+      @package_set = PackageSet.load_all_from(app_dir)
+    end
+
+    teardown do
+      teardown_application_fixture
     end
 
     test "#package_from_path returns package instance for a known path" do
@@ -33,38 +41,38 @@ module Packwerk
     end
 
     test ".package_paths supports a path wildcard" do
-      package_paths = PackageSet.package_paths("test/fixtures/skeleton", "**")
+      package_paths = PackageSet.package_paths(".", "**")
 
-      assert_includes(package_paths, Pathname.new("test/fixtures/skeleton/components/sales/package.yml"))
-      assert_includes(package_paths, Pathname.new("test/fixtures/skeleton/package.yml"))
+      assert_includes(package_paths, Pathname.new("components/sales/package.yml"))
+      assert_includes(package_paths, Pathname.new("package.yml"))
     end
 
     test ".package_paths supports a single path as a string" do
-      package_paths = PackageSet.package_paths("test/fixtures/skeleton", "components/sales")
+      package_paths = PackageSet.package_paths(".", "components/sales")
 
-      assert_equal(package_paths, [Pathname.new("test/fixtures/skeleton/components/sales/package.yml")])
+      assert_equal(package_paths, [Pathname.new("components/sales/package.yml")])
     end
 
     test ".package_paths supports many paths as an array" do
-      package_paths = PackageSet.package_paths("test/fixtures/skeleton", ["components/sales", "."])
+      package_paths = PackageSet.package_paths(".", ["components/sales", "."])
 
       assert_equal(
         package_paths,
         [
-          Pathname.new("test/fixtures/skeleton/components/sales/package.yml"),
-          Pathname.new("test/fixtures/skeleton/package.yml"),
+          Pathname.new("components/sales/package.yml"),
+          Pathname.new("package.yml"),
         ]
       )
     end
 
     test ".package_paths excludes paths inside the gem directory" do
-      vendor_package_path = Pathname.new("test/fixtures/skeleton/vendor/cache/gems/example/package.yml")
+      vendor_package_path = Pathname.new("vendor/cache/gems/example/package.yml")
 
-      package_paths = PackageSet.package_paths("test/fixtures/skeleton", "**")
+      package_paths = PackageSet.package_paths(".", "**")
       assert_includes(package_paths, vendor_package_path)
 
       Bundler.expects(:bundle_path).returns(Rails.root.join("vendor/cache/gems"))
-      package_paths = PackageSet.package_paths("test/fixtures/skeleton", "**")
+      package_paths = PackageSet.package_paths(".", "**")
       refute_includes(package_paths, vendor_package_path)
     end
   end

--- a/test/unit/privacy_checker_test.rb
+++ b/test/unit/privacy_checker_test.rb
@@ -5,16 +5,17 @@ require "test_helper"
 
 module Packwerk
   class PrivacyCheckerTest < Minitest::Test
+    include ApplicationFixtureHelper
+
     setup do
-      @temp_dir = Dir.mktmpdir
-      FileUtils.cp_r("test/fixtures/skeleton", @temp_dir)
-      @root_path = File.join(@temp_dir, "skeleton/")
-      @reference_lister = CheckingDeprecatedReferences.new(@root_path)
+      setup_application_fixture
+      use_template(:skeleton)
+      @reference_lister = CheckingDeprecatedReferences.new(app_dir)
       @source_package = Package.new(name: "source_package", config: {})
     end
 
     teardown do
-      FileUtils.remove_entry(@temp_dir)
+      teardown_application_fixture
     end
 
     test "ignores if destination package is not enforcing" do

--- a/test/unit/reference_extractor_test.rb
+++ b/test/unit/reference_extractor_test.rb
@@ -8,19 +8,27 @@ require "packwerk/node"
 
 module Packwerk
   class ReferenceExtractorTest < Minitest::Test
-    def setup
-      @root_path = "test/fixtures/skeleton/"
-      load_paths =
-        Dir.glob(File.join(@root_path, "components/*/{app,test}/*{/concerns,}"))
-          .map { |p| Pathname.new(p).relative_path_from(@root_path).to_s }
+    include ApplicationFixtureHelper
 
-      resolver = ConstantResolver.new(root_path: @root_path, load_paths: load_paths)
-      packages = ::Packwerk::PackageSet.load_all_from(@root_path)
+    def setup
+      setup_application_fixture
+      use_template(:skeleton)
+
+      load_paths =
+        Dir.glob(to_app_path("components/*/{app,test}/*{/concerns,}"))
+          .map { |p| Pathname.new(p).relative_path_from(app_dir).to_s }
+
+      resolver = ConstantResolver.new(root_path: app_dir, load_paths: load_paths)
+      packages = ::Packwerk::PackageSet.load_all_from(app_dir)
 
       @context_provider = ::Packwerk::ConstantDiscovery.new(
         constant_resolver: resolver,
         packages: packages
       )
+    end
+
+    def teardown
+      teardown_application_fixture
     end
 
     test "finds simple cross package references" do
@@ -232,13 +240,13 @@ module Packwerk
 
     def process(code, file_path, constant_name_inspectors = DEFAULT_INSPECTORS)
       root_node = ParserTestHelper.parse(code)
-      file_path = File.join(@root_path, file_path)
+      file_path = to_app_path(file_path)
 
       extractor = ::Packwerk::ReferenceExtractor.new(
         context_provider: @context_provider,
         constant_name_inspectors: constant_name_inspectors,
         root_node: root_node,
-        root_path: @root_path
+        root_path: app_dir
       )
 
       find_references_in_ast(root_node, ancestors: [], extractor: extractor, file_path: file_path)


### PR DESCRIPTION
## What are you trying to accomplish?
Rework some existing test suites to use the new application fixture helpers introduced in #75 and #81.  As mentioned in [this comment thread](https://github.com/Shopify/packwerk/pull/75#issuecomment-734330902), we would like to have consistent test setup/teardown patterns where possible.

## What approach did you choose and why?
Have tests call `use_template(:skeleton)` and read/write into the temporary copy instead of:
- reading from `test/fixtures/skeleton/*` directly;
- creating temporary application files (e.g. yml or rb) into a separate system temp dir.

## What should reviewers focus on?
Although many suites were working just fine with the existing setup/teardown code, I chose to replace those with equivalent aplication fixture setup/teardown, which does not always offer a clear benefit.  I'm doing so for consistency.

Are there any suites that should not be adapted? Are there any suites that **should** be adapted?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] It is safe to rollback this change.
