### PR TITLE
Use autoload instead of explicit requires

### DIFF
--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -3,7 +3,6 @@
 
 require "sorbet-runtime"
 require "active_support"
-require "constant_resolver"
 require "fileutils"
 
 require "packwerk/offense"

--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -7,7 +7,6 @@ require "constant_resolver"
 require "fileutils"
 
 require "packwerk/offense"
-
 require "packwerk/application_validator"
 require "packwerk/association_inspector"
 require "packwerk/checking_deprecated_references"

--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -5,40 +5,80 @@ require "sorbet-runtime"
 require "active_support"
 require "fileutils"
 
-require "packwerk/offense"
-require "packwerk/application_validator"
-require "packwerk/association_inspector"
-require "packwerk/checking_deprecated_references"
-require "packwerk/cli"
-require "packwerk/configuration"
-require "packwerk/const_node_inspector"
-require "packwerk/constant_discovery"
-require "packwerk/dependency_checker"
-require "packwerk/deprecated_references"
-require "packwerk/files_for_processing"
-require "packwerk/file_processor"
-require "packwerk/formatters/progress_formatter"
-require "packwerk/generators/application_validation"
-require "packwerk/generators/configuration_file"
-require "packwerk/generators/inflections_file"
-require "packwerk/generators/root_package"
-require "packwerk/graph"
-require "packwerk/inflector"
-require "packwerk/node_processor"
-require "packwerk/node_visitor"
-require "packwerk/output_style"
-require "packwerk/output_styles/plain"
-require "packwerk/output_styles/coloured"
-require "packwerk/package_set"
-require "packwerk/package"
-require "packwerk/parse_run"
-require "packwerk/parsers"
-require "packwerk/privacy_checker"
-require "packwerk/reference_extractor"
-require "packwerk/run_context"
-require "packwerk/updating_deprecated_references"
-require "packwerk/version"
-require "packwerk/violation_type"
-
 module Packwerk
+  extend ActiveSupport::Autoload
+
+  autoload :ApplicationLoadPaths
+  autoload :ApplicationValidator
+  autoload :AssociationInspector
+  autoload :CacheDeprecatedReferences
+  autoload :Checker
+  autoload :CheckingDeprecatedReferences
+  autoload :Cli
+  autoload :Configuration
+  autoload :ConstantDiscovery
+  autoload :ConstantNameInspector
+  autoload :ConstNodeInspector
+  autoload :DependencyChecker
+  autoload :DeprecatedReferences
+  autoload :DetectStaleDeprecatedReferences
+  autoload :FileProcessor
+  autoload :FilesForProcessing
+  autoload :Graph
+  autoload :Inflector
+  autoload :Node
+  autoload :NodeProcessor
+  autoload :NodeProcessorFactory
+  autoload :NodeVisitor
+  autoload :Offense
+  autoload :OutputStyle
+  autoload :Package
+  autoload :PackageSet
+  autoload :ParsedConstantDefinitions
+  autoload :Parsers
+  autoload :ParseRun
+  autoload :PrivacyChecker
+  autoload :Reference
+  autoload :ReferenceExtractor
+  autoload :ReferenceLister
+  autoload :ReferenceOffense
+  autoload :Result
+  autoload :RunContext
+  autoload :UpdatingDeprecatedReferences
+  autoload :Version
+  autoload :ViolationType
+
+  module Inflections
+    extend ActiveSupport::Autoload
+
+    autoload :Custom
+    autoload :Default
+  end
+
+  module OutputStyles
+    extend ActiveSupport::Autoload
+
+    autoload :Coloured
+    autoload :Plain
+  end
+
+  autoload_under "commands" do
+    autoload :OffenseProgressMarker
+  end
+
+  module Formatters
+    extend ActiveSupport::Autoload
+
+    autoload :OffensesFormatter
+    autoload :ProgressFormatter
+  end
+
+  module Generators
+    extend ActiveSupport::Autoload
+
+    autoload :ApplicationValidation
+    autoload :ConfigurationFile
+    autoload :InflectionsFile
+    autoload :RootPackage
+  end
 end

--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -6,11 +6,6 @@ require "constant_resolver"
 require "pathname"
 require "yaml"
 
