### PR TITLE
Introduce ReferenceOffense

### DIFF
--- a/lib/packwerk/checker.rb
+++ b/lib/packwerk/checker.rb
@@ -16,8 +16,5 @@ module Packwerk
 
     sig { params(reference: Reference, reference_lister: ReferenceLister).returns(T::Boolean).abstract }
     def invalid_reference?(reference, reference_lister); end
-
-    sig { params(reference: Reference).returns(String).abstract }
-    def message_for(reference); end
   end
 end

--- a/lib/packwerk/dependency_checker.rb
+++ b/lib/packwerk/dependency_checker.rb
@@ -26,14 +26,5 @@ module Packwerk
       return false if reference_lister.listed?(reference, violation_type: violation_type)
       true
     end
-
-    sig { override.params(reference: Packwerk::Reference).returns(String) }
-    def message_for(reference)
-      "Dependency violation: #{reference.constant.name} belongs to '#{reference.constant.package}', but " \
-        "'#{reference.source_package}' does not specify a dependency on " \
-        "'#{reference.constant.package}'.\n" \
-        "Are we missing an abstraction?\n" \
-        "Is the code making the reference, and the referenced constant, in the right packages?\n"
-    end
   end
 end

--- a/lib/packwerk/privacy_checker.rb
+++ b/lib/packwerk/privacy_checker.rb
@@ -33,14 +33,6 @@ module Packwerk
       true
     end
 
-    sig { override.params(reference: Packwerk::Reference).returns(String) }
-    def message_for(reference)
-      source_desc = reference.source_package ? "'#{reference.source_package}'" : "here"
-      "Privacy violation: '#{reference.constant.name}' is private to '#{reference.constant.package}' but " \
-        "referenced from #{source_desc}.\n" \
-        "Is there a public entrypoint in '#{reference.constant.package.public_path}' that you can use instead?"
-    end
-
     private
 
     sig do

--- a/lib/packwerk/reference_offense.rb
+++ b/lib/packwerk/reference_offense.rb
@@ -1,0 +1,52 @@
+# typed: true
+# frozen_string_literal: true
+
+require "packwerk/offense"
+require "sorbet-runtime"
+
+module Packwerk
+  class ReferenceOffense < Offense
+    extend T::Sig
+    extend T::Helpers
+
+    attr_reader :reference, :violation_type
+
+    sig do
+      params(
+        reference: Packwerk::Reference,
+        violation_type: Packwerk::ViolationType,
+        location: T.nilable(Node::Location)
+      )
+        .void
+    end
+    def initialize(reference:, violation_type:, location: nil)
+      super(file: reference.relative_path, message: build_message(reference, violation_type), location: location)
+      @reference = reference
+      @violation_type = violation_type
+    end
+
+    private
+
+    def build_message(reference, violation_type)
+      violation_message = case violation_type
+      when ViolationType::Privacy
+        source_desc = reference.source_package ? "'#{reference.source_package}'" : "here"
+        "Privacy violation: '#{reference.constant.name}' is private to '#{reference.constant.package}' but " \
+        "referenced from #{source_desc}.\n" \
+        "Is there a public entrypoint in '#{reference.constant.package.public_path}' that you can use instead?"
+      when ViolationType::Dependency
+        "Dependency violation: #{reference.constant.name} belongs to '#{reference.constant.package}', but " \
+        "'#{reference.source_package}' does not specify a dependency on " \
+        "'#{reference.constant.package}'.\n" \
+        "Are we missing an abstraction?\n" \
+        "Is the code making the reference, and the referenced constant, in the right packages?\n"
+      end
+
+      <<~EOS
+        #{violation_message}
+        Inference details: this is a reference to #{reference.constant.name} which seems to be defined in #{reference.constant.location}.
+        To receive help interpreting or resolving this error message, see: https://github.com/Shopify/packwerk/blob/main/TROUBLESHOOT.md#Troubleshooting-violations
+      EOS
+    end
+  end
+end

--- a/test/unit/dependency_checker_test.rb
+++ b/test/unit/dependency_checker_test.rb
@@ -107,34 +107,6 @@ module Packwerk
       refute checker.invalid_reference?(reference, @reference_lister)
     end
 
