### PR TITLE
Diagnostics for packwerk memory bloat issue

### DIFF
--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -7,6 +7,9 @@ require "fileutils"
 
 # Provides String#pluralize
 require "active_support/core_ext/string"
+require 'packwerk/diagnostics'
+Packwerk::Diagnostics.log('Requiring railtie if Rails is defined', __FILE__)
+require 'packwerk/railtie' if defined?(Rails)
 
 module Packwerk
   extend ActiveSupport::Autoload

--- a/lib/packwerk/application_load_paths.rb
+++ b/lib/packwerk/application_load_paths.rb
@@ -11,7 +11,9 @@ module Packwerk
 
       sig { params(root: String, environment: String).returns(T::Array[String]) }
       def extract_relevant_paths(root, environment)
-        require_application(root, environment)
+        # I believe this can go away now that we are using `bin/rake` for this.
+        # Probably we should more explicitly separate out "this is code that Packwerk code should call, this is code that it shouldn't call"
+        # require_application(root, environment)
         all_paths = extract_application_autoload_paths
         relevant_paths = filter_relevant_paths(all_paths)
         assert_load_paths_present(relevant_paths)
@@ -54,6 +56,7 @@ module Packwerk
 
       sig { params(root: String, environment: String).void }
       def require_application(root, environment)
+        puts "The application is being required..."
         environment_file = "#{root}/config/environment"
 
         if File.file?("#{environment_file}.rb")

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -79,10 +79,10 @@ module Packwerk
     end
 
     def load_paths
-      T.unsafe(Process).fork do
-        `bin/rake packwerk:dump_rails_dependencies_to_json`
-      end
-      raise 'blah'
+      Packwerk::Diagnostics.log('About to execute "bin/rake packwerk:dump_rails_dependencies_to_json"', __FILE__)
+      puts `bin/rake packwerk:dump_rails_dependencies_to_json`
+      Packwerk::Diagnostics.log('Finished executing command.', __FILE__)
+      raise 'Diagnostic tests complete'
     end
 
     def parallel?

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -79,7 +79,10 @@ module Packwerk
     end
 
     def load_paths
-      @load_paths ||= ApplicationLoadPaths.extract_relevant_paths(@root_path, "test")
+      T.unsafe(Process).fork do
+        `bin/rake packwerk:dump_rails_dependencies_to_json`
+      end
+      raise 'blah'
     end
 
     def parallel?

--- a/lib/packwerk/diagnostics.rb
+++ b/lib/packwerk/diagnostics.rb
@@ -1,0 +1,19 @@
+# typed: strict
+
+module Packwerk
+  # A temporary class that will not land on production to help understand things.
+  class Diagnostics
+    extend T::Sig
+
+    sig { params(message: String, file_location: String).void }
+    def self.log(message, file_location)
+      # Fom https://stackoverflow.com/questions/7220896/get-current-ruby-process-memory-usage
+      pid, size = `ps ax -o pid,rss | grep -E "^[[:space:]]*#{$$}"`.strip.split.map(&:to_i)
+      if pid != Process.pid
+        raise "Something unexpected is happening: pid is #{pid} from system call but #{Process.pid} from Ruby call"
+      end
+      truncated_location = Pathname.new(file_location).basename
+      puts "Diagnostics: #{{ msg: message, file: truncated_location.to_s, pid: Process.pid, rails_is_defined: !!defined?(Rails), memory: size }}"
+    end
+  end
+end

--- a/lib/packwerk/railtie.rb
+++ b/lib/packwerk/railtie.rb
@@ -1,0 +1,13 @@
+require 'packwerk'
+require 'rails'
+
+module Packwerk
+  class Railtie < Rails::Railtie
+    railtie_name :packwerk
+
+    rake_tasks do
+      path = File.expand_path(__dir__)
+      Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }
+    end
+  end
+end

