### PR TITLE
Update packwerk update-deprecations cmd

### DIFF
--- a/lib/packwerk/commands/detect_stale_violations_command.rb
+++ b/lib/packwerk/commands/detect_stale_violations_command.rb
@@ -49,7 +49,7 @@ module Packwerk
       sig { returns(Result) }
       def calculate_result
         result_status = !reference_lister.stale_violations?
-        message = "There were stale violations found, please run `packwerk update`"
+        message = "There were stale violations found, please run `packwerk update-deprecations`"
         if result_status
           message = "No stale violations detected"
         end

--- a/test/unit/commands/detect_stale_violations_command_test.rb
+++ b/test/unit/commands/detect_stale_violations_command_test.rb
@@ -7,7 +7,7 @@ module Packwerk
   module Commands
     class DetectStaleViolationsCommandTest < Minitest::Test
       test "#run returns status code 1 if stale violations" do
-        stale_violations_message = "There were stale violations found, please run `packwerk update`"
+        stale_violations_message = "There were stale violations found, please run `packwerk update-deprecations`"
         offense = stub
         detect_stale_deprecated_references = stub
         detect_stale_deprecated_references.stubs(:stale_violations?).returns(true)


### PR DESCRIPTION
## What are you trying to accomplish?

> There were stale violations found, please run `packwerk update`

```
$ packwerk update
`packwerk update` is deprecated in favor of `packwerk update-deprecations`.
```

## What approach did you choose and why?

Updating error message

## What should reviewers focus on?


## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
