### PR TITLE
Improve types on interface implementations 

### DIFF
--- a/lib/packwerk/cache_deprecated_references.rb
+++ b/lib/packwerk/cache_deprecated_references.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -15,9 +15,15 @@ module Packwerk
     include ReferenceLister
     abstract!
 
+    sig do
+      params(
+        root_path: String,
+        deprecated_references: T::Hash[Packwerk::Package, Packwerk::DeprecatedReferences]
+      ).void
+    end
     def initialize(root_path, deprecated_references = {})
       @root_path = root_path
-      @deprecated_references = T.let(deprecated_references, T::Hash[String, Packwerk::DeprecatedReferences])
+      @deprecated_references = T.let(deprecated_references, T::Hash[Packwerk::Package, Packwerk::DeprecatedReferences])
     end
 
     sig do
@@ -33,6 +39,7 @@ module Packwerk
 
     private
 
+    sig { params(package: Packwerk::Package).returns(Packwerk::DeprecatedReferences) }
     def deprecated_references_for(package)
       @deprecated_references[package] ||= Packwerk::DeprecatedReferences.new(
         package,
@@ -40,6 +47,7 @@ module Packwerk
       )
     end
 
+    sig { params(package: Packwerk::Package).returns(String) }
     def deprecated_references_file_for(package)
       File.join(@root_path, package.name, "deprecated_references.yml")
     end

--- a/lib/packwerk/checker.rb
+++ b/lib/packwerk/checker.rb
@@ -11,6 +11,9 @@ module Packwerk
 
     interface!
 
+    sig { returns(ViolationType).abstract }
+    def violation_type; end
+
     sig { params(reference: Reference, reference_lister: ReferenceLister).returns(T::Boolean).abstract }
     def invalid_reference?(reference, reference_lister); end
 

--- a/lib/packwerk/checking_deprecated_references.rb
+++ b/lib/packwerk/checking_deprecated_references.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -10,9 +10,10 @@ module Packwerk
     extend T::Sig
     include ReferenceLister
 
+    sig { params(root_path: String).void }
     def initialize(root_path)
       @root_path = root_path
-      @deprecated_references = {}
+      @deprecated_references = T.let({}, T::Hash[Packwerk::Package, Packwerk::DeprecatedReferences])
     end
 
     sig do
@@ -26,6 +27,7 @@ module Packwerk
 
     private
 
+    sig { params(source_package: Packwerk::Package).returns(Packwerk::DeprecatedReferences) }
     def deprecated_references_for(source_package)
       @deprecated_references[source_package] ||= Packwerk::DeprecatedReferences.new(
         source_package,
@@ -33,6 +35,7 @@ module Packwerk
       )
     end
 
+    sig { params(package: Packwerk::Package).returns(String) }
     def deprecated_references_file_for(package)
       File.join(@root_path, package.name, "deprecated_references.yml")
     end

--- a/lib/packwerk/const_node_inspector.rb
+++ b/lib/packwerk/const_node_inspector.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "packwerk/constant_name_inspector"
@@ -20,7 +20,7 @@ module Packwerk
       return nil unless root_constant?(parent)
 
       if parent && constant_in_module_or_class_definition?(node, parent: parent)
-        fully_qualify_constant(node, ancestors: ancestors)
+        fully_qualify_constant(ancestors)
       else
         begin
           Node.constant_name(node)
@@ -45,20 +45,11 @@ module Packwerk
       parent_name && parent_name == Node.constant_name(node)
     end
 
-    sig { params(node: AST::Node, ancestors: T::Array[AST::Node]).returns(String) }
-    def fully_qualify_constant(node, ancestors:)
+    sig { params(ancestors: T::Array[AST::Node]).returns(String) }
+    def fully_qualify_constant(ancestors)
       # We're defining a class with this name, in which case the constant is implicitly fully qualified by its
       # enclosing namespace
-      name = Node.parent_module_name(ancestors: ancestors)
-      name ||= generate_qualified_constant(node, ancestors: ancestors)
-      "::" + name
-    end
-
-    sig { params(node: AST::Node, ancestors: T::Array[AST::Node]).returns(String) }
-    def generate_qualified_constant(node, ancestors:)
-      namespace_path = Node.enclosing_namespace_path(node, ancestors: ancestors)
-      constant_name = Node.constant_name(node)
-      namespace_path.push(constant_name).join("::")
+      "::" + Node.parent_module_name(ancestors: ancestors)
     end
   end
 end

