### PR TITLE
Clarify development status note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Packwerk [![Build Status](https://github.com/Shopify/packwerk/workflows/CI/badge.svg)](https://github.com/Shopify/packwerk/actions?query=workflow%3ACI)
 
-## NOTE: Packwerk is considered to be feature-complete for Shopify's uses. We is currently accepting bug fixes only, and it is not being actively developed. Please fork this project if you are interested in adding new features.
+## NOTE: Packwerk is considered to be feature-complete for Shopify's uses. We are currently accepting bug fixes only, and it is not being actively developed. Please fork this project if you are interested in adding new features.
 
 > "I know who you are and because of that I know what you do."  
 > This knowledge is a dependency that raises the cost of change.  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Packwerk [![Build Status](https://github.com/Shopify/packwerk/workflows/CI/badge.svg)](https://github.com/Shopify/packwerk/actions?query=workflow%3ACI)
 
-## NOTE: Packwerk is currently accepting bug fixes only, and is not being actively developed. Please fork this project if you are interested in adding new features.
+## NOTE: Packwerk is considered to be feature-complete for Shopify's uses. We is currently accepting bug fixes only, and it is not being actively developed. Please fork this project if you are interested in adding new features.
 
 > "I know who you are and because of that I know what you do."  
 > This knowledge is a dependency that raises the cost of change.  


### PR DESCRIPTION
A point was raised in the [Ruby Modularity Slack](https://rubymod.slack.com/) that the current message could be interpreted as the project no longer being used at Shopify. I've updated the text to add some context from #102.

cc @gmcgibbon