### PR TITLE
Combined check and detect-stale-violations

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -230,7 +230,7 @@ After enforcing the boundary checks for a package, you may execute:
 
     bundle exec packwerk check
 
-Packwerk will check the entire codebase for any violations.
+Packwerk will check the entire codebase for any new or stale violations.
 
 You can also specify folders or packages for a shorter run time:
 

--- a/lib/packwerk/formatters/offenses_formatter.rb
+++ b/lib/packwerk/formatters/offenses_formatter.rb
@@ -15,7 +15,7 @@ module Packwerk
 
       sig { override.params(offenses: T::Array[T.nilable(Offense)]).returns(String) }
       def show_offenses(offenses)
-        return "No offenses detected 🎉" if offenses.empty?
+        return "No offenses detected" if offenses.empty?
 
         <<~EOS
           #{offenses_list(offenses)}

--- a/lib/packwerk/formatters/offenses_formatter.rb
+++ b/lib/packwerk/formatters/offenses_formatter.rb
@@ -23,6 +23,15 @@ module Packwerk
         EOS
       end
 
+      sig { override.params(offense_collection: Packwerk::OffenseCollection).returns(String) }
+      def show_stale_violations(offense_collection)
+        if offense_collection.stale_violations?
+          "There were stale violations found, please run `packwerk update-deprecations`"
+        else
+          "No stale violations detected"
+        end
+      end
+
       private
 
       sig { params(offenses: T::Array[T.nilable(Offense)]).returns(String) }

--- a/lib/packwerk/offenses_formatter.rb
+++ b/lib/packwerk/offenses_formatter.rb
@@ -11,5 +11,9 @@ module Packwerk
     sig { abstract.params(offenses: T::Array[T.nilable(Offense)]).returns(String) }
     def show_offenses(offenses)
     end
+
+    sig { abstract.params(offense_collection: Packwerk::OffenseCollection).returns(String) }
+    def show_stale_violations(offense_collection)
+    end
   end
 end

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -43,8 +43,14 @@ module Packwerk
 
     def check
       offense_collection = find_offenses(show_errors: true)
-      message = @offenses_formatter.show_offenses(offense_collection.outstanding_offenses)
-      Result.new(message: message, status: offense_collection.outstanding_offenses.empty?)
+
+      messages = [
+        @offenses_formatter.show_offenses(offense_collection.outstanding_offenses),
+        @offenses_formatter.show_stale_violations(offense_collection),
+      ]
+      result_status = offense_collection.outstanding_offenses.empty? && !offense_collection.stale_violations?
+
+      Result.new(message: messages.join("\n") + "\n", status: result_status)
     end
 
     private

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -24,11 +24,7 @@ module Packwerk
       offense_collection = find_offenses
 
       result_status = !offense_collection.stale_violations?
-      message = if result_status
-        "No stale violations detected"
-      else
-        "There were stale violations found, please run `packwerk update-deprecations`"
-      end
+      message = @offenses_formatter.show_stale_violations(offense_collection)
 
       Result.new(message: message, status: result_status)
     end

--- a/test/integration/custom_executable_test.rb
+++ b/test/integration/custom_executable_test.rb
@@ -63,7 +63,7 @@ module Packwerk
           \\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.
           📦 Finished in \\d+\\.\\d+ seconds
 
-          No offenses detected 🎉
+          No offenses detected
           ✅ `deprecated_references.yml` has been updated.
         EOS
 
@@ -98,7 +98,7 @@ module Packwerk
             \\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.\\.
             📦 Finished in \\d+\\.\\d+ seconds
 
-            No offenses detected 🎉
+            No offenses detected
             ✅ `deprecated_references.yml` has been updated.
           EOS
 

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -158,6 +158,10 @@ module Packwerk
         def show_offenses(offenses)
           ["hi i am a custom offense formatter", *offenses].join("\n")
         end
+
+        def show_stale_violations(_offense_collection)
+          "stale violations report"
+        end
       end
 
       file_path = "path/of/exile.rb"