-    test "renders a sensible error message" do
-      source_package = Package.new(
-        name: "components/sales",
-        config: { "enforce_dependencies" => true, "dependencies" => ["destination_package"] }
-      )
-      checker = dependency_checker
-
-      reference =
-        Reference.new(
-          source_package,
-          "some/path.rb",
-          ConstantDiscovery::ConstantContext.new(
-            "::SomeName",
-            "some/location.rb",
-            @destination_package,
-            false
-          )
-        )
-
-      expected = <<~EXPECTED
-        Dependency violation: ::SomeName belongs to 'destination_package', but 'components/sales' does not specify a dependency on 'destination_package'.
-        Are we missing an abstraction?
-        Is the code making the reference, and the referenced constant, in the right packages?
-      EXPECTED
-
-      assert_equal(expected, checker.message_for(reference))
-    end
-
     private
 
     def dependency_checker

--- a/test/unit/privacy_checker_test.rb
+++ b/test/unit/privacy_checker_test.rb
@@ -175,29 +175,6 @@ module Packwerk
       checker.invalid_reference?(reference, @reference_lister)
     end
 
-    test "generates nice message for violation" do
-      destination_package = Package.new(name: "destination_package", config: { "enforce_privacy" => true })
-      checker = privacy_checker
-
-      reference =
-        Reference.new(
-          @source_package,
-          "some/path.rb",
-          ConstantDiscovery::ConstantContext.new(
-            "::SomeName",
-            "some/location.rb",
-            destination_package,
-            false
-          )
-        )
-
-      assert_match(
-        "Privacy violation: '::SomeName' is private to 'destination_package' but referenced from " \
-          "'source_package'.",
-        checker.message_for(reference)
-      )
-    end
-
     private
 
     def privacy_checker

--- a/test/unit/reference_offense_test.rb
+++ b/test/unit/reference_offense_test.rb
@@ -1,0 +1,54 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Packwerk
+  class ReferenceOffenseTest < Minitest::Test
+    setup do
+      destination_package = Package.new(name: "destination_package", config: { "enforce_privacy" => true })
+      source_package = Package.new(name: "source_package", config: nil)
+
+      @reference =
+        Reference.new(
+          source_package,
+          "some/path.rb",
+          ConstantDiscovery::ConstantContext.new(
+            "::SomeName",
+            "some/location.rb",
+            destination_package,
+            false
+          )
+        )
+    end
+
+    test "has its file attribute set to the relative path of the reference" do
+      offense = ReferenceOffense.new(reference: @reference, violation_type: ViolationType::Privacy)
+      assert_equal(@reference.relative_path, offense.file)
+    end
+
+    test "generates a sensible message for privacy violations" do
+      offense = ReferenceOffense.new(reference: @reference, violation_type: ViolationType::Privacy)
+
+      assert_match(
+        "Privacy violation: '::SomeName' is private to 'destination_package' but referenced from " \
+          "'source_package'.", offense.message
+      )
+    end
+
+    test "generates a sensible message for dependency violations" do
+      offense = ReferenceOffense.new(reference: @reference, violation_type: ViolationType::Dependency)
+
+      expected = <<~EXPECTED
+        Dependency violation: ::SomeName belongs to 'destination_package', but 'source_package' does not specify a dependency on 'destination_package'.
+        Are we missing an abstraction?
+        Is the code making the reference, and the referenced constant, in the right packages?
+
+        Inference details: this is a reference to ::SomeName which seems to be defined in some/location.rb.
+        To receive help interpreting or resolving this error message, see: https://github.com/Shopify/packwerk/blob/main/TROUBLESHOOT.md#Troubleshooting-violations
+      EXPECTED
+
+      assert_equal(expected, offense.message)
+    end
+  end
+end


### PR DESCRIPTION
## What are you trying to accomplish?
https://github.com/Shopify/packwerk/pull/109 introduces parallelism for packwerk by default for `update-deprecations` and `detect-stale-violations`. Toward that goal we needed to refactor some of the underlying logic of Packwerk's parsing logic. This PR is the first of those refactoring PRs which introduces the `Packwerk::ReferenceOffense` class. This new offense is a subclass of `Packwerk::Offense` which contains a reference to the originating `Packwerk::Reference` instance and the `Packwerk::ViolationType` of the checker that failed.

## What approach did you choose and why?

Having this information in the `ReferenceOffense` itself allows us to filter these objects as the given command requires _after_ the files have all been parsed for constant references and allows us to eventually remove the `Packwerk::RefLister` instance that is passed along and mutated during the parse.

## What should reviewers focus on?

I don't like `case` statements and I'm not a fan of the one in `Packwerk::ReferenceOffense#build_message`. However, the alternative I considered, making `ViolationType` subclasses for each type, seemed a bit over the top and would explode the diff for this PR a bit much. I thought this could probably revisited in the future if we like and is not too bad yet. If we introduce a third `ViolationType` subclass I may change my tune.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