-require "packwerk/package_set"
-require "packwerk/graph"
-require "packwerk/inflector"
-require "packwerk/application_load_paths"
-
 module Packwerk
   class ApplicationValidator
     def initialize(config_file_path:, configuration:)

--- a/lib/packwerk/association_inspector.rb
+++ b/lib/packwerk/association_inspector.rb
@@ -1,9 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "packwerk/constant_name_inspector"
-require "packwerk/node"
-
 module Packwerk
   # Extracts the implicit constant reference from an active record association
   class AssociationInspector

--- a/lib/packwerk/cache_deprecated_references.rb
+++ b/lib/packwerk/cache_deprecated_references.rb
@@ -1,11 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "packwerk/deprecated_references"
-require "packwerk/reference"
-require "packwerk/reference_lister"
-require "packwerk/violation_type"
-
 module Packwerk
   class CacheDeprecatedReferences
     extend T::Sig

--- a/lib/packwerk/cache_deprecated_references.rb
+++ b/lib/packwerk/cache_deprecated_references.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "sorbet-runtime"
-
 require "packwerk/deprecated_references"
 require "packwerk/reference"
 require "packwerk/reference_lister"

--- a/lib/packwerk/checker.rb
+++ b/lib/packwerk/checker.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "sorbet-runtime"
 require "packwerk/reference_lister"
 
 module Packwerk

--- a/lib/packwerk/checker.rb
+++ b/lib/packwerk/checker.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "packwerk/reference_lister"
-
 module Packwerk
   module Checker
     extend T::Sig

--- a/lib/packwerk/checking_deprecated_references.rb
+++ b/lib/packwerk/checking_deprecated_references.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "packwerk/reference_lister"
-
 module Packwerk
   class CheckingDeprecatedReferences
     extend T::Sig

--- a/lib/packwerk/checking_deprecated_references.rb
+++ b/lib/packwerk/checking_deprecated_references.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "sorbet-runtime"
-
 require "packwerk/reference_lister"
 
 module Packwerk

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -1,7 +1,5 @@
 # typed: true
 # frozen_string_literal: true
-require "benchmark"
-require "sorbet-runtime"
 
 require "packwerk/application_load_paths"
 require "packwerk/application_validator"

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -1,19 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "packwerk/application_load_paths"
-require "packwerk/application_validator"
-require "packwerk/configuration"
-require "packwerk/files_for_processing"
-require "packwerk/formatters/offenses_formatter"
-require "packwerk/formatters/progress_formatter"
-require "packwerk/inflector"
-require "packwerk/output_style"
-require "packwerk/output_styles/plain"
-require "packwerk/updating_deprecated_references"
-require "packwerk/checking_deprecated_references"
-require "packwerk/commands/offense_progress_marker"
-
 module Packwerk
   class Cli
     extend T::Sig

--- a/lib/packwerk/commands/offense_progress_marker.rb
+++ b/lib/packwerk/commands/offense_progress_marker.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 # typed: strict
 
-require "packwerk/formatters/progress_formatter"
-
 module Packwerk
   module OffenseProgressMarker
     extend T::Sig

--- a/lib/packwerk/commands/offense_progress_marker.rb
+++ b/lib/packwerk/commands/offense_progress_marker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # typed: strict
-require "sorbet-runtime"
+
 require "packwerk/formatters/progress_formatter"
 
 module Packwerk

--- a/lib/packwerk/const_node_inspector.rb
+++ b/lib/packwerk/const_node_inspector.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "packwerk/constant_name_inspector"
-
 module Packwerk
   # Extracts a constant name from an AST node of type :const
   class ConstNodeInspector

--- a/lib/packwerk/constant_discovery.rb
+++ b/lib/packwerk/constant_discovery.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "constant_resolver"
+
 module Packwerk
   # Get information about (partially qualified) constants without loading the application code.
   # Information gathered: Fully qualified name, path to file containing the definition, package,

--- a/lib/packwerk/constant_name_inspector.rb
+++ b/lib/packwerk/constant_name_inspector.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "ast"
-require "sorbet-runtime"
 
 module Packwerk
   # An interface describing some object that can extract a constant name from an AST node

--- a/lib/packwerk/dependency_checker.rb
+++ b/lib/packwerk/dependency_checker.rb
@@ -1,9 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "packwerk/violation_type"
-require "packwerk/checker"
-
 module Packwerk
   class DependencyChecker
     extend T::Sig

