### PR TITLE
require FileUtils explicitly to prevent NameError when running generator

### DIFF
--- a/lib/packwerk/generators/application_validation.rb
+++ b/lib/packwerk/generators/application_validation.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "fileutils"
+
 module Packwerk
   module Generators
     class ApplicationValidation


### PR DESCRIPTION
## What are you trying to accomplish?

I was setting up packwerk and got:

```
/Users/dorianmariefr/.rvm/gems/ruby-3.0.0/gems/packwerk-1.1.2/lib/packwerk/generators/application_validation.rb:31:in `generate_packwerk_validate_script': uninitialized constant Packwerk::Generators::ApplicationValidation::FileUtils (NameError)
```

## What approach did you choose and why?

I require the `fileutils` library explictly because it was probably already loaded for other users of the gem.

## What should reviewers focus on?

Why was it working for other people and not me?

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
