### PR TITLE
Promote bundler to a runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ PATH
       activesupport (>= 5.2)
       ast
       better_html
+      bundler
       constant_resolver
       parallel
       parser
@@ -237,7 +238,6 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  bundler
   byebug
   constant_resolver
   m

--- a/packwerk.gemspec
+++ b/packwerk.gemspec
@@ -44,8 +44,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency("constant_resolver")
   spec.add_dependency("parallel")
   spec.add_dependency("sorbet-runtime")
+  spec.add_dependency("bundler")
 
-  spec.add_development_dependency("bundler")
   spec.add_development_dependency("rake")
   spec.add_development_dependency("sorbet")
   spec.add_development_dependency("m")


### PR DESCRIPTION
## What are you trying to accomplish?

I was trying to run packwerk in a CI container without installing our whole gem bundle, but `/path/to/packwerk check` fails with `uninitialized constant #<Class:Packwerk::PackageSet>::Bundler (NameError)` if bundler isn't loaded. This suggested to me that `bundler` should be promoted from a development dependency to a runtime dependency. It looks like @rafaelfranca mentioned the same notion month or so ago here: https://github.com/Shopify/packwerk/pull/138#issuecomment-914585018.

Ideally we could have run it without `bundler` even being installed, but this will be a step forward for now.

## What approach did you choose and why?

```diff
+  spec.add_dependency("bundler")
-  spec.add_development_dependency("bundler")
```

## What should reviewers focus on?

I think this is pretty straightforward, but let me know if I'm overlooking anything.

## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly. - I don't believe a documentation change is necessary.
- [x] I have added tests to cover my changes. - If you have an idea of an effective test that I could add here, let me know.
- [x] It is safe to rollback this change. - Sure, it wouldn't be any worse than it is now. 👍 
