### PR TITLE
Add option to ignore nested packages

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -231,9 +231,13 @@ After enforcing the boundary checks for a package, you may execute:
 
 Packwerk will check the entire codebase for any new or stale violations.
 
-You can also specify folders for a shorter run time:
+You can also specify folders for a shorter run time. When checking against folders all subfolders will be analyzed, irrespective of nested package boundaries.
 
     packwerk check components/your_package
+
+You can also specify packages for a shorter run time. When checking against packages any packages nested underneath the specified packages will not be checked. This can be helpful to test packages like the root package, which can have many nested packages.
+
+    packwerk check --packages=components/your_package,components/your_other_package
 
 ![](static/packwerk_check.gif)
 

--- a/lib/packwerk/files_for_processing.rb
+++ b/lib/packwerk/files_for_processing.rb
@@ -4,14 +4,15 @@
 module Packwerk
   class FilesForProcessing
     class << self
-      def fetch(paths:, configuration:)
-        new(paths, configuration).files
+      def fetch(paths:, configuration:, ignore_nested_packages: false)
+        new(paths, configuration, ignore_nested_packages).files
       end
     end
 
-    def initialize(paths, configuration)
+    def initialize(paths, configuration, ignore_nested_packages)
       @paths = paths
       @configuration = configuration
+      @ignore_nested_packages = ignore_nested_packages
     end
 
     def files
@@ -43,11 +44,21 @@ module Packwerk
         File.expand_path(glob, @configuration.root_path)
       end
 
-      Dir.glob([File.join(path, "**", "*")]).select do |file_path|
+      files = Dir.glob([File.join(path, "**", "*")]).select do |file_path|
         absolute_includes.any? do |pattern|
           File.fnmatch?(pattern, file_path, File::FNM_EXTGLOB)
         end
       end
+
+      if @ignore_nested_packages
+        nested_packages_paths = Dir.glob(File.join(path, "*", "**", "package.yml"))
+        nested_packages_globs = nested_packages_paths.map { |npp| npp.gsub("package.yml", "**/*") }
+        nested_packages_globs.each do |glob|
+          files -= Dir.glob(glob)
+        end
+      end
+
+      files
     end
 
     def configured_included_files

--- a/test/unit/files_for_processing_test.rb
+++ b/test/unit/files_for_processing_test.rb
@@ -43,6 +43,39 @@ module Packwerk
       assert_equal files, files.uniq
     end
 
+    test "fetch with custom paths without ignoring nested packages includes only include glob in custom paths including nested package files" do
+      files = ::Packwerk::FilesForProcessing.fetch(
+        paths: ["."],
+        configuration: @configuration,
+        ignore_nested_packages: false
+      )
+      included_file_patterns = @configuration.include.map { |pattern| File.join(@configuration.root_path, pattern) }
+
+      assert_all_match(files, included_file_patterns)
+    end
+
+    test "fetch with no custom paths ignoring nested packages includes only include glob across codebase" do
+      files = ::Packwerk::FilesForProcessing.fetch(
+        paths: [],
+        configuration: @configuration,
+        ignore_nested_packages: true
+      )
+      included_file_patterns = @configuration.include.map { |pattern| File.join(@configuration.root_path, pattern) }
+
+      assert_all_match(files, included_file_patterns)
+    end
+
+    test "fetch with custom paths ignoring nested packages includes only include glob in custom paths without nested package files" do
+      files = ::Packwerk::FilesForProcessing.fetch(
+        paths: ["."],
+        configuration: @configuration,
+        ignore_nested_packages: true
+      )
+
+      refute_any_match(files, [File.join(@configuration.root_path, "components/sales", "**/*.rb")])
+      refute_any_match(files, [File.join(@configuration.root_path, "components/timeline", "**/*.rb")])
+    end
+
     private
 
     def assert_all_match(files, patterns)


### PR DESCRIPTION
This PR adds an option to ignore nested packages when running packwerk. This is helpful in cases where you want to parallelize checks (on CI) for packwerk packages when, for example, the root package is included. Without this option checking the root package always means checking everything (i.e., CI runs can't really parallelize packwerk check).

If unused, this doesn't change performance or behavior of what is currently there.