### PR TITLE
Specify `bundle exec` when running `packwerk` commands

### DIFF
--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -14,9 +14,9 @@ Packwerk can give feedback via continuous integration (CI) if you have it set up
 
 You can specify folders or packages in Packwerk commands for a shorter run time:
 
-     packwerk check components/your_package
+     bundle exec packwerk check components/your_package
 
-     packwerk update-deprecations components/your_package
+     bundle exec packwerk update-deprecations components/your_package
 
 _Note: You cannot specify folders or packages for `packwerk validate` because the command runs for the entire application._
 


### PR DESCRIPTION
Without `bundle exec`, I am getting this failure:

```
/Users/andyw8/.gem/ruby/3.0.2/gems/packwerk-1.3.1/lib/packwerk/package_set.rb:27:in `package_paths':
uninitialized constant #<Class:Packwerk::PackageSet>::Bundler (NameError)
```