--- a/lib/packwerk/tasks/packwerk/dump_rails_dependencies_to_json.rake
+++ b/lib/packwerk/tasks/packwerk/dump_rails_dependencies_to_json.rake
@@ -1,0 +1,39 @@
+# typed: strict
+
+module Packwerk
+  # This rake task is in a class so that it can be strictly typed.
+  class TaskLoader
+    include Rake::DSL
+    extend T::Sig
+
+    sig { void }
+    def create_tasks!
+      namespace(:packwerk) do
+        #
+        # The purpose of this task is to give a rake command to output our dependencies on Rails in JSON format.
+        # The reason we want this is because we don't want our `bin/packwerk` process to load Rails, since when we run Parallel.flat_map (in `parse_run.rb`),
+        # we fork the process. `parallel` (https://github.com/grosser/parallel#processes) will create a new forked process that duplicates the memory space,
+        # meaning we have X processes each with their own copy of the Rails app. We want to avoid this, so we want to only grab what we need from Rails in a single process,
+        # and have the forked processes remain lightweight.
+        # See https://github.com/Shopify/packwerk/issues/164 for bug report associated with this.
+        #
+        # Note that by default, `spring` will automatically springify all rake tasks run via `bin/rake` (https://github.com/rails/spring#rake).
+        # So we should expect to see the fast execution of this task by the parent process.
+        #
+        # Lastly -- we do not expect clients to be using this task. It is only exposed so that the client-run `bin/packwerk` command can fork and run this command to get the STDOUT.
+        # We reflect this by running this command with `WARNING="This is private API." bin/rake packwerk:dump_rails_dependencies_to_json`. Open to other suggestions
+        # for incorporating this in a more conventionally private way.
+        #
+        desc('This prints out Rails dependencies to STDOUT.')
+        task(dump_rails_dependencies_to_json: :environment) do |_task, _args|
+          # TODO: Pass this in as an argument to the rake task
+          root_path = File.expand_path('.')
+          puts "HERE WE ARE!"
+          puts ApplicationLoadPaths.extract_relevant_paths(root_path, "test").join("\n")
+        end
+      end
+    end
+  end
+end
+
+Packwerk::TaskLoader.new.create_tasks!

--- a/lib/packwerk/tasks/packwerk/dump_rails_dependencies_to_json.rake
+++ b/lib/packwerk/tasks/packwerk/dump_rails_dependencies_to_json.rake
@@ -28,8 +28,12 @@ module Packwerk
         task(dump_rails_dependencies_to_json: :environment) do |_task, _args|
           # TODO: Pass this in as an argument to the rake task
           root_path = File.expand_path('.')
-          puts "HERE WE ARE!"
-          puts ApplicationLoadPaths.extract_relevant_paths(root_path, "test").join("\n")
+          Packwerk::Diagnostics.log('Extracting load paths and inflections', __FILE__)
+          load_paths = ApplicationLoadPaths.extract_relevant_paths(root_path, "test").count
+          inflections = ActiveSupport::Inflector.inflections.as_json
+          puts "Load path count: #{load_paths}"
+          puts "Inflections (acronyms for brevity): #{inflections['acronyms']}"
+          Packwerk::Diagnostics.log('Successfully extracted Rails data', __FILE__)
         end
       end
     end


### PR DESCRIPTION
# Summary
This PR is in response to https://github.com/Shopify/packwerk/issues/164

The goal is to assess the feasibility of *no longer* requiring Rails in the main packwerk process so that when forking the process in order to parse files over multiple CPUs, we do not create a memory bloat from cloned Rails applications.

# Approach
1) I pulled the `ApplicationLoadPaths` step into a rake task. Spring automatically springifies rake tasks (more in comments within PR) so we still get the speedup of a springified rails boot.
2) I shell out to that rake task, forking the process.
3) I run some diagnostics to confirm that the main thread continues to not have Rails loaded, and check the size of memory space to confirm.

# Results summary
This appears to have been successful. 

In the main process, our PID is 6775, the memory is about 50000KB, and Rails is not defined.
After forking, the PID is 6788 and memory is 320000KB, and Rails is defined.
Right before we dump the load paths, our PID changs again to 6798 (as a result of spring, I confirm by running `DISABLE_SPRING=1 bin/packwerk check` and note that the PID does not change again, also note the spring output confirms the PID)
Load paths and inflections are dumped correctly, and Rails is defined.
After jumping back to the main process, our PID is back to 6775, our memory back to 50000KB, and Rails is no longer defined.

The full results are at the bottom.

# Followup

