### PR TITLE
Added functionality to visualize dependencies

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -285,3 +285,13 @@ Above is an example of a constant violation entry in `deprecated_references.yml`
 * `components/merchant/app/public/merchant/generate_order.rb` - path to the file containing the violated constant
 
 Violations exist within the package that makes a violating reference. This means privacy violations of your package can be found listed in `deprecated_references.yml` files in the packages with the reference to a private constant.
+
+## Visualizing dependencies
+You can visualize dependencies specified in package.yml and deprecated_references.yml files by using:
+
+    bin/packwerk visualize-dependencies 
+
+You can also visualize dependencies for specific package and specify output folder for visualization file by using following options:               
+    
+    -p package                       Visualize dependencies for specific package
+    -o out_dir                       Output folder

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -6,6 +6,7 @@ require "sorbet-runtime"
 require "packwerk/application_load_paths"
 require "packwerk/application_validator"
 require "packwerk/configuration"
+require "packwerk/dependencies_visualizer"
 require "packwerk/files_for_processing"
 require "packwerk/formatters/offenses_formatter"
 require "packwerk/formatters/progress_formatter"
@@ -59,6 +60,8 @@ module Packwerk
         update_deprecations(args)
       when "validate"
         validate(args)
+      when "visualize-dependencies"
+        visualize_dependencies(args)
       when nil, "help"
         @err_out.puts(<<~USAGE)
           Usage: #{$PROGRAM_NAME} <subcommand>
@@ -209,6 +212,10 @@ module Packwerk
 
         return result.ok?
       end
+    end
+
+    def visualize_dependencies(args)
+      DependenciesVisualizer.new.visualize(args)
     end
 
     def list_validation_errors(result)

--- a/lib/packwerk/dependencies_visualizer.rb
+++ b/lib/packwerk/dependencies_visualizer.rb
@@ -1,0 +1,63 @@
+# typed: true
+# frozen_string_literal: true
+
+require "optparse"
+
+require "packwerk/visualization_graph"
+
+module Packwerk
+  class DependenciesVisualizer
+    DEPRECATED_REFERENCES_FILE_NAME = "deprecated_references.yml"
+
+    def visualize(args)
+      options = options(args)
+      package_set = Packwerk::PackageSet.load_all_from(".", package_pathspec: options[:package])
+      visualization_graph = DependenciesVisualizer.new.visualization_graph(package_set)
+      visualization_graph.generate_visualization_file(out_dir: options[:out_dir])
+      true
+    end
+
+    def visualization_graph(package_set)
+      Packwerk::VisualizationGraph.new(edges: edges(package_set))
+    end
+
+    private
+
+    def edges(package_set)
+      edges = []
+      package_set.each do |package|
+        package.dependencies.each do |dependency|
+          edges.push({ from: package.name, to: dependency, arrow_color: "blue" })
+        end
+        deprecated_references(package.name).each do |reference|
+          edges.push({ from: package.name, to: reference, arrow_color: "red" })
+        end
+      end
+      edges
+    end
+
+    def deprecated_references(package_name)
+      path = File.join(package_name, DEPRECATED_REFERENCES_FILE_NAME)
+      File.exist?(path) ? YAML.load_file(path).keys : []
+    end
+
+    def options(args)
+      options = {
+        out_dir: nil,
+        package: nil,
+      }
+      OptionParser.new do |opts|
+        opts.banner = "Usage: visualize [options]"
+        opts.on("-p package", "Visualize dependencies for specific package") do |package|
+          options[:package] = package
+        end
+        opts.on("-o out_dir", "Output folder") do |out_dir|
+          options[:out_dir] = out_dir
+        end
+        options[:help] = opts.help
+      end.parse!(args)
+      puts(options[:help])
+      options
+    end
+  end
+end