--- a/lib/packwerk/deprecated_references.rb
+++ b/lib/packwerk/deprecated_references.rb
@@ -3,10 +3,6 @@
 
 require "yaml"
 
-require "packwerk/reference"
-require "packwerk/reference_lister"
-require "packwerk/violation_type"
-
 module Packwerk
   class DeprecatedReferences
     extend T::Sig

--- a/lib/packwerk/deprecated_references.rb
+++ b/lib/packwerk/deprecated_references.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "sorbet-runtime"
 require "yaml"
 
 require "packwerk/reference"

--- a/lib/packwerk/detect_stale_deprecated_references.rb
+++ b/lib/packwerk/detect_stale_deprecated_references.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "packwerk/cache_deprecated_references"
-
 module Packwerk
   class DetectStaleDeprecatedReferences < CacheDeprecatedReferences
     extend T::Sig

--- a/lib/packwerk/file_processor.rb
+++ b/lib/packwerk/file_processor.rb
@@ -3,10 +3,6 @@
 
 require "ast/node"
 
-require "packwerk/node"
-require "packwerk/offense"
-require "packwerk/parsers"
-
 module Packwerk
   class FileProcessor
     class UnknownFileTypeResult < Offense

--- a/lib/packwerk/formatters/offenses_formatter.rb
+++ b/lib/packwerk/formatters/offenses_formatter.rb
@@ -1,7 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "benchmark"
 require "packwerk/inflector"
 require "packwerk/output_style"
 require "packwerk/output_styles/plain"

--- a/lib/packwerk/formatters/offenses_formatter.rb
+++ b/lib/packwerk/formatters/offenses_formatter.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 require "benchmark"
-require "sorbet-runtime"
-
 require "packwerk/inflector"
 require "packwerk/output_style"
 require "packwerk/output_styles/plain"

--- a/lib/packwerk/formatters/offenses_formatter.rb
+++ b/lib/packwerk/formatters/offenses_formatter.rb
@@ -1,10 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "packwerk/inflector"
-require "packwerk/output_style"
-require "packwerk/output_styles/plain"
-
 module Packwerk
   module Formatters
     class OffensesFormatter

--- a/lib/packwerk/formatters/progress_formatter.rb
+++ b/lib/packwerk/formatters/progress_formatter.rb
@@ -2,9 +2,6 @@
 # frozen_string_literal: true
 
 require "benchmark"
-require "packwerk/inflector"
-require "packwerk/output_style"
-require "packwerk/output_styles/plain"
 
 module Packwerk
   module Formatters

--- a/lib/packwerk/formatters/progress_formatter.rb
+++ b/lib/packwerk/formatters/progress_formatter.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "benchmark"
-
 require "packwerk/inflector"
 require "packwerk/output_style"
 require "packwerk/output_styles/plain"

--- a/lib/packwerk/generators/configuration_file.rb
+++ b/lib/packwerk/generators/configuration_file.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "packwerk/configuration"
 require "erb"
 
 module Packwerk

--- a/lib/packwerk/inflector.rb
+++ b/lib/packwerk/inflector.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 require "active_support/inflector"
-require "packwerk/inflections/default"
-require "packwerk/inflections/custom"
 
 module Packwerk
   class Inflector

--- a/lib/packwerk/node_processor.rb
+++ b/lib/packwerk/node_processor.rb
@@ -1,11 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "packwerk/node"
-require "packwerk/reference_offense"
-require "packwerk/checker"
-require "packwerk/reference_lister"
-
 module Packwerk
   class NodeProcessor
     extend T::Sig

--- a/lib/packwerk/node_processor_factory.rb
+++ b/lib/packwerk/node_processor_factory.rb
@@ -1,9 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "packwerk/constant_name_inspector"
-require "packwerk/checker"
-
 module Packwerk
   class NodeProcessorFactory < T::Struct
     extend T::Sig

--- a/lib/packwerk/node_visitor.rb
+++ b/lib/packwerk/node_visitor.rb
@@ -1,8 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "packwerk/node"
-
 module Packwerk
   class NodeVisitor
     def initialize(node_processor:)

--- a/lib/packwerk/offense.rb
+++ b/lib/packwerk/offense.rb
@@ -3,9 +3,6 @@
 
 require "parser/source/map"
 
