### PR TITLE
[Bugfix] Enforce explicitly private constants to have `::` prefix

### DIFF
--- a/test/unit/application_validator_test.rb
+++ b/test/unit/application_validator_test.rb
@@ -113,6 +113,23 @@ module Packwerk
       )
     end
 
+    test "check_package_manifests_for_privacy returns an error for constants without `::` prefix" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("package.yml", { "enforce_privacy" => %w[::PrivateThing OtherThing] })
+
+      result = validator.check_package_manifests_for_privacy
+
+      refute result.ok?, result.error_value
+      assert_match(
+        /'OtherThing', listed in the 'enforce_privacy' option in .*package.yml, is invalid./,
+        result.error_value
+      )
+      assert_match(
+        /Private constants need to be prefixed with the top-level namespace operator `::`/,
+        result.error_value
+      )
+    end
+
     test "check_acyclic_graph returns error when package set contains circular dependencies" do
       use_template(:minimal)
       merge_into_app_yaml_file("components/sales/package.yml", { "dependencies" => ["components/timeline"] })


### PR DESCRIPTION
## What are you trying to accomplish?
Resolve issue #158 where private constants that are not honored unless prefixed with the top-level namespace operator`::`, which causes "silent failures".
This is a do-over of #160, based on @exterm 's feedback.

## What approach did you choose and why?
Enforce in `ApplicationValidator` that the constant names found in the `package.yml`s `enforce_privacy` config section be prefixed with the top-level namespace operator`::`.

## What should reviewers focus on?
Is this the correct place to enforce checking for  the`::` prefixes? 

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
