### PR TITLE
Switch to using Gem::Version and provide a full release procedure in CONTRIBUTING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,139 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.3.2] - September 1st, 2021
+
+### Bug fixes
+
+* Fix bug in the `update-deprecations` command when the deprecation file has conflicts.
+* Ignore duplicated load paths
+
+## [1.3.1] - July 14th, 2021
+
+### Bug fixes
+
+* Fix usage of `Object#present?` that was not present in the library
+
+## [1.3.0] - July 7th, 2021
+
+### New features
+
+* Booting changes. Should only boot the Rails application when needed. Check #128 for more info.
+* Combined check and detect-stale-violations. Check #131 for more info.
+
+### Bug fixes
+
+* Constants under the public path in the root package were not correctly identified as public.
+
+### Breaking changes
+
+* Possibly breaking if spring was used with your project from the booting changes.
+* packwerk check can fail if the violations are stale or the "No offenses detected" string was checked in the output.
+
+## [1.2.0] - June 10th, 2021
+
+### New Features
+
+* Execute Packwerk commands in parallel.
+* Add support to CLI for specifying a custom offenses formatter.
+* Lazy load constant only when needed to avoid doing unnecessary work when loading the gem.
+
+### Bug Fixes
+
+None.
+
+### Breaking changes
+
+None.
+
+## [1.1.3] Apri 1st, 2021
+
+### New Features
+
+none.
+
+### Bug Fixes
+
+* https://github.com/Shopify/packwerk/issues/106 Require fileutils to fix uninitialized constant error (https://github.com/Shopify/packwerk/pull/107, @jaydorsey)
+* Support Ruby 3.0 and Rails 7 (https://github.com/Shopify/packwerk/pull/110)
+
+### Breaking changes
+
+none.
+
+## [1.1.2] - January 12th, 2021
+
+### New Features
+
+* Give more helpful error message if privatized constant can not be resolved #89 (@exterm)
+
+### Bug Fixes
+
+* Convert autoload paths to strings to resolve a Sorbet type violation #91 (@steve-low)
+* Improve types on interface implementations for stronger Sorbet type checking #92 (@samuelgiles)
+* Extract an interface out of PackWerk::OutputStyles and enforce stronger type checking #93 (@samuelgiles)
+
+### Breaking changes
+
+none.
+
+## [1.1.1] - December 9th, 2020
+
+### New Features
+
+none.
+
+### Bug Fixes
+
+* `self::SOME_CONSTANT` doesn't break the parser anymore https://github.com/Shopify/packwerk/pull/54 (thanks @shageman)
+* fixes Sorbet TypeError during `packwerk init` on fresh install  https://github.com/Shopify/packwerk/pull/77 (thanks @mikelkew)
+* fix Ruby warnings https://github.com/Shopify/packwerk/pull/82 (thanks @santib)
+* refactor `packwerk detect-stale-violations` and `packwerk update-deprecations` https://github.com/Shopify/packwerk/pull/78 (thanks again @santib)
+* fix a bug in `packwerk check` due to empty `packwerk.yml` file https://github.com/Shopify/packwerk/pull/87 (thanks @alexblackie and @jaruserickson)
+
+### Breaking changes
+
+none.
+
+## [1.1.0] - November 24th, 2020
+
+### Changes
+
+* Detect stale violations for Packwerk command https://github.com/Shopify/packwerk/pull/61
+* Support array of paths in PackageSet https://github.com/Shopify/packwerk/pull/71
+* Support providing a custom ERB parser class https://github.com/Shopify/packwerk/pull/67
+
+## [1.0.2] - November 16th, 2020
+
+### Bug fixes
+
+* Fix inflections bug that resulted in missed constant associations violations https://github.com/Shopify/packwerk/pull/53
+  * This bug fix may result in additional valid violations being found / recorded in applications with custom inflections.
+* Add missing `.realpath` that was causing validation error https://github.com/Shopify/packwerk/pull/65
+
+-------
+
+This release also includes other refactors to improve the codebase.
+
+## [1.0.1] - October 30th, 2020
+
+### This release is broken. Please use `v1.0.0`
+
+### Changes
+
+* `packwerk update` deprecated in favour of `packwerk update-deprecations`
+  * This will update messaging in `deprecated_references.yml` files
+
+### Bug Fixes
+
+* Vendored gems will no longer be included when `packwerk` is run
+
+## [1.0.0] - September 23rd, 2020
+
+Packwerk has been developed in conjunction with the Shopify codebase by several developers. This initial release extracts the existing code from the private repository into a public gem to be open sourced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+* `Packwerk::VERSION` now follows the `Gem::Version` syntax, which allows for more reliable version comparison. You need to use `Packwerk.gem_version` instead of `Packwerk::VERSION` to get the version string
+
 ## [1.3.2] - September 1st, 2021
 
 ### Bug fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,14 @@
 # Contributing
 
 ## Issue reporting
+
 * Check to make sure the same issue has not already been reported or fixed
 * Open an issue with a descriptive title and summary
 * Be clear and concise and provide as many details as possible (e.g. Ruby version, Packwerk version, etc.)
 * Include relevant code, where necessary
 
 ## Pull requests
+
 * Read and understand our [Code of Conduct](https://github.com/Shopify/packwerk/blob/main/CODE_OF_CONDUCT.md)
 * Make sure tests are added for any changes to the code
 * [Squash related commits together](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html)
@@ -15,3 +17,29 @@
 * Be descriptive about the problem and reason about the proposed solution
 * Include release notes describing the potential impact of the change in the pull request
 * Make sure there has been at least one approval from Shopify before merging
+
+## Release
+
+After your changes update [CHANGELOG.md](./CHANGELOG.md) with summary of all user facing changes.
+
+* Increment the version (`major`, `minor`, or `patch`) in [version.rb](./lib/packwerk/version.rb)
+* Commit a PR and merge to the default branch
+* Create a new gem
+
+  ```shell script
+  $ bundle exec rake build
+  > packwerk 1.3.2 built to pkg/packwerk-1.3.2.gem.
+  ```
+
+* Create github release and tag. You can do this via the [Web Interface](https://github.com/Shopify/packwerk/releases/new) or using `hub` or `gh`.
+  * Github CLI [gh_release_create](https://cli.github.com/manual/gh_release_create) :
+  
+    ```shell script
+    $ gh release create v<version> pkg/packwerk-<version>.gem
+    ```
+  
+  * Hub:
+  
+    ```shell script
+    $ hub release create -a pkg/packwerk-<version>.gem v<version>
+    ```

--- a/lib/packwerk/version.rb
+++ b/lib/packwerk/version.rb
@@ -1,6 +1,17 @@
-# typed: strong
+# typed: true
 # frozen_string_literal: true
 
 module Packwerk
-  VERSION = "1.3.2"
+  def self.gem_version
+    Gem::Version.new(VERSION::STRING)
+  end
+
+  module VERSION
+    MAJOR = 1
+    MINOR = 3
+    TINY  = 2
+    PRE   = nil
+
+    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+  end
 end

--- a/packwerk.gemspec
+++ b/packwerk.gemspec
@@ -4,7 +4,7 @@ require_relative "lib/packwerk/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "packwerk"
-  spec.version       = Packwerk::VERSION
+  spec.version       = Packwerk.gem_version
   spec.authors       = ["Shopify Inc."]
   spec.email         = ["gems@shopify.com"]
 


### PR DESCRIPTION
## What are you trying to accomplish?

As part of the Fall Packwerk cleanup Hackdays project, one of the things we identified was a lack of clear release process (even if it's just a few lines), this can be done via the Github releases page, or using the [`hub`](https://hub.github.com/) or [`gh`](https://github.com/cli/cli) command line interfaces

I also decided to switch to the `Gem::Version` style of versioning, since it's more reliable for comparissons.

## What approach did you choose and why?

The `Packwerk::VERSION` changes do make this a breaking change, since we're looking to reorganize code in the repo, this makes sense to bundle it all up together and one big `this is a breaking change Update` instead of doing multiple breaking changes.

I can't imaging that there's many (any) people doing explicit version checks on this Gem, but safety is free.

## What should reviewers focus on?

Reasons not to do this?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [x] Breaking change (fix or feature that would cause existing functionality to change)

`Packwerk::VERSION` is now a module and not a static string, please use `Packwerk.gem_version` for the same behaviour

## Checklist

- [x] I have updated the documentation accordingly.
- [-] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