--- a/lib/packwerk/generators/templates/dependencies_template.html
+++ b/lib/packwerk/generators/templates/dependencies_template.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+    <title>Dependencies visualization</title>
+
+    <script type="text/javascript" src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+
+    <style type="text/css">
+        #dependencies {
+            width: 1280px;
+            height: 720px;
+        }
+    </style>
+</head>
+<body>
+<label for="hideDeprecatedDependencies">Hide deprecated dependencies</label>
+<input id="hideDeprecatedDependencies" type="checkbox" onchange="hideDeprecatedDependencies(this)"/>
+
+<div id="dependencies"></div>
+
+<script type="text/javascript">
+    var data = {};
+    data.nodes = $nodesValues$;
+    data.edges = $edgesValues$;
+    var nodes = new vis.DataSet(data.nodes);
+    var edges = new vis.DataSet(data.edges);
+    var deprecatedDependenciesIds = data.edges.filter(edge => edge.color === 'red').map(edge => edge.id);
+    var container = document.getElementById('dependencies');
+    var networkData = {
+        nodes: nodes,
+        edges: edges
+    };
+    var options = {}
+    var network = new vis.Network(container, networkData, options);
+    network.on("stabilizationIterationsDone", function () {
+        network.setOptions({physics: false});
+    });
+
+    function hideDeprecatedDependencies(checkbox) {
+        deprecatedDependenciesIds.forEach(edgeId => edges.update([{
+            id: edgeId,
+            hidden: checkbox.checked
+        }]))
+    }
+</script>
+</body>
+</html>

--- a/lib/packwerk/visualization_graph.rb
+++ b/lib/packwerk/visualization_graph.rb
@@ -1,0 +1,61 @@
+# typed: true
+# frozen_string_literal: true
+
+require "json"
+
+module Packwerk
+  class VisualizationGraph
+    attr_reader :nodes, :edges
+
+    GENERATED_FILE_DIR = File.join(__dir__, "tmp/packwerk")
+    GENERATED_FILE_NAME = "visualization.html"
+    HTML_TEMPLATE_PATH = File.join(__dir__, "generators/templates/dependencies_template.html")
+
+    private_constant :GENERATED_FILE_DIR
+    private_constant :GENERATED_FILE_NAME
+    private_constant :HTML_TEMPLATE_PATH
+
+    def initialize(edges: [])
+      @edges = edges
+      nodes_set = Set.new
+      edges.each do |edge|
+        nodes_set.add(edge[:from])
+        nodes_set.add(edge[:to])
+      end
+      @nodes = nodes_set.to_a
+      format_data
+    end
+
+    def generate_visualization_file(out_dir:, out_file_name: GENERATED_FILE_NAME, template_path: HTML_TEMPLATE_PATH)
+      out_dir ||= GENERATED_FILE_DIR
+      FileUtils.mkdir_p(out_dir)
+      out_file_path = File.join(out_dir, out_file_name)
+      template = File.read(template_path)
+      filled_template = template
+        .gsub("$nodesValues$", @formatted_nodes.to_json)
+        .gsub("$edgesValues$", @formatted_edges.to_json)
+      File.write(out_file_path, filled_template)
+      puts("#{out_file_path} has been generated")
+    end
+
+    private
+
+    def format_data
+      @formatted_nodes = @nodes.map { |node| format_node(node) }
+      @formatted_edges = @edges.map { |edge| format_edge(edge) }
+    end
+
+    def format_node(node)
+      { 'id': node, 'label': node }
+    end
+
+    def format_edge(edge)
+      { 'from': edge[:from], 'to': edge[:to], 'arrows': {
+        'to': {
+          'enabled': true,
+          'type': "arrow",
+        },
+      }, 'color': edge[:arrow_color].empty? ? "blue" : edge[:arrow_color] }
+    end
+  end
+end

--- a/test/unit/dependencies_visualizer_test.rb
+++ b/test/unit/dependencies_visualizer_test.rb
@@ -1,0 +1,44 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Packwerk
+  class DependenciesVisualizerTest < ActiveSupport::TestCase
+    setup do
+      packages = [
+        stub(name: "app/test/test1", dependencies: ["app/test/test2"]),
+        stub(name: "app/test/test3", dependencies: ["app/test/test2"]),
+      ]
+      @package_set = Packwerk::PackageSet.new(packages)
+    end
+
+    test "returns visualization graph with correct data" do
+      expected_edges = [
+        { from: "app/test/test1", to: "app/test/test2", arrow_color: "blue" },
+        { from: "app/test/test3", to: "app/test/test2", arrow_color: "blue" },
+      ]
+
+      graph = DependenciesVisualizer.new.visualization_graph(@package_set)
+
+      assert_equal %w(app/test/test1 app/test/test2 app/test/test3), graph.nodes.sort
+      assert_equal expected_edges, graph.edges
+    end
+
+    test "generates visualization file with correct data" do
+      expected_template_value = "[{\"id\":\"app/test/test1\",\"label\":\"app/test/test1\"}," \
+        "{\"id\":\"app/test/test2\",\"label\":\"app/test/test2\"},{\"id\":\"app/test/test3\",\"label\":" \
+        "\"app/test/test3\"}] [{\"from\":\"app/test/test1\",\"to\":\"app/test/test2\",\"arrows\":{\"to\":" \
+        "{\"enabled\":true,\"type\":\"arrow\"}},\"color\":\"blue\"},{\"from\":\"app/test/test3\",\"to\":\"" \
+        "app/test/test2\",\"arrows\":{\"to\":{\"enabled\":true,\"type\":\"arrow\"}},\"color\":\"blue\"}]"
+
+      Packwerk::PackageSet.expects(:load_all_from).returns(@package_set)
+      FileUtils.stubs(:mkdir_p).returns(true)
+      File.stubs(:read).returns("$nodesValues$ $edgesValues$")
+
+      File.expects(:write).with(anything, expected_template_value).once
+
+      DependenciesVisualizer.new.visualize({})
+    end
+  end
+end

