### PR TITLE
bump packwerk version for new release v1.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GIT
 PATH
   remote: .
   specs:
-    packwerk (1.1.1)
+    packwerk (1.1.2)
       activesupport (>= 5.2)
       ast
       better_html

--- a/lib/packwerk/version.rb
+++ b/lib/packwerk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Packwerk
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end


### PR DESCRIPTION
## What are you trying to accomplish?
Bump packwerk to v1.1.2 - See [Draft Release](https://github.com/Shopify/packwerk/releases) for the list of relevant changes

## What approach did you choose and why?
Tested on core using `dev packages check`, `dev packages update` (packwerk 1.1.1 and 1.1.2 report the same deprecated references), and `bin/spring packwerk validate`.
Tested on payment-service using `packwerk check`, `packwerk update` and `bin/packwerk validate`.

## What should reviewers focus on?
Are the release notes ok?  Running `bundle update` updates many gems in Gemfile.lock, so I did not do that. I manually incremented the version for `packwerk` instead, as it appears we've done in previous releases.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
