### PR TITLE
Remove dependency on ActiveSupport Blank extension

### DIFF
--- a/lib/packwerk/deprecated_references.rb
+++ b/lib/packwerk/deprecated_references.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "yaml"
-require "active_support/core_ext/object/blank"
 
 module Packwerk
   class DeprecatedReferences
@@ -54,7 +53,7 @@ module Packwerk
           if entries_for_file["violations"].all? { |type| new_entries_violation_types.include?(type) }
             stale_violations =
               entries_for_file["files"] - Array(@new_entries.dig(package, constant_name, "files"))
-            stale_violations.present?
+            stale_violations.any?
           else
             return true
           end

--- a/lib/packwerk/deprecated_references.rb
+++ b/lib/packwerk/deprecated_references.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "yaml"
+require "active_support/core_ext/object/blank"
 
 module Packwerk
   class DeprecatedReferences


### PR DESCRIPTION
## What are you trying to accomplish?
Fix a bug in the `DeprecatedReferences` class.

This class uses `#present?`, which is defined in [`active_support/core_ext/object/blank`](https://github.com/rails/rails/blob/83217025a171593547d1268651b446d3533e2019/activesupport/lib/active_support/core_ext/object/blank.rb#L25), but doesn't require the file. 

This can cause an error when running the `packwerk check` command, because the Rails environment is not loaded.

Note that this error doesn't surface in the test env, because it includes the [`rails_test_helper`](https://github.com/Shopify/packwerk/blob/820d1d169aa4f5d132938d00540ebb8b34ac6f58/test/rails_test_helper.rb#L4), which requires `rails`, which in turn requires the [`blank` extension](https://github.com/rails/rails/blob/main/railties/lib/rails.rb#L11).

## What approach did you choose and why?
I opted to refactor the code to use `any?`. This has the same behaviour for arrays composed of strings (or empty arrays). This means we can drop the dependency on ActiveSupport.

Since I'm unable to reproduce in the test env, there's no need to add a test.

## What should reviewers focus on?
Maybe there's a better approach?

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