--- a/lib/packwerk/dependency_checker.rb
+++ b/lib/packwerk/dependency_checker.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "packwerk/violation_type"
@@ -6,20 +6,28 @@ require "packwerk/checker"
 
 module Packwerk
   class DependencyChecker
+    extend T::Sig
     include Checker
 
+    sig { override.returns(ViolationType) }
     def violation_type
       ViolationType::Dependency
     end
 
+    sig do
+      override
+        .params(reference: Packwerk::Reference, reference_lister: Packwerk::ReferenceLister)
+        .returns(T::Boolean)
+    end
     def invalid_reference?(reference, reference_lister)
-      return unless reference.source_package
-      return unless reference.source_package.enforce_dependencies?
-      return if reference.source_package.dependency?(reference.constant.package)
-      return if reference_lister.listed?(reference, violation_type: violation_type)
+      return false unless reference.source_package
+      return false unless reference.source_package.enforce_dependencies?
+      return false if reference.source_package.dependency?(reference.constant.package)
+      return false if reference_lister.listed?(reference, violation_type: violation_type)
       true
     end
 
+    sig { override.params(reference: Packwerk::Reference).returns(String) }
     def message_for(reference)
       "Dependency violation: #{reference.constant.name} belongs to '#{reference.constant.package}', but " \
         "'#{reference.source_package}' does not specify a dependency on " \

--- a/lib/packwerk/deprecated_references.rb
+++ b/lib/packwerk/deprecated_references.rb
@@ -35,7 +35,7 @@ module Packwerk
       violated_constants_found.fetch("violations", []).include?(violation_type.serialize)
     end
 
-    sig { params(reference: Packwerk::Reference, violation_type: ViolationType).void }
+    sig { params(reference: Packwerk::Reference, violation_type: String).void }
     def add_entries(reference, violation_type)
       package_violations = @new_entries.fetch(reference.constant.package.name, {})
       entries_for_file = package_violations[reference.constant.name] ||= {}

--- a/lib/packwerk/deprecated_references.rb
+++ b/lib/packwerk/deprecated_references.rb
@@ -3,7 +3,6 @@
 
 require "sorbet-runtime"
 require "yaml"
-require "sorbet-runtime"
 
 require "packwerk/reference"
 require "packwerk/reference_lister"
@@ -14,6 +13,7 @@ module Packwerk
     extend T::Sig
     include ReferenceLister
 
+    sig { params(package: Packwerk::Package, filepath: String).void }
     def initialize(package, filepath)
       @package = package
       @filepath = filepath
@@ -35,6 +35,7 @@ module Packwerk
       violated_constants_found.fetch("violations", []).include?(violation_type.serialize)
     end
 
+    sig { params(reference: Packwerk::Reference, violation_type: ViolationType).void }
     def add_entries(reference, violation_type)
       package_violations = @new_entries.fetch(reference.constant.package.name, {})
       entries_for_file = package_violations[reference.constant.name] ||= {}
@@ -66,6 +67,7 @@ module Packwerk
       end
     end
 
+    sig { void }
     def dump
       if @new_entries.empty?
         File.delete(@filepath) if File.exist?(@filepath)
@@ -88,6 +90,7 @@ module Packwerk
 
     private
 
+    sig { returns(Hash) }
     def prepare_entries_for_dump
       @new_entries.each do |package_name, package_violations|
         package_violations.each do |_, entries_for_file|
@@ -100,6 +103,7 @@ module Packwerk
       @new_entries = @new_entries.sort.to_h
     end
 
+    sig { returns(Hash) }
     def deprecated_references
       @deprecated_references ||= if File.exist?(@filepath)
         YAML.load_file(@filepath) || {}

--- a/lib/packwerk/node.rb
+++ b/lib/packwerk/node.rb
@@ -9,6 +9,8 @@ module Packwerk
     Location = Struct.new(:line, :column)
 
     class << self
+      extend T::Sig
+
       def class_or_module_name(class_or_module_node)
         case type_of(class_or_module_node)
         when CLASS, MODULE
@@ -178,6 +180,7 @@ module Packwerk
         class_node.children[1]
       end
 
