### PR TITLE
Convert autoload paths to strings to prevent sorbet error related to Pathname

### DIFF
--- a/lib/packwerk/application_load_paths.rb
+++ b/lib/packwerk/application_load_paths.rb
@@ -28,8 +28,9 @@ module Packwerk
           .select { |railtie| railtie.is_a?(Rails::Engine) }
           .push(Rails.application)
           .flat_map do |engine|
-          (engine.config.autoload_paths + engine.config.eager_load_paths + engine.config.autoload_once_paths).uniq
-        end
+            paths = (engine.config.autoload_paths + engine.config.eager_load_paths + engine.config.autoload_once_paths)
+            paths.map(&:to_s).uniq
+          end
       end
 
       sig do

--- a/test/unit/application_load_paths_test.rb
+++ b/test/unit/application_load_paths_test.rb
@@ -53,5 +53,21 @@ module Packwerk
 
       assert_equal 1, ApplicationLoadPaths.extract_relevant_paths.count
     end
+
+    test ".extract_application_autoload_paths returns unique autoload paths" do
+      path = Pathname.new("/application/app/models")
+      Rails.application.config.expects(:autoload_paths).once.returns([path])
+      Rails.application.config.expects(:eager_load_paths).once.returns([path])
+      Rails.application.config.expects(:autoload_once_paths).once.returns([path])
+
+      assert_equal 1, ApplicationLoadPaths.extract_application_autoload_paths.count
+    end
+
+    test ".extract_application_autoload_paths returns autoload paths as strings" do
+      path = Pathname.new("/application/app/models")
+      Rails.application.config.expects(:autoload_paths).once.returns([path])
+
+      assert_instance_of String, ApplicationLoadPaths.extract_application_autoload_paths.first
+    end
   end
 end


### PR DESCRIPTION
## What are you trying to accomplish?
Fix a Sorbet error that occurs when running `bundle exec packwerk init`,  due to autoload paths potentially bing a pathname. Detailed in the issue here - https://github.com/Shopify/packwerk/issues/90.

Since making this PR I've discovered the Pathname causing the exception in the Repo mentioned in the issue was a custom `eager_load_path` added by the repo. I am going to update the Repo in question to provide the `eager_load_path` as a String, which will fix the issue, but the question I ask of the packwerk team is - Are Pathname's valid `eager_load_paths` that should be handled? If the answer is `yes`, then I think this PR would be useful, otherwise we can close it. I don't have enough context in Rails engines to answer this, but the repo from the issue seems to have been working correctly, perhaps we should handle this.

## What approach did you choose and why?
Map the autoload paths to a String so that any Pathname returned for a Rails engine autoload path is converted. This fixes the Sorbet type check and the Pathname value is included in the autoload paths. 
An alternative would have been to make the type returned from the `extract_application_autoload_paths` method a `T.any(Pathname, String)` but I chose to keep the typing simple rather than make the caller of the method have to handle 2 types.

## What should reviewers focus on?
- Do we need to do this String conversion? Should we handle Pathnames as `eager_load_paths`.
- Is there another approach that could be better?
- Is the testing sufficient?

## Type of Change

- [X] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] It is safe to rollback this change.
