### PR TITLE
Bump packwerk to 2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GIT
 PATH
   remote: .
   specs:
-    packwerk (1.4.0)
+    packwerk (2.0.0)
       activesupport (>= 5.2)
       ast
       better_html

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -53,8 +53,6 @@ module Packwerk
         output_result(parse_run(args).check)
       when "detect-stale-violations"
         output_result(parse_run(args).detect_stale_violations)
-      when "update"
-        update(args)
       when "update-deprecations"
         output_result(parse_run(args).update_deprecations)
       when "validate"
@@ -112,11 +110,6 @@ module Packwerk
 
       @out.puts(result)
       success
-    end
-
-    def update(paths)
-      warn("`packwerk update` is deprecated in favor of `packwerk update-deprecations`.")
-      output_result(parse_run(paths).update_deprecations)
     end
 
     def output_result(result)

--- a/lib/packwerk/version.rb
+++ b/lib/packwerk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Packwerk
-  VERSION = "1.4.0"
+  VERSION = "2.0.0"
 end

--- a/test/integration/custom_executable_test.rb
+++ b/test/integration/custom_executable_test.rb
@@ -129,11 +129,6 @@ module Packwerk
         end
       end
 
-      test "'update' gives deprecation warning" do
-        _out, err = capture_io { assert_successful_run("update") }
-        assert_match(/`packwerk update` is deprecated/, err)
-      end
-
       private
 
       def assert_successful_run(command)


### PR DESCRIPTION
# Commits
- Remove need for custom inflections (this commit will be dropped when https://github.com/Shopify/packwerk/pull/157 lands)
- Add a changelog
- Bump version to 2.0.0

## What are you trying to accomplish?
Bump to 2.0.0 and add a changelog to help users migrate.

## What approach did you choose and why?
I made a `CHANGELOG.md` (instead of `UPGRADING.md`) because it's a pretty well understood convention for communicating various types of changes (including upgrades). I could have put the upgrade specific stuff elsewhere, but I figured it's nice to keep it on one place, for now (perhaps future, more involved upgrades can have their own guides). This also allowed me to backfill the info on `1.4.0` which enabled spring.

## What should reviewers focus on?
Let me know if the changelog entries make sense.

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [x] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes. (in a previous PR)
- [x] It is safe to rollback this change.
