### PR TITLE
Require fileutils fix uninitialized constant error

### DIFF
--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -4,6 +4,7 @@
 require "sorbet-runtime"
 require "active_support"
 require "constant_resolver"
+require "fileutils"
 
 require "packwerk/offense"
 


### PR DESCRIPTION

## What are you trying to accomplish?

Resolve an error in #106 observed when running `bundle exec packwerk init`

## What approach did you choose and why?

FileUtils doesn't appear to be required explicitly by packwerk. This generates the error. Adding the require makes it go away.

## What should reviewers focus on?

I'm not sure how/why this worked without the require. This might be good to verify/test in isolation inside of a docker container. Examples provided below.

## Type of Change

- [X] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Closes #106

Tested with a local app by using `gem 'packwerk', path: '../packwerk'`
and `bundle exec packwerk init`. This appears to resolve the bug

This generates the NameError (current behavior)
```shell
> docker run -it --rm ruby:3.0.0 /bin/bash
root@foo: gem install rails && \
  rails new --api foo && \
  cd foo && \
  bundle add packwerk && \
  bundle && \
  bundle exec packwerk init
```

This shows the fix
```shell
>  docker run -it --rm ruby:3.0.0 /bin/bash
root@foo: gem install rails && \
  rails new --api foo && \
  cd foo && \
  bundle add packwerk --git 'https://github.com/jaydorsey/packwerk' --branch 'jaydorsey/require_fileutils' && \
  bundle && \
  bundle exec packwerk init
```

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] It is safe to rollback this change.
