### PR TITLE
Fix support for constants under the public path of the root package

### DIFF
--- a/lib/packwerk/package.rb
+++ b/lib/packwerk/package.rb
@@ -71,11 +71,5 @@ module Packwerk
     def root?
       @name == ROOT_PACKAGE_NAME
     end
-
-    private
-
-    def unprefixed_public_path
-      @unprefixed_public_path ||= user_defined_public_path || "app/public/"
-    end
   end
 end

--- a/lib/packwerk/package.rb
+++ b/lib/packwerk/package.rb
@@ -33,11 +33,15 @@ module Packwerk
     end
 
     def public_path
-      @public_path ||= File.join(@name, user_defined_public_path || "app/public/")
+      @public_path ||= File.join(@name, unprefixed_public_path)
     end
 
     def public_path?(path)
-      path.start_with?(public_path)
+      if root?
+        path.start_with?(unprefixed_public_path)
+      else
+        path.start_with?(public_path)
+      end
     end
 
     def user_defined_public_path
@@ -66,6 +70,12 @@ module Packwerk
 
     def root?
       @name == ROOT_PACKAGE_NAME
+    end
+
+    private
+
+    def unprefixed_public_path
+      @unprefixed_public_path ||= user_defined_public_path || "app/public/"
     end
   end
 end

--- a/lib/packwerk/package.rb
+++ b/lib/packwerk/package.rb
@@ -33,7 +33,15 @@ module Packwerk
     end
 
     def public_path
-      @public_path ||= File.join(@name, unprefixed_public_path)
+      @public_path ||= begin
+        unprefixed_public_path = user_defined_public_path || "app/public/"
+
+        if root?
+          unprefixed_public_path
+        else
+          File.join(@name, unprefixed_public_path)
+        end
+      end
     end
 
     def public_path?(path)

--- a/lib/packwerk/package.rb
+++ b/lib/packwerk/package.rb
@@ -37,11 +37,7 @@ module Packwerk
     end
 
     def public_path?(path)
-      if root?
-        path.start_with?(unprefixed_public_path)
-      else
-        path.start_with?(public_path)
-      end
+      path.start_with?(public_path)
     end
 
     def user_defined_public_path

--- a/test/unit/package_test.rb
+++ b/test/unit/package_test.rb
@@ -38,13 +38,13 @@ module Packwerk
 
     test "#public_path returns expected path when using the default public path in root package" do
       package = Package.new(name: ".", config: {})
-      assert_equal("./app/public/", package.public_path)
+      assert_equal("app/public/", package.public_path)
     end
 
     test "#public_path returns expected path when using a user defined public path" do
       package = Package.new(name: ".", config: { "public_path" => "my/path/" })
 
-      assert_equal("./my/path/", package.public_path)
+      assert_equal("my/path/", package.public_path)
     end
 
     test "#package_path? returns true for path under the package's public path" do

--- a/test/unit/package_test.rb
+++ b/test/unit/package_test.rb
@@ -36,12 +36,33 @@ module Packwerk
       assert_equal("components/timeline/my/path/", package.public_path)
     end
 
+    test "#public_path returns expected path when using the default public path in root package" do
+      package = Package.new(name: ".", config: {})
+      assert_equal("./app/public/", package.public_path)
+    end
+
+    test "#public_path returns expected path when using a user defined public path" do
+      package = Package.new(name: ".", config: { "public_path" => "my/path/" })
+
+      assert_equal("./my/path/", package.public_path)
+    end
+
     test "#package_path? returns true for path under the package's public path" do
       assert_equal(true, @package.public_path?("components/timeline/app/public/entrypoint.rb"))
     end
 
     test "#package_path? returns false for path not under the package's public path" do
       assert_equal(false, @package.public_path?("components/timeline/app/models/something.rb"))
+    end
+
+    test "#public_path? returns true for path under the root package's public path" do
+      package = Package.new(name: ".", config: {})
+      assert_equal(true, package.public_path?("app/public/entrypoint.rb"))
+    end
+
+    test "#public_path? returns false for path not under the root package's public path" do
+      package = Package.new(name: ".", config: {})
+      assert_equal(false, package.public_path?("app/models/something.rb"))
     end
 
     test "#<=> compares against name" do


### PR DESCRIPTION
## What are you trying to accomplish?

Constants in the public folder of the root package are not treated as public. This is due to their location not being recognized as public.

## What approach did you choose and why?

The constant location that is used to check if the constant is public is relative to the root of the project. That path is checked against the configured public path for a package to determine if the constant is public.

For all packages, the public path that is used for this check is prefixed by the package name. For the root package that is ".".

The constant location is relative and not prefixed by "./" and therefore never matches the root package's public path used for the check (default for the check would be "./app/public/").

There are multiple ways of approaching this, but I chose to use the public path without the package name prefix when testing if a path is a public path for the root project. This kept the change small and avoids modifying the `#public_path` method or the `#package_path?` check which is working.

There is added test coverage for the root package to make the behavior more obvious.

## What should reviewers focus on?

The change is pretty small, but is there another way we'd like to implement it?

Are constants in the public folder of the root package expected to be supported?

## Type of Change

- [x] Bugfix

### Additional Release Notes

- [x] Bugfix: fix support for constants under the public path of the root package

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