-require "packwerk/output_style"
-require "packwerk/output_styles/plain"
-
 module Packwerk
   class Offense
     extend T::Sig

--- a/lib/packwerk/offense.rb
+++ b/lib/packwerk/offense.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "parser/source/map"
-require "sorbet-runtime"
 
 require "packwerk/output_style"
 require "packwerk/output_styles/plain"

--- a/lib/packwerk/package_set.rb
+++ b/lib/packwerk/package_set.rb
@@ -3,8 +3,6 @@
 
 require "pathname"
 
-require "packwerk/package"
-
 module Packwerk
   class PackageSet
     include Enumerable

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -2,10 +2,6 @@
 # frozen_string_literal: true
 
 require "benchmark"
-require "packwerk/run_context"
-require "packwerk/detect_stale_deprecated_references"
-require "packwerk/commands/offense_progress_marker"
-require "packwerk/result"
 
 module Packwerk
   class ParseRun

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -1,6 +1,6 @@
 # typed: true
 # frozen_string_literal: true
-require "sorbet-runtime"
+
 require "benchmark"
 require "packwerk/run_context"
 require "packwerk/detect_stale_deprecated_references"

--- a/lib/packwerk/parsed_constant_definitions.rb
+++ b/lib/packwerk/parsed_constant_definitions.rb
@@ -3,8 +3,6 @@
 
 require "ast/node"
 
-require "packwerk/node"
-
 module Packwerk
   class ParsedConstantDefinitions
     def initialize(root_node:)

--- a/lib/packwerk/parsers.rb
+++ b/lib/packwerk/parsers.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "packwerk/offense"
-
 module Packwerk
   module Parsers
     autoload :Erb, "packwerk/parsers/erb"

--- a/lib/packwerk/parsers/erb.rb
+++ b/lib/packwerk/parsers/erb.rb
@@ -6,8 +6,6 @@ require "better_html"
 require "better_html/parser"
 require "parser/source/buffer"
 
-require "packwerk/parsers"
-
 module Packwerk
   module Parsers
     class Erb

--- a/lib/packwerk/parsers/factory.rb
+++ b/lib/packwerk/parsers/factory.rb
@@ -3,8 +3,6 @@
 
 require "singleton"
 
-require "packwerk/parsers"
-
 module Packwerk
   module Parsers
     class Factory

--- a/lib/packwerk/privacy_checker.rb
+++ b/lib/packwerk/privacy_checker.rb
@@ -1,9 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "packwerk/violation_type"
-require "packwerk/checker"
-
 module Packwerk
   class PrivacyChecker
     extend T::Sig

--- a/lib/packwerk/reference_extractor.rb
+++ b/lib/packwerk/reference_extractor.rb
@@ -1,12 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "packwerk/constant_discovery"
-require "packwerk/constant_name_inspector"
-require "packwerk/node"
-require "packwerk/parsed_constant_definitions"
-require "packwerk/reference"
-
 module Packwerk
   # extracts a possible constant reference from a given AST node
   class ReferenceExtractor

--- a/lib/packwerk/reference_extractor.rb
+++ b/lib/packwerk/reference_extractor.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "sorbet-runtime"
-
 require "packwerk/constant_discovery"
 require "packwerk/constant_name_inspector"
 require "packwerk/node"

--- a/lib/packwerk/reference_lister.rb
+++ b/lib/packwerk/reference_lister.rb
@@ -1,9 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "packwerk/reference"
-require "packwerk/violation_type"
-
 module Packwerk
   module ReferenceLister
     extend T::Sig

--- a/lib/packwerk/reference_lister.rb
+++ b/lib/packwerk/reference_lister.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "sorbet-runtime"
-
 require "packwerk/reference"
 require "packwerk/violation_type"
 

--- a/lib/packwerk/reference_offense.rb
+++ b/lib/packwerk/reference_offense.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "packwerk/offense"
-require "sorbet-runtime"
 
 module Packwerk
   class ReferenceOffense < Offense

--- a/lib/packwerk/reference_offense.rb
+++ b/lib/packwerk/reference_offense.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "packwerk/offense"
-
 module Packwerk
   class ReferenceOffense < Offense
     extend T::Sig

