### PR TITLE
add violation_count to deprecated_references.yml

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -275,6 +275,7 @@ components/merchant:
     - dependency
     files:
     - components/merchant/app/public/merchant/generate_order.rb
+    violation_count: 3
 ```
 
 Above is an example of a constant violation entry in `deprecated_references.yml`.
@@ -283,5 +284,6 @@ Above is an example of a constant violation entry in `deprecated_references.yml`
 * `::Checkouts::Core::CheckoutId` - violated constant in question
 * `dependency` - type of violation, either dependency or privacy
 * `components/merchant/app/public/merchant/generate_order.rb` - path to the file containing the violated constant
+* `violation_count` - the number of distinct reference violations for this constant, accounting for the fact a single file can have multiple violations for the same constant
 
 Violations exist within the package that makes a violating reference. This means privacy violations of your package can be found listed in `deprecated_references.yml` files in the packages with the reference to a private constant.

--- a/lib/packwerk/deprecated_references.rb
+++ b/lib/packwerk/deprecated_references.rb
@@ -95,6 +95,7 @@ module Packwerk
       @new_entries.each do |package_name, package_violations|
         package_violations.each do |_, entries_for_file|
           entries_for_file["violations"].sort!.uniq!
+          entries_for_file["violation_count"] = entries_for_file["files"].count
           entries_for_file["files"].sort!.uniq!
         end
         @new_entries[package_name] = package_violations.sort.to_h

--- a/test/unit/deprecated_references_test.rb
+++ b/test/unit/deprecated_references_test.rb
@@ -173,7 +173,11 @@ module Packwerk
     test "#add_entries and #dump adds constant violation to file in the appropriate format" do
       expected_output = {
         "buyers" => {
-          "::Checkout::Wallet" => { "violations" => ["privacy"], "files" => ["some/violated/path.rb"] },
+          "::Checkout::Wallet" => {
+            "violations" => ["privacy"],
+            "files" => ["some/violated/path.rb"],
+            "violation_count" => 1,
+          },
         },
       }
 
@@ -203,11 +207,23 @@ module Packwerk
     test "#dump dumps a deprecated references file with sorted and unique package, constant and file violations" do
       expected_output = {
         "a_package" => {
-          "::Checkout::Wallet" => { "violations" => ["privacy"], "files" => ["some/violated/path.rb"] },
+          "::Checkout::Wallet" => {
+            "violations" => ["privacy"],
+            "files" => ["some/violated/path.rb"],
+            "violation_count" => 1,
+          },
         },
         "another_package" => {
-          "::Abc::Constant" => { "violations" => ["dependency"], "files" => ["a/b/c.rb", "this/should/come/last.rb"] },
-          "::Checkout::Wallet" => { "violations" => ["dependency", "privacy"], "files" => ["some/violated/path.rb"] },
+          "::Abc::Constant" => {
+            "violations" => ["dependency"],
+            "files" => ["a/b/c.rb", "this/should/come/last.rb"],
+            "violation_count" => 3,
+          },
+          "::Checkout::Wallet" => {
+            "violations" => ["dependency", "privacy"],
+            "files" => ["some/violated/path.rb"],
+            "violation_count" => 2,
+          },
         },
       }
 


### PR DESCRIPTION
## What are you trying to accomplish?

In order to improve our metrics around reference violations, we would like to be able to view the actual violation count for each constant, rather than just the number of files that contain violations. A single file could conceivably contain a hundred reference violations, but that impossible to determine without parsing the file either via script or visually.

Adding a violation count per constant is a relatively unobtrusive way to get this count that should not interfere or overly complicate the core functions of packwerk. With this number included in `deprecated_references.yml`, the granularity of the monitoring for referential integrity of each package is improved and progress toward detangling dependencies can be better tracked.

## What approach did you choose and why?

I chose to just add another key/value pair to the package violations hash. Now, in addition to `"files"` and `"violations"`, we also have `"violation_count"`. This is an additive change to the existing structure of the `deprecated_dependencies.yml` file that is unlikely to affect consumers' expectations for the file's structure.

On [another branch](https://github.com/Shopify/packwerk/compare/main...mclark:ref-violation-counts-per-file) I also wrote a _per file_ violation count which **does** alter the structure of the `deprecated_dependencies.yml` but I thought I'd hold off on that for now to see if we truly need it at GitHub or if there is interest elsewhere in the community.

## What should reviewers focus on?

There's just one line of production code change, so I guess just focus on ensuring this is an accurate reflection of the violation count for the constant. No new tests were added but existing tests have been adapted in a way I believe sufficiently covers the change. Maybe there are other scenarios that should be tested which I did not consider?

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
