### PR TITLE
Add support to CLI for specifying a custom offenses formatter

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -10,15 +10,23 @@ module Packwerk
         configuration: T.nilable(Configuration),
         out: T.any(StringIO, IO),
         err_out: T.any(StringIO, IO),
-        style: Packwerk::OutputStyle
+        style: Packwerk::OutputStyle,
+        offenses_formatter: T.nilable(Packwerk::OffensesFormatter)
       ).void
     end
-    def initialize(configuration: nil, out: $stdout, err_out: $stderr, style: OutputStyles::Plain.new)
+    def initialize(
+      configuration: nil,
+      out: $stdout,
+      err_out: $stderr,
+      style: OutputStyles::Plain.new,
+      offenses_formatter: nil
+    )
       @out = out
       @err_out = err_out
       @style = style
       @configuration = configuration || Configuration.from_path
       @progress_formatter = Formatters::ProgressFormatter.new(@out, style: style)
+      @offenses_formatter = offenses_formatter
     end
 
     sig { params(args: T::Array[String]).returns(T.noreturn) }

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -26,7 +26,7 @@ module Packwerk
       @style = style
       @configuration = configuration || Configuration.from_path
       @progress_formatter = Formatters::ProgressFormatter.new(@out, style: style)
-      @offenses_formatter = offenses_formatter
+      @offenses_formatter = offenses_formatter || Formatters::OffensesFormatter.new(style: @style)
     end
 
     sig { params(args: T::Array[String]).returns(T.noreturn) }
@@ -187,10 +187,6 @@ module Packwerk
         progress_formatter: @progress_formatter,
         offenses_formatter: offenses_formatter
       )
-    end
-
-    def offenses_formatter
-      @offenses_formatter ||= Formatters::OffensesFormatter.new(style: @style)
     end
   end
 end

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -185,7 +185,7 @@ module Packwerk
         files: fetch_files_to_process(paths),
         configuration: @configuration,
         progress_formatter: @progress_formatter,
-        offenses_formatter: offenses_formatter
+        offenses_formatter: @offenses_formatter
       )
     end
   end

--- a/lib/packwerk/formatters/offenses_formatter.rb
+++ b/lib/packwerk/formatters/offenses_formatter.rb
@@ -4,6 +4,8 @@
 module Packwerk
   module Formatters
     class OffensesFormatter
+      include Packwerk::OffensesFormatter
+
       extend T::Sig
 
       sig { params(style: OutputStyle).void }
@@ -11,7 +13,7 @@ module Packwerk
         @style = style
       end
 
-      sig { params(offenses: T::Array[T.nilable(Offense)]).returns(String) }
+      sig { override.params(offenses: T::Array[T.nilable(Offense)]).returns(String) }
       def show_offenses(offenses)
         return "No offenses detected 🎉" if offenses.empty?
 

--- a/lib/packwerk/offenses_formatter.rb
+++ b/lib/packwerk/offenses_formatter.rb
@@ -1,0 +1,15 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Packwerk
+  module OffensesFormatter
+    extend T::Sig
+    extend T::Helpers
+
+    interface!
+
+    sig { abstract.params(offenses: T::Array[T.nilable(Offense)]).returns(String) }
+    def show_offenses(offenses)
+    end
+  end
+end

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -150,5 +150,44 @@ module Packwerk
       expected_output = "'beep boop' is not a packwerk command. See `packwerk help`.\n"
       assert_equal expected_output, @err_out.string
     end
+
+    test "#execute_command using a custom offenses class" do
+      offenses_formatter = Class.new do
+        include Packwerk::OffensesFormatter
+
+        def show_offenses(offenses)
+          ["hi i am a custom offense formatter", *offenses].join("\n")
+        end
+      end
+      file_path = "path/of/exile.rb"
+      violation_message = "This is a violation of code health."
+      offense = Offense.new(file: file_path, message: violation_message)
+
+      configuration = Configuration.new
+      run_context = RunContext.from_configuration(
+        configuration,
+        reference_lister: CheckingDeprecatedReferences.new(configuration.root_path)
+      )
+      run_context.stubs(:process_file).at_least_once.returns([offense])
+
+      string_io = StringIO.new
+
+      cli = ::Packwerk::Cli.new(
+        out: string_io,
+        configuration: configuration,
+        run_context: run_context,
+        offenses_formatter: offenses_formatter.new
+      )
+
+      # TODO: Dependency injection for a "target finder" (https://github.com/Shopify/packwerk/issues/164)
+      ::Packwerk::FilesForProcessing.stubs(fetch: [file_path])
+
+      success = cli.execute_command(["check", file_path])
+
+      assert_includes string_io.string, "hi i am a custom offense formatter"
+      assert_includes string_io.string, violation_message
+
+      refute success
+    end
   end
 end


### PR DESCRIPTION

## What are you trying to accomplish?

This adds a new interface Packwerk::OffenseFormatter, and that is included in the existing Packwerk::Formatters::OffenseFormatter, so the CLI can extend it

This lets users customize how to display each offense. I am working with @mclark to customize our packwerk output to format it for parsing by our CI. It could also be used to make a few default available formatters like JSON or YAML which could remove some need for custom ones.

## What approach did you choose and why?

I copied what OutputStyle was doing, but I think there is some room for improvement about Packwerk::OffensesFormat vs Packwerk::Formatters::OffensesFormatter.

## What should reviewers focus on?


## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] It is safe to rollback this change.
