### PR TITLE
give more helpful error message if privatized constant can not be resolved

### DIFF
--- a/lib/packwerk/package_set.rb
+++ b/lib/packwerk/package_set.rb
@@ -60,7 +60,8 @@ module Packwerk
     end
 
     def package_from_path(file_path)
-      @packages.values.find { |package| package.package_path?(file_path) }
+      path_string = file_path.to_s
+      @packages.values.find { |package| package.package_path?(path_string) }
     end
   end
 end

--- a/test/unit/application_validator_test.rb
+++ b/test/unit/application_validator_test.rb
@@ -120,6 +120,25 @@ module Packwerk
       )
     end
 
+    test "check_package_manifests_for_privacy returns an error for privatized constants in other packages" do
+      use_template(:skeleton)
+      context = ConstantResolver::ConstantContext.new("::PrivateThing", "private_thing.rb")
+
+      ConstantResolver.expects(:new).returns(stub("resolver", resolve: context))
+
+      result = validator.check_package_manifests_for_privacy
+
+      refute result.ok?, result.error_value
+      assert_match(
+        %r{'::PrivateThing' is declared as private in the 'components/timeline' package},
+        result.error_value
+      )
+      assert_match(
+        /but appears to be defined\sin the '.' package/,
+        result.error_value
+      )
+    end
+
     test "check_inflection_file returns error for mismatched inflections.yml file" do
       use_template(:skeleton)
       merge_into_app_yaml_file("different_inflections.yml", { "acronym" => %w(TLA WTF LOL) })

--- a/test/unit/application_validator_test.rb
+++ b/test/unit/application_validator_test.rb
@@ -111,11 +111,11 @@ module Packwerk
 
       refute result.ok?, result.error_value
       assert_match(
-        /'::PrivateThing', listed in \"#{to_app_path('components\/timeline\/package.yml')}\", could not be resolved/,
+        /'::PrivateThing', listed in #{to_app_path('components\/timeline\/package.yml')}, could not be resolved/,
         result.error_value
       )
       assert_match(
-        /Add a 'private_thing.rb'/,
+        /Add a private_thing.rb file/,
         result.error_value
       )
     end

--- a/test/unit/application_validator_test.rb
+++ b/test/unit/application_validator_test.rb
@@ -111,7 +111,11 @@ module Packwerk
 
       refute result.ok?, result.error_value
       assert_match(
-        /::PrivateThing, listed in \"#{to_app_path('components\/timeline\/package.yml')}\", could not be resolved/,
+        /'::PrivateThing', listed in \"#{to_app_path('components\/timeline\/package.yml')}\", could not be resolved/,
+        result.error_value
+      )
+      assert_match(
+        /Add a 'private_thing.rb'/,
         result.error_value
       )
     end


### PR DESCRIPTION
## What are you trying to accomplish?

We recently had someone stumbling over the error message that appears when a constant that Packwerk can't resolve is declared as private. This is due to `constant_resolver` not auto-vivifying namespaces.

## What approach did you choose and why?

I added some detail to the error message. And while I was at it, I also did two other things:

- no longer generally require a constant to be defined in its own file. Packwerk should now be able to always correctly resolve something like `Nested::Constant` to `nested.rb` if `nested/constant.rb` doesn't exist, and to `nested/constant.rb` otherwise. This check was a leftover from before we supported custom inflections.
- added a check that makes sure that a constant can only be declared private on the package that defines it.

## What should reviewers focus on?


## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