@@ -181,6 +185,7 @@ module Packwerk
       success = cli.execute_command(["check", file_path])
 
       assert_includes string_io.string, "hi i am a custom offense formatter"
+      assert_includes string_io.string, "stale violations report"
       assert_includes string_io.string, violation_message
 
       refute success

--- a/test/unit/formatters/offenses_formatter_test.rb
+++ b/test/unit/formatters/offenses_formatter_test.rb
@@ -11,7 +11,7 @@ module Packwerk
       end
 
       test "#show_offenses prints No offenses detected when there are no offenses" do
-        assert_match "No offenses detected 🎉", @offenses_formatter.show_offenses([])
+        assert_match "No offenses detected", @offenses_formatter.show_offenses([])
       end
 
       test "#show_offenses prints the amount of files when there are offenses" do

--- a/test/unit/parse_run_test.rb
+++ b/test/unit/parse_run_test.rb
@@ -24,7 +24,7 @@ module Packwerk
       result = parse_run.update_deprecations
 
       assert_equal result.message, <<~EOS
-        No offenses detected 🎉
+        No offenses detected
         ✅ `deprecated_references.yml` has been updated.
       EOS
       assert result.status
@@ -70,7 +70,7 @@ module Packwerk
       assert_match(/#{expected_output}/, out.string)
 
       assert result.status
-      assert_equal "No offenses detected 🎉", result.message
+      assert_equal "No offenses detected", result.message
     end
 
     test "runs in parallel" do

--- a/test/unit/parse_run_test.rb
+++ b/test/unit/parse_run_test.rb
@@ -70,7 +70,40 @@ module Packwerk
       assert_match(/#{expected_output}/, out.string)
 
       assert result.status
-      assert_equal "No offenses detected", result.message
+      expected_message = <<~EOS
+        No offenses detected
+        No stale violations detected
+      EOS
+      assert_equal expected_message, result.message
+    end
+
+    test "#check result has failure status when stale violations exist" do
+      offense = ReferenceOffense.new(reference: build_reference, violation_type: ViolationType::Privacy)
+      DeprecatedReferences.any_instance.stubs(:listed?).returns(true)
+      OffenseCollection.any_instance.stubs(:stale_violations?).returns(true)
+      out = StringIO.new
+      parse_run = Packwerk::ParseRun.new(
+        files: ["some/path.rb"],
+        configuration: Configuration.new({ "parallel" => false }),
+        progress_formatter: Packwerk::Formatters::ProgressFormatter.new(out)
+      )
+      RunContext.any_instance.stubs(:process_file).returns([offense])
+      result = parse_run.check
+
+      expected_output = <<~EOS
+        📦 Packwerk is inspecting 1 file
+        \\.
+        📦 Finished in \\d+\\.\\d+ seconds
+      EOS
+      assert_match(/#{expected_output}/, out.string)
+
+      expected_message = <<~EOS
+        No offenses detected
+        There were stale violations found, please run `packwerk update-deprecations`
+      EOS
+
+      refute result.status
+      assert_equal expected_message, result.message
     end
 
     test "runs in parallel" do


### PR DESCRIPTION
## What are you trying to accomplish?
Currently, `packwerk check` just checks for new violations in the codebase. If we want to also check for stale violations we need to do that as an additional parse of the entire codebase which is quite expensive. This PR makes `packwerk check` check for _new_ **and** _stale_ violations.

## What approach did you choose and why?
I opted to change the behaviour of `packwerk check` after consultation with @rafaelfranca in https://github.com/Shopify/packwerk/issues/129.

## What should reviewers focus on?
* The old "No offenses detected 🎉 " message has been made sadder and less celebratory in order to conform with the more austere language of the "no stale violations" message. If anyone is matching on that, then it could cause problems. That being said, no one should be matching on that.
* This breaks `packwerk check`. Previously passing checks could easily start failing.

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [x] Breaking change (fix or feature that would cause existing functionality to change)

`packwerk check` will now fail if stale violations are present in the codebase.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