--- a/lib/packwerk/result.rb
+++ b/lib/packwerk/result.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "sorbet-runtime"
-
 module Packwerk
   class Result < T::Struct
     prop :message, String

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -3,17 +3,6 @@
 
 require "constant_resolver"
 
-require "packwerk/association_inspector"
-require "packwerk/constant_discovery"
-require "packwerk/const_node_inspector"
-require "packwerk/dependency_checker"
-require "packwerk/file_processor"
-require "packwerk/inflector"
-require "packwerk/package_set"
-require "packwerk/privacy_checker"
-require "packwerk/reference_extractor"
-require "packwerk/node_processor_factory"
-
 module Packwerk
   class RunContext
     extend T::Sig

--- a/lib/packwerk/sanity_checker.rb
+++ b/lib/packwerk/sanity_checker.rb
@@ -1,8 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "packwerk/application_validator"
-
 module Packwerk
   # To do: This alias and file should be removed as it is deprecated
   warn("DEPRECATION WARNING: Packwerk::SanityChecker is deprecated, use Packwerk::ApplicationValidator instead.")

--- a/lib/packwerk/updating_deprecated_references.rb
+++ b/lib/packwerk/updating_deprecated_references.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "packwerk/cache_deprecated_references"
-
 module Packwerk
   class UpdatingDeprecatedReferences < CacheDeprecatedReferences
     def dump_deprecated_references_files

--- a/lib/packwerk/violation_type.rb
+++ b/lib/packwerk/violation_type.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "sorbet-runtime"
-
 module Packwerk
   class ViolationType < T::Enum
     enums do

--- a/test/parser_test_helper.rb
+++ b/test/parser_test_helper.rb
@@ -1,8 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "packwerk/parsers/ruby"
-
 module ParserTestHelper
   class << self
     def parse(source)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,6 @@ ENV["RAILS_ENV"] = "test"
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 ROOT = Pathname.new(__dir__).join("..").expand_path
 
-require "constant_resolver"
 require "packwerk"
 
 require "minitest/autorun"

--- a/test/unit/application_validator_test.rb
+++ b/test/unit/application_validator_test.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "packwerk/application_validator"
 
 # make sure PrivateThing.constantize succeeds to pass the privacy validity check
 require "fixtures/skeleton/components/timeline/app/models/private_thing.rb"

--- a/test/unit/detect_stale_deprecated_references_test.rb
+++ b/test/unit/detect_stale_deprecated_references_test.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "packwerk/detect_stale_deprecated_references"
+
 module Packwerk
   class DetectStaleDeprecatedReferencesTest < Minitest::Test
     setup do

--- a/test/unit/inflections/custom_test.rb
+++ b/test/unit/inflections/custom_test.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "packwerk/inflections/custom"
 
 module Packwerk
   module Inflections

--- a/test/unit/inflector_test.rb
+++ b/test/unit/inflector_test.rb
@@ -3,8 +3,6 @@
 
 require "test_helper"
 
-require "packwerk/inflector"
-
 module Packwerk
   class InflectorTest < Minitest::Test
     def setup

--- a/test/unit/parse_run_test.rb
+++ b/test/unit/parse_run_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require "test_helper"
 require "rails_test_helper"
-require "packwerk/parse_run"
 
 module Packwerk
   class ParseRunTest < Minitest::Test

--- a/test/unit/parsed_constant_definitions_test.rb
+++ b/test/unit/parsed_constant_definitions_test.rb
@@ -4,8 +4,6 @@
 require "test_helper"
 require "parser_test_helper"
 
-require "packwerk/node"
-
 module Packwerk
   class ParsedConstantDefinitionsTest < Minitest::Test
     test "recognizes constant assignment" do

--- a/test/unit/reference_extractor_test.rb
+++ b/test/unit/reference_extractor_test.rb
@@ -4,8 +4,6 @@
 require "test_helper"
 require "parser_test_helper"
 
-require "packwerk/node"
-
 module Packwerk
   class ReferenceExtractorTest < Minitest::Test
     include ApplicationFixtureHelper


### PR DESCRIPTION
This has two goals:

1. Remove the need to use `require: false` in the Gemfile given all the code will be lazily evaluated.
2. Will avoid the mistake of requiring a file in the tests but not in the code, since all autoload are setup in the same place.

The only disadvantage is that is a file is removed but the autoload is not nothing fails.