--- a/test/unit/visualization_graph_test.rb
+++ b/test/unit/visualization_graph_test.rb
@@ -1,0 +1,53 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require "test_helper"
+require "packwerk/visualization_graph"
+
+module Packwerk
+  class VisualizationGraphTest < ActiveSupport::TestCase
+    setup do
+      @edges = [
+        { from: "app/test/test1", to: "app/test/test2", arrow_color: "blue" },
+        { from: "app/test/test3", to: "app/test/test2", arrow_color: "blue" },
+      ]
+    end
+
+    test "calculates nodes correctly" do
+      assert_equal %w(app/test/test1 app/test/test2 app/test/test3), VisualizationGraph.new(edges: @edges).nodes.sort
+    end
+
+    test "calculates edges correctly" do
+      expected_edges = [
+        { from: "app/test/test1", to: "app/test/test2", arrow_color: "blue" },
+        { from: "app/test/test3", to: "app/test/test2", arrow_color: "blue" },
+      ]
+
+      assert_equal expected_edges, VisualizationGraph.new(edges: @edges).edges
+    end
+
+    test "generates visualization file with provided path" do
+      FileUtils.stubs(:mkdir_p).returns(true)
+      File.stubs(:read).returns("$nodesValues$ $edgesValues$")
+      out_dir = "/test/"
+      out_file_name = "file.html"
+
+      File.expects(:write).with(File.join(out_dir, out_file_name), anything).once
+
+      VisualizationGraph.new(edges: @edges).generate_visualization_file(out_dir: out_dir, out_file_name: out_file_name)
+    end
+
+    test "generates correct visualization file" do
+      edges = [{ from: "app/test/test1", to: "app/test/test1", arrow_color: "blue" }]
+      expected_template_value = "[{\"id\":\"app/test/test1\",\"label\":\"app/test/test1\"}] " \
+        "[{\"from\":\"app/test/test1\",\"to\":\"app/test/test1\",\"arrows\":{\"to\":" \
+        "{\"enabled\":true,\"type\":\"arrow\"}},\"color\":\"blue\"}]"
+      FileUtils.stubs(:mkdir_p).returns(true)
+      File.stubs(:read).returns("$nodesValues$ $edgesValues$")
+
+      File.expects(:write).with(anything, expected_template_value).once
+
+      VisualizationGraph.new(edges: edges).generate_visualization_file(out_dir: nil)
+    end
+  end
+end


### PR DESCRIPTION
## What are you trying to accomplish?
Added functionality to visualize dependencies specified in package.yml and deprecated_references.yml files

## What approach did you choose and why?
Iterating through all package.yml(blue arrows) and deprecated_references.yml(red arrows) files and building the VisualizationGraph based on the information about dependencies after which html file is generated using dependencies_template.html and collected data. dependencies_template.html is using vis.js library to display dependencies graph. 

## What should reviewers focus on?


## Type of Change

- [ ] Bugfix
- [X] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] It is safe to rollback this change.

Notes:
To run in development use:

    bundle exec packwerk visualize-dependencies  

You can also visualize dependencies for specific package and specify output folder for visualization file by using following options:               
    
    -p package                       Visualize dependencies for specific package
    -o out_dir                       Output folder

![image](https://user-images.githubusercontent.com/58051206/101075961-b5f0d280-3570-11eb-9ab8-ee9c7f845a5c.png)