+      sig { params(ancestors: T::Array[AST::Node]).returns(String) }
       def parent_module_name(ancestors:)
         definitions = ancestors
           .select { |n| [CLASS, MODULE, CONSTANT_ASSIGNMENT, BLOCK].include?(type_of(n)) }

--- a/lib/packwerk/privacy_checker.rb
+++ b/lib/packwerk/privacy_checker.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "packwerk/violation_type"
@@ -6,26 +6,34 @@ require "packwerk/checker"
 
 module Packwerk
   class PrivacyChecker
+    extend T::Sig
     include Checker
 
+    sig { override.returns(Packwerk::ViolationType) }
     def violation_type
       ViolationType::Privacy
     end
 
+    sig do
+      override
+        .params(reference: Packwerk::Reference, reference_lister: Packwerk::ReferenceLister)
+        .returns(T::Boolean)
+    end
     def invalid_reference?(reference, reference_lister)
-      return if reference.constant.public?
+      return false if reference.constant.public?
 
       privacy_option = reference.constant.package.enforce_privacy
-      return if enforcement_disabled?(privacy_option)
+      return false if enforcement_disabled?(privacy_option)
 
-      return unless privacy_option == true ||
+      return false unless privacy_option == true ||
         explicitly_private_constant?(reference.constant, explicitly_private_constants: privacy_option)
 
-      return if reference_lister.listed?(reference, violation_type: violation_type)
+      return false if reference_lister.listed?(reference, violation_type: violation_type)
 
       true
     end
 
+    sig { override.params(reference: Packwerk::Reference).returns(String) }
     def message_for(reference)
       source_desc = reference.source_package ? "'#{reference.source_package}'" : "here"
       "Privacy violation: '#{reference.constant.name}' is private to '#{reference.constant.package}' but " \
@@ -35,12 +43,22 @@ module Packwerk
 
     private
 
+    sig do
+      params(
+        constant: ConstantDiscovery::ConstantContext,
+        explicitly_private_constants: T::Array[String]
+      ).returns(T::Boolean)
+    end
     def explicitly_private_constant?(constant, explicitly_private_constants:)
       explicitly_private_constants.include?(constant.name) ||
         # nested constants
         explicitly_private_constants.any? { |epc| constant.name.start_with?(epc + "::") }
     end
 
+    sig do
+      params(privacy_option: T.nilable(T.any(T::Boolean, T::Array[String])))
+        .returns(T::Boolean)
+    end
     def enforcement_disabled?(privacy_option)
       [false, nil].include?(privacy_option)
     end

--- a/test/unit/checking_deprecated_references_test.rb
+++ b/test/unit/checking_deprecated_references_test.rb
@@ -11,18 +11,21 @@ module Packwerk
     end
 
     test "#listed? returns true if constant is listed in file" do
-      deprecated_references = stub(listed?: true)
-      Packwerk::DeprecatedReferences
-        .stubs(:new)
-        .with(@package, "./buyer/deprecated_references.yml")
-        .returns(deprecated_references)
-
       reference =
         Reference.new(
           @package,
           "some/path.rb",
           ConstantDiscovery::ConstantContext.new(nil, nil, nil, false)
         )
+      deprecated_references = Packwerk::DeprecatedReferences.new(@package, ".")
+      deprecated_references
+        .stubs(:listed?)
+        .with(reference, violation_type: Packwerk::ViolationType::Dependency)
+        .returns(true)
+      Packwerk::DeprecatedReferences
+        .stubs(:new)
+        .with(@package, "./buyer/deprecated_references.yml")
+        .returns(deprecated_references)
 
       assert @checking_deprecated_references.listed?(reference, violation_type: ViolationType::Dependency)
     end


### PR DESCRIPTION
## What are you trying to accomplish?

To improve the types on implementations of `Packwerk::Checker`, `Packwerk::ConstantNameInspector` and `Packwerk::ReferenceLister` so that where possible the strictness level can be upped to `strict` to enable the interfaces these classes implement be better enforced by Sorbet.

## What approach did you choose and why?

- Added types on the implementations of abstract methods within mentioned classes whilst leaving the sigil as `typed: true`
- Later upgrading to `typed: strict` via the addition of types on all other methods

## What should reviewers focus on?

- I note this is the first usage of `T.type_alias` in the project, are we happy with the usage of this or has it been actively avoided?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