If we like this approach, I'll make the following changes (sequencing TBD)
1) The dumped load paths and inflections will be read in from STDOUT (as JSON) and stored in the configuration.
2) Load paths can continue to be read with exactly the same interface (an array of strings on `Configuration`).
3) Inflections can be read via the interface that was removed here https://github.com/Shopify/packwerk/pull/157. Note, importantly, that this interface is now simply an implementation detail, and it is not exposed to the client. It's just used as a wrapper around the JSON, similar to how it previously read the loaded `inflections.yml` file previously.
4) Release 2.1.0. It should not technically be a breaking change, because it should *just work* for the client. However, we would recommend the client unspringify their `bin/packwerk` binstub, since they won't get the bug fix unless they do that.
5) Update the docs to remove the recommendation to springify the binstub, and instead encourage the general usage of spring to speed up the forked Rails process.

# Results of diagnostic check
```
DevSpace(ae-use-local-packwerk) ./ $ bin/packwerk check
fatal: not a git repository (or any of the parent directories): .git
Diagnostics: {:msg=>"Requiring railtie if Rails is defined", :file=>"packwerk.rb", :pid=>6775, :rails_is_defined=>false, :memory=>49516}
📦 Packwerk is inspecting 38010 files
Diagnostics: {:msg=>"About to execute \"bin/rake packwerk:dump_rails_dependencies_to_json\"", :file=>"configuration.rb", :pid=>6775, :rails_is_defined=>false, :memory=>54676}
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
Running via Spring preloader in process 6798
Diagnostics: {:msg=>"Requiring railtie if Rails is defined", :file=>"packwerk.rb", :pid=>6788, :rails_is_defined=>true, :memory=>326392}
[TEST PROF INFO] Spring detected
Diagnostics: {:msg=>"Extracting load paths and inflections", :file=>"dump_rails_dependencies_to_json.rake", :pid=>6798, :rails_is_defined=>true, :memory=>522176}
Load path count: 753
Inflections (acronyms for brevity): {"ssnvs"=>"SSNVS", "noc"=>"NOC", "svb"=>"SVB", "pgp"=>"PGP", "pnc"=>"PNC", "bai"=>"BAI", "hi"=>"HI", "csv"=>"CSV", "epd"=>"EPD", "tdi"=>"TDI", "sdi"=>"SDI"}
Diagnostics: {:msg=>"Successfully extracted Rails data", :file=>"dump_rails_dependencies_to_json.rake", :pid=>6798, :rails_is_defined=>true, :memory=>522348}
Diagnostics: {:msg=>"Finished executing command.", :file=>"configuration.rb", :pid=>6775, :rails_is_defined=>false, :memory=>54512}
Traceback (most recent call last):
        14: from bin/packwerk:29:in `<main>'
        13: from bin/packwerk:29:in `load'
        12: from /var/www/components/packwerk/exe/packwerk:12:in `<top (required)>'
        11: from /usr/local/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9291/lib/types/private/methods/_methods.rb:269:in `block in _on_method_added'
        10: from /usr/local/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9291/lib/types/private/methods/call_validation.rb:161:in `validate_call'
         9: from /usr/local/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9291/lib/types/private/methods/call_validation.rb:161:in `bind_call'
         8: from /var/www/components/packwerk/lib/packwerk/cli.rb:40:in `run'
         7: from /usr/local/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9291/lib/types/private/methods/_methods.rb:269:in `block in _on_method_added'
         6: from /usr/local/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9291/lib/types/private/methods/call_validation.rb:161:in `validate_call'
         5: from /usr/local/bundle/ruby/2.7.0/gems/sorbet-runtime-0.5.9291/lib/types/private/methods/call_validation.rb:161:in `bind_call'
         4: from /var/www/components/packwerk/lib/packwerk/cli.rb:53:in `execute_command'
         3: from /var/www/components/packwerk/lib/packwerk/parse_run.rb:45:in `check'
         2: from /var/www/components/packwerk/lib/packwerk/parse_run.rb:62:in `find_offenses'
         1: from /var/www/components/packwerk/lib/packwerk/run_context.rb:30:in `from_configuration'
/var/www/components/packwerk/lib/packwerk/configuration.rb:85:in `load_paths': Diagnostic tests complete (RuntimeError)
```