### PR TITLE
Clean up service manifest

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,3 @@
-# https://services.shopify.io/services/packwerk/production
-org_line: Kernel
-owners: Shopify/core-stewardship
 classification: library
 slack_channels:
-  - core-stewardship
+- core-stewardship


### PR DESCRIPTION
The concept of ownership at Shopify has recently changed. Services need to have owners configured through the ServicesDB UI as opposed to through the service manifest. As such, this pull request removes the `owners` key, as well as any other deprecated keys related to ownership.

Please go to ServicesDB and verify that the ownership for your services that use this repository were correctly migrated. If they were not, refer to the documentation (https://service-docs.docs.shopify.io/ownership/) on how to find the correct owner for your service.

Previously, CloudPortal access was also tied to the concept of ownership (if you were listed as an owner, you were granted CloudPortal) access by default. This is still the case, however it means that you must be a part of the Vault teams that are listed as owners of the service. If you would like to grant additional access to other users besides those listed as owners in ServicesDB, you may add the `additional_cloudportal_access` key to your service manifest, which should be a list of GitHub team and user handles. Those people will then have access to CloudPortal.

For more information, here are a couple of links that you may find helpful:

* The concept of ownership at Shopify: https://service-docs.docs.shopify.io/ownership/
* How to configure your service manifest: `https://service-docs.docs.shopify.io/getting_started/configuring_a_service.html`

Note that the `service.yml` changes in this pull request were generated programmatically, so it may have accidentally deleted comments or aliases. Feel free to touch up the pull request to match whatever style you'd like before merging.

Adding [ci skip] here because this won't impact application code.
