### PR TITLE
ignore duplicated load paths

### DIFF
--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -35,9 +35,9 @@ module Packwerk
     end
 
     def check_autoload_path_cache
-      expected = @application_load_paths
-      actual = @configuration.load_paths
-      if expected.sort == actual.sort
+      expected = Set.new(@application_load_paths)
+      actual = Set.new(@configuration.load_paths)
+      if expected == actual
         Result.new(true)
       else
         Result.new(

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -45,7 +45,7 @@ module Packwerk
       @root_path = File.expand_path(root)
       @package_paths = configs["package_paths"] || "**/"
       @custom_associations = configs["custom_associations"] || []
-      @load_paths = configs["load_paths"] || []
+      @load_paths = (configs["load_paths"] || []).uniq
       @inflections_file = File.expand_path(configs["inflections_file"] || "config/inflections.yml", @root_path)
       @parallel = configs.key?("parallel") ? configs["parallel"] : true
 

--- a/test/unit/application_validator_test.rb
+++ b/test/unit/application_validator_test.rb
@@ -36,6 +36,16 @@ module Packwerk
       assert_match %r{Extraneous load paths in file:.*components/sales/app/models}m, result.error_value
     end
 
+    test "check_autoload_path_cache succeeds on duplicated, but correct config load paths" do
+      use_template(:minimal)
+      config.expects(:load_paths).returns(["components/timeline/app/models"] * 2)
+      ApplicationLoadPaths.expects(:extract_relevant_paths).returns(["components/timeline/app/models"])
+
+      result = validator.check_autoload_path_cache
+
+      assert result.ok?, result.error_value
+    end
+
     test "check_autoload_path_cache fails on missing config load paths" do
       use_template(:minimal)
       ApplicationLoadPaths


### PR DESCRIPTION
## What are you trying to accomplish?
Fix https://github.com/Shopify/packwerk/issues/26

## What approach did you choose and why?
Just ignore dulicated load paths. They don't break anything.

I did however add a `uniq.` when initializing the config, since we don't want to slow down analysis with an unnecessarily large set of load paths.

## Type of Change

- [X] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [X] I have added tests to cover my changes.
- [X] It is safe to rollback this change.
