### PR TITLE
use a mimemagic version that wasn't pulled

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)


### PR DESCRIPTION
## What are you trying to accomplish?
Builds are currently broken on master because the mimemagic version we're using has been pulled.

## What approach did you choose and why?
Update mimemagic - this is the simplest possible fix.

