### PR TITLE
Add caching to reduce runtime by 85% (all files) and 42% (single file)

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -100,6 +100,10 @@ end
 Packwerk::Parsers::Factory.instance.erb_parser_class = CustomParser
 ```
 
+## Using the experimental cache
+Packwerk ships with an experimental cache to help speed up file parsing. You can run packwerk with `EXPERIMENTAL_PACKWERK_CACHE=1 bin/packwerk ...` to turn this on.
+This will write to `tmp/cache/packwerk`.
+
 ## Validating the package system
 
 There are some criteria that an application must meet in order to have a valid package system. These criteria include having a valid autoload path cache, package definition files, and application folder structure. The dependency graph within the package system also has to be acyclic.

--- a/USAGE.md
+++ b/USAGE.md
@@ -102,7 +102,7 @@ Packwerk::Parsers::Factory.instance.erb_parser_class = CustomParser
 
 ## Using the experimental cache
 Packwerk ships with an experimental cache to help speed up file parsing. You can run packwerk with `EXPERIMENTAL_PACKWERK_CACHE=1 bin/packwerk ...` to turn this on.
-This will write to `tmp/cache/packwerk`.
+This will write to `tmp/cache/packwerk`. It is not recommended to use the cache in your test suite, as this cache is experimental and its best to ensure CI is running with no cache.
 
 ## Validating the package system
 

--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -15,6 +15,7 @@ module Packwerk
   autoload :ApplicationValidator
   autoload :AssociationInspector
   autoload :OffenseCollection
+  autoload :Cache
   autoload :Cli
   autoload :Configuration
   autoload :ConstantDiscovery

--- a/lib/packwerk/cache.rb
+++ b/lib/packwerk/cache.rb
@@ -22,14 +22,18 @@ module Packwerk
       ).returns(T::Array[RunContext::ProcessedFileResult])
     end
     def self.with_cache(files, root_path:, &block)
-      cache = Private.new(files: files, root_path: root_path)
-      uncached_files = cache.uncached_files
-      Debug.out("Using cache - #{cache.cached_file_count} files are cached, #{uncached_files.count} are not")
-      Debug.out("First 5 uncached files: #{uncached_files.first(5).inspect}")
-      uncached_results = block.call(uncached_files)
-      cache.cache_results(uncached_files, uncached_results)
+      if ENV['EXPERIMENTAL_PACKWERK_CACHE']
+        cache = Private.new(files: files, root_path: root_path)
+        uncached_files = cache.uncached_files
+        Debug.out("Using cache - #{cache.cached_file_count} files are cached, #{uncached_files.count} are not")
+        Debug.out("First 5 uncached files: #{uncached_files.first(5).inspect}")
+        uncached_results = block.call(uncached_files)
+        cache.cache_results(uncached_files, uncached_results)
 
-      uncached_results + cache.cached_results
+        uncached_results + cache.cached_results
+      else
+        block.call(files)
+      end
     end
 
     sig { void }

--- a/lib/packwerk/cache.rb
+++ b/lib/packwerk/cache.rb
@@ -69,6 +69,7 @@ module Packwerk
         # Whether or not the cache is hit is based on the `cache_digest` key within each file (more below).
         files.each do |filename|
           filecache_path = CACHE_DIR.join(digest_for_string(filename))
+
           # We take the basename which is the file name digest
           if filecache_path.exist?
             cache_contents = T.let(YAML.load(filecache_path.read), CacheContents)
@@ -76,9 +77,7 @@ module Packwerk
               @cache[filename] = cache_contents
               @cached_files << filename
             else
-              # Bust the cache so our cache directory doesn't grow so much faster than our codebase
               @uncached_files << filename
-              filecache_path.delete
             end
           else
             @uncached_files << filename
@@ -109,6 +108,7 @@ module Packwerk
       sig { params(uncached_files: T::Array[String], uncached_results: T::Array[RunContext::ProcessedFileResult]).void }
       def cache_results(uncached_files, uncached_results)
         Debug.out("Storing results in cache by digest...")
+
         uncached_results.each do |result|
           cache_contents = CacheContents.new(
             cache_digest: digest_for_result(result),

--- a/lib/packwerk/cache.rb
+++ b/lib/packwerk/cache.rb
@@ -9,17 +9,18 @@ module Packwerk
       params(
         files: T::Array[String],
         root_path: String,
-        block: T.proc.params(untracked_files: T::Array[String]).returns(T::Array[Offense])
-      ).returns(T::Array[Offense])
+        block: T.proc.params(untracked_files: T::Array[String]).returns(T::Array[RunContext::ProcessedFileResult])
+      ).returns(T::Array[RunContext::ProcessedFileResult])
     end
     def self.with_cache(files, root_path:, &block)
       cache = Private.new(root_path: root_path)
-      uncached_files = cache.uncached_files(files)
+      uncached_files = cache.files_without_cache_hits(files)
       puts("Using cache - #{cache.cached_file_count} files are cached, #{uncached_files.count} are not")
-      puts "First 5 uncached files: #{uncached_files.first(5).inspect}"
-      uncached_offenses = block.call(uncached_files)
-      cache.cache_results(uncached_files, uncached_offenses)
-      uncached_offenses + cache.cached_offenses
+      puts("First 5 uncached files: #{uncached_files.first(5).inspect}")
+      uncached_results = block.call(uncached_files)
+      cache.cache_results(uncached_files, uncached_results)
+
+      uncached_results + cache.cached_results
     end
 
     class Private
@@ -28,21 +29,33 @@ module Packwerk
       CACHE_DIR = T.let(Pathname.new("tmp/cache/packwerk"), Pathname)
       CACHE_FILE = T.let(CACHE_DIR.join("all.txt"), Pathname)
 
+      class CacheContents < T::Struct
+        const :cache_digest, String
+        const :result, RunContext::ProcessedFileResult
+      end
+
+      CACHE_SHAPE = T.type_alias do
+        T::Hash[
+          String,
+          CacheContents
+        ]
+      end
+
       sig { params(root_path: String).void }
       def initialize(root_path:)
         FileUtils.mkdir_p(CACHE_DIR)
-        @cache = T.let({}, T::Hash[String, T::Array[Offense]])
+        @cache = T.let({}, CACHE_SHAPE)
         if CACHE_FILE.exist?
-          @cache = T.let(YAML.load(CACHE_FILE.read), T::Hash[String, T::Array[Offense]])
+          @cache = T.let(YAML.load(CACHE_FILE.read), CACHE_SHAPE)
         end
 
         @root_path = root_path
         @files_by_digest = T.let({}, T::Hash[String, String])
       end
 
-      sig { returns(T::Array[Offense]) }
-      def cached_offenses
-        @cache.values.flatten.compact
+      sig { returns(T::Array[RunContext::ProcessedFileResult]) }
+      def cached_results
+        @cache.values.map(&:result)
       end
 
       sig { returns(Integer) }
@@ -51,29 +64,91 @@ module Packwerk
       end
 
       sig { params(files: T::Array[String]).returns(T::Array[String]) }
-      def uncached_files(files)
+      def files_without_cache_hits(files)
         files.select do |file|
-          @cache[digest_for_file(file)].nil?
+          if File.exist?(file)
+            current_entry = @cache[file]
+            if current_entry.nil?
+              true
+            else
+
+              cached_digest = current_entry.cache_digest
+              current_digest = digest_for_result(current_entry.result)
+              current_digest != cached_digest
+            end
+          else
+            true
+          end
         end
       end
 
-      sig { params(uncached_files: T::Array[String], uncached_offenses: T::Array[Offense]).void }
-      def cache_results(uncached_files, uncached_offenses)
-        uncached_offenses_by_file = uncached_offenses.group_by(&:file)
-        puts("Storing offenses in cache by digest...")
+      sig { params(uncached_files: T::Array[String], uncached_results: T::Array[RunContext::ProcessedFileResult]).void }
+      def cache_results(uncached_files, uncached_results)
+        uncached_results_by_file = uncached_results.group_by(&:file)
+        puts("Storing results in cache by digest...")
         uncached_files.each do |file|
-          relative_path = Pathname.new(file).relative_path_from(@root_path)
-          # Offense#file returns a relative path, but the uncached files are a list of absolute paths
-          @cache[digest_for_file(file)] = uncached_offenses_by_file[relative_path] || []
+          result = T.must(uncached_results_by_file.fetch(file).first)
+          cache_contents = CacheContents.new(
+            cache_digest: digest_for_result(result),
+            result: result
+          )
+          @cache[file] = cache_contents
         end
         puts("Dumping into cache...")
         CACHE_FILE.write(YAML.dump(@cache))
         puts("Finished dumping into cache...")
       end
 
+      sig { params(result: RunContext::ProcessedFileResult).returns(String) }
+      def digest_for_result(result)
+        all_inputs_to_digest = []
+        #
+        # Each file can create one "cache input." A cache input should contain ALL of the
+        # inputs needed to know if we can reliably use the cached results for a given file.
+        #
+        # Remember that when a file is read, we look for each class, constant, and module,
+        # and then use the ConstantResolver to find the source location of each constant.
+        # We then find the source pack, and based on its configuration, we determine if there
+        # is an result or not
+        #
+        # Therefore to know if we can reliably use the cached results, we need to know
+        # if any of the following have changed:
+        # 1) The entire file contents
+        #   - The contents are what dictate what references there are, and therefore what results there are.
+        #     If the file contents change, we need to reparse the file
+        #
+        all_inputs_to_digest << digest_for_file(result.file)
+        # 2) The file contents of all of the source locations of all of the Packwerk::Reference.
+        #   - Note that packwerk prevents ambiguous definitions, so for classes and modules, a "cache hit"
+        #     here is simply that those files still exist. If they don't, it means the file has been moved and another
+        #     pack now defines that class/module. However, for a constant, we need to confirm that the source location
+        #     digest is the same, because the constant can be moved without file names changing.
+        result.references.each do |reference|
+          all_inputs_to_digest << if File.exist?(reference.constant.location)
+            digest_for_file(reference.constant.location)
+          else
+            "constant location does not exist"
+          end
+        end
+        # 3) The file contents of the package YMLs in any of the Packwerk::Reference
+        #   - We need this because something can be a reference but not an result, and simply changing
+        #     The setting for enforce_privacy can turn that Reference into an RunContext::ProcessedFileResult.
+        result.references.each do |reference|
+          all_inputs_to_digest << if reference.constant.package.yml.exist?
+            digest_for_file(reference.constant.package.yml.to_s)
+          else
+            "constant pack does not exist"
+          end
+        end
+
+        Digest::MD5.hexdigest(all_inputs_to_digest.inspect)
+      end
+
       sig { params(file: String).returns(String) }
       def digest_for_file(file)
-        @files_by_digest[file] ||= Digest::SHA256.hexdigest(File.read(file))
+        # MD5 appears to be the fastest
+        # https://gist.github.com/morimori/1330095
+        @files_by_digest[file] ||= Digest::MD5.hexdigest(File.read(file))
       end
     end
 

--- a/lib/packwerk/cache.rb
+++ b/lib/packwerk/cache.rb
@@ -83,10 +83,10 @@ module Packwerk
         # The cache associated with each file is named by the digest of the file name (not contents).
         # Whether or not the cache is hit is based on the `cache_digest` key within each file (more below).
         # enumerator = parallel ? Parallel.map(files) : files.map
-        if parallel
-          @cache = Parallel.map(files, &get_cached_result).compact.to_h
+        @cache = if parallel
+          Parallel.map(files, &get_cached_result).compact.to_h
         else
-          @cache = files.map(&get_cached_result).compact.to_h
+          files.map(&get_cached_result).compact.to_h
         end
 
         @cached_files = @cache.keys

--- a/lib/packwerk/cache.rb
+++ b/lib/packwerk/cache.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 # typed: strict
 
+#
+# There are some known bugs in this cache:
+# 1) The cache should be busted if the contents of `packwerk.yml` change, since custom associations can affect what is considered a violation
+# 2) The cache should be busted if inflections change.
+#
+# In practice, we think these things change rarely enough that when they do change, a user can just run `rm -rf tmp/cache/packwerk` to reset the cache
+#
 module Packwerk
   class Cache
     extend T::Sig

--- a/lib/packwerk/cache.rb
+++ b/lib/packwerk/cache.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+# typed: strict
+
+module Packwerk
+  class Cache
+    extend T::Sig
+
+    sig do
+      params(
+        files: T::Array[String],
+        root_path: String,
+        block: T.proc.params(untracked_files: T::Array[String]).returns(T::Array[Offense])
+      ).returns(T::Array[Offense])
+    end
+    def self.with_cache(files, root_path:, &block)
+      cache = Private.new(root_path: root_path)
+      uncached_files = cache.uncached_files(files)
+      puts("Using cache - #{cache.cached_file_count} files are cached, #{uncached_files.count} are not")
+      puts "First 5 uncached files: #{uncached_files.first(5).inspect}"
+      uncached_offenses = block.call(uncached_files)
+      cache.cache_results(uncached_files, uncached_offenses)
+      uncached_offenses + cache.cached_offenses
+    end
+
+    class Private
+      extend T::Sig
+
+      CACHE_DIR = T.let(Pathname.new("tmp/cache/packwerk"), Pathname)
+      CACHE_FILE = T.let(CACHE_DIR.join("all.txt"), Pathname)
+
+      sig { params(root_path: String).void }
+      def initialize(root_path:)
+        FileUtils.mkdir_p(CACHE_DIR)
+        @cache = T.let({}, T::Hash[String, T::Array[Offense]])
+        if CACHE_FILE.exist?
+          @cache = T.let(YAML.load(CACHE_FILE.read), T::Hash[String, T::Array[Offense]])
+        end
+
+        @root_path = root_path
+        @files_by_digest = T.let({}, T::Hash[String, String])
+      end
+
+      sig { returns(T::Array[Offense]) }
+      def cached_offenses
+        @cache.values.flatten.compact
+      end
+
+      sig { returns(Integer) }
+      def cached_file_count
+        @cache.keys.count
+      end
+
+      sig { params(files: T::Array[String]).returns(T::Array[String]) }
+      def uncached_files(files)
+        files.select do |file|
+          @cache[digest_for_file(file)].nil?
+        end
+      end
+
+      sig { params(uncached_files: T::Array[String], uncached_offenses: T::Array[Offense]).void }
+      def cache_results(uncached_files, uncached_offenses)
+        uncached_offenses_by_file = uncached_offenses.group_by(&:file)
+        puts("Storing offenses in cache by digest...")
+        uncached_files.each do |file|
+          relative_path = Pathname.new(file).relative_path_from(@root_path)
+          # Offense#file returns a relative path, but the uncached files are a list of absolute paths
+          @cache[digest_for_file(file)] = uncached_offenses_by_file[relative_path] || []
+        end
+        puts("Dumping into cache...")
+        CACHE_FILE.write(YAML.dump(@cache))
+        puts("Finished dumping into cache...")
+      end
+
+      sig { params(file: String).returns(String) }
+      def digest_for_file(file)
+        @files_by_digest[file] ||= Digest::SHA256.hexdigest(File.read(file))
+      end
+    end
+
+    private_constant :Private
+  end
+end

--- a/lib/packwerk/package.rb
+++ b/lib/packwerk/package.rb
@@ -44,18 +44,26 @@ module Packwerk
       path.start_with?(@name)
     end
 
+    sig { returns(Pathname) }
+    def directory
+      @directory = T.let(@directory, T.nilable(Pathname))
+      @directory ||= if root?
+        Pathname.new(".")
+      else
+        Pathname.new(@name)
+      end
+    end
+
+    sig { returns(Pathname) }
+    def yml
+      @yml = T.let(@yml, T.nilable(Pathname))
+      @yml ||= directory.join(PackageSet::PACKAGE_CONFIG_FILENAME)
+    end
+
     sig { returns(String) }
     def public_path
       @public_path = T.let(@public_path, T.nilable(String))
-      @public_path ||= begin
-        unprefixed_public_path = user_defined_public_path || "app/public/"
-
-        if root?
-          unprefixed_public_path
-        else
-          File.join(@name, unprefixed_public_path)
-        end
-      end
+      @public_path ||= directory.join(user_defined_public_path || "app/public/").to_s
     end
 
     sig { params(path: String).returns(T::Boolean) }

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -70,7 +70,7 @@ module Packwerk
       end
 
       execution_time = Benchmark.realtime do
-        all_results = Cache.with_cache(@files, root_path: @configuration.root_path) do |uncached_files|
+        all_results = Cache.with_cache(@files, parallel: @configuration.parallel?, root_path: @configuration.root_path) do |uncached_files|
           if @configuration.parallel?
             Parallel.flat_map(uncached_files, &process_file)
           else

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -70,10 +70,12 @@ module Packwerk
       end
 
       execution_time = Benchmark.realtime do
-        all_results = if @configuration.parallel?
-          Parallel.flat_map(@files, &process_file)
-        else
-          serial_find_results(&process_file)
+        all_results = Cache.with_cache(@files, root_path: @configuration.root_path) do |uncached_files|
+          if @configuration.parallel?
+            Parallel.flat_map(uncached_files, &process_file)
+          else
+            serial_find_offenses(uncached_files, &process_file)
+          end
         end
       end
 

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -70,7 +70,8 @@ module Packwerk
       end
 
       execution_time = Benchmark.realtime do
-        all_results = Cache.with_cache(@files, parallel: @configuration.parallel?, root_path: @configuration.root_path) do |uncached_files|
+        all_results = Cache.with_cache(@files, parallel: @configuration.parallel?,
+root_path: @configuration.root_path) do |uncached_files|
           if @configuration.parallel?
             Parallel.flat_map(uncached_files, &process_file)
           else

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -74,7 +74,7 @@ module Packwerk
           if @configuration.parallel?
             Parallel.flat_map(uncached_files, &process_file)
           else
-            serial_find_offenses(uncached_files, &process_file)
+            serial_find_results(uncached_files, &process_file)
           end
         end
       end
@@ -85,9 +85,9 @@ module Packwerk
       offense_collection
     end
 
-    def serial_find_results
+    def serial_find_results(files)
       all_results = T.let([], T::Array[RunContext::ProcessedFileResult])
-      @files.each do |path|
+      files.each do |path|
         result = yield path
         all_results << result
       end

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -62,11 +62,12 @@ module Packwerk
       references_and_offenses = file_processor.call(file)
       reference_checker = ReferenceChecking::ReferenceChecker.new(checkers)
       offenses = references_and_offenses.flat_map { |reference| reference_checker.call(reference) }
+      references = references_and_offenses.select { |r| r.is_a?(Reference) }
 
       ProcessedFileResult.new(
         file: file,
         offenses: offenses,
-        references: references_and_offenses.select{|r| r.is_a?(Reference)}
+        references: T.cast(references, T::Array[Reference])
       )
     end
 

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -60,7 +60,6 @@ module Packwerk
     sig { params(file: String).returns(ProcessedFileResult) }
     def process_file(file:)
       references_and_offenses = file_processor.call(file)
-
       reference_checker = ReferenceChecking::ReferenceChecker.new(checkers)
       offenses = references_and_offenses.flat_map { |reference| reference_checker.call(reference) }
 

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -59,10 +59,16 @@ module Packwerk
 
     sig { params(file: String).returns(ProcessedFileResult) }
     def process_file(file:)
-      references = file_processor.call(file)
+      references_and_offenses = file_processor.call(file)
 
       reference_checker = ReferenceChecking::ReferenceChecker.new(checkers)
-      references.flat_map { |reference| reference_checker.call(reference) }
+      offenses = references_and_offenses.flat_map { |reference| reference_checker.call(reference) }
+
+      ProcessedFileResult.new(
+        file: file,
+        offenses: offenses,
+        references: references_and_offenses.select{|r| r.is_a?(Reference)}
+      )
     end
 
     private

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -59,21 +59,10 @@ module Packwerk
 
     sig { params(file: String).returns(ProcessedFileResult) }
     def process_file(file:)
-      cache_dir = Pathname.new('tmp/cache/packwerk')
-      FileUtils.mkdir_p(cache_dir)
+      references = file_processor.call(file)
 
-      file_digest = Digest::SHA256.hexdigest(File.read(file))
-      file_cache = cache_dir.join(file_digest)
-      if file_cache.exist?
-        YAML.load(file_cache.read)
-      else
-        references = file_processor.call(file)
-        reference_checker = ReferenceChecking::ReferenceChecker.new(checkers)
-        offenses = references.flat_map { |reference| reference_checker.call(reference) }
-
-        file_cache.open('w') { |file| file.write YAML.dump(offenses)}
-        offenses
-      end
+      reference_checker = ReferenceChecking::ReferenceChecker.new(checkers)
+      references.flat_map { |reference| reference_checker.call(reference) }
     end
 
     private

--- a/test/unit/cache_test.rb
+++ b/test/unit/cache_test.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+require "test_helper"
+require "rails_test_helper"
+
+module Packwerk
+  class CacheTest < Minitest::Test
+    include FactoryHelper
+    include ApplicationFixtureHelper
+
+    setup do
+      ENV['EXPERIMENTAL_PACKWERK_CACHE'] = '1'
+      setup_application_fixture
+    end
+
+    teardown do
+      teardown_application_fixture
+      Cache.bust_cache!
+    end
+
+    test "#update_deprecations writes to the cache" do
+      use_template(:minimal)
+      offense = Offense.new(file: "path/of/exile.rb", message: "something")
+
+      processed_file_result = RunContext::ProcessedFileResult.new(
+        file: build_reference.relative_path,
+        references: [build_reference],
+        offenses: [offense],
+      )
+
+      RunContext.any_instance.stubs(:process_file).returns(processed_file_result)
+      OffenseCollection.any_instance.expects(:dump_deprecated_references_files).once
+
+      parse_run = Packwerk::ParseRun.new(files: ["path/of/exile.rb"], configuration: Configuration.from_path)
+      result = parse_run.update_deprecations
+
+      cache_files = Pathname.pwd.join(Cache::CACHE_DIR).glob('**')
+      assert_equal cache_files.count, 1
+
+      cached_result = YAML.load(cache_files.first.read).result
+      assert_equal cached_result.references, processed_file_result.references
+      assert_equal cached_result.offenses.count, processed_file_result.offenses.count
+      assert_equal cached_result.offenses.first.message, processed_file_result.offenses.first.message
+      assert_equal cached_result.file, processed_file_result.file
+    end
+
+    test "#update_deprecations reads from the cache if there is a cache hit" do
+      use_template(:minimal)
+      offense = Offense.new(file: "path/of/exile.rb", message: "something")
+
+      processed_file_result = RunContext::ProcessedFileResult.new(
+        file: "path/of/exile.rb",
+        references: [build_reference],
+        offenses: [offense],
+      )
+
+      # We expect process file once, but dump twice
+      RunContext.any_instance.expects(:process_file).returns(processed_file_result).once
+      OffenseCollection.any_instance.expects(:dump_deprecated_references_files).twice
+
+      configuration = Configuration.new({ "parallel" => false })
+      parse_run = Packwerk::ParseRun.new(files: ["path/of/exile.rb"], configuration: configuration)
+
+      result = parse_run.update_deprecations
+      result = parse_run.update_deprecations
+    end
+
+    test "#update_deprecations does not read from the cache if the constant package YML has changed" do
+      use_template(:minimal)
+      offense = Offense.new(file: "path/of/exile.rb", message: "something")
+
+      reference = build_reference
+      processed_file_result = RunContext::ProcessedFileResult.new(
+        file: "path/of/exile.rb",
+        references: [reference],
+        offenses: [offense],
+      )
+
+      RunContext.any_instance.expects(:process_file).returns(processed_file_result).twice
+      OffenseCollection.any_instance.expects(:dump_deprecated_references_files).twice
+
+      configuration = Configuration.new({ "parallel" => false })
+      parse_run = Packwerk::ParseRun.new(files: ["path/of/exile.rb"], configuration: configuration)
+
+      result = parse_run.update_deprecations
+      FileUtils.mkdir_p(reference.constant.package.directory)
+      reference.constant.package.yml.write("some change!")
+
+      result = parse_run.update_deprecations
+    end
+
+    test "#update_deprecations does not read from the cache if the constant file location has changed" do
+      use_template(:minimal)
+      offense = Offense.new(file: "path/of/exile.rb", message: "something")
+
+      reference = build_reference
+      processed_file_result = RunContext::ProcessedFileResult.new(
+        file: "path/of/exile.rb",
+        references: [reference],
+        offenses: [offense],
+      )
+
+      RunContext.any_instance.expects(:process_file).returns(processed_file_result).twice
+      OffenseCollection.any_instance.expects(:dump_deprecated_references_files).twice
+
+      configuration = Configuration.new({ "parallel" => false })
+      parse_run = Packwerk::ParseRun.new(files: ["path/of/exile.rb"], configuration: configuration)
+
+      result = parse_run.update_deprecations
+      constant_pathname = Pathname.new(reference.constant.location)
+      FileUtils.mkdir_p(constant_pathname.dirname)
+      constant_pathname.write("some change!")
+
+      result = parse_run.update_deprecations
+    end
+
+    test "#update_deprecations does not read from the cache if the file itself has changed" do
+      use_template(:minimal)
+      offense = Offense.new(file: "path/of/exile.rb", message: "something")
+
+      reference = build_reference
+      processed_file_result = RunContext::ProcessedFileResult.new(
+        file: "path/of/exile.rb",
+        references: [reference],
+        offenses: [offense],
+      )
+
+      RunContext.any_instance.expects(:process_file).returns(processed_file_result).twice
+      OffenseCollection.any_instance.expects(:dump_deprecated_references_files).twice
+
+      configuration = Configuration.new({ "parallel" => false })
+      parse_run = Packwerk::ParseRun.new(files: ["path/of/exile.rb"], configuration: configuration)
+
+      result = parse_run.update_deprecations
+      file_path = Pathname.new('path/of/exile.rb')
+      FileUtils.mkdir_p(file_path.dirname)
+      file_path.write("some change!")
+
+      result = parse_run.update_deprecations
+    end
+
+    test "#update_deprecations will delete the old cache if it no longer is a hit for the file" do
+      use_template(:minimal)
+      offense = Offense.new(file: "path/of/exile.rb", message: "something")
+
+      reference = build_reference
+      processed_file_result = RunContext::ProcessedFileResult.new(
+        file: "path/of/exile.rb",
+        references: [reference],
+        offenses: [offense],
+      )
+
+      RunContext.any_instance.expects(:process_file).returns(processed_file_result).twice
+      OffenseCollection.any_instance.expects(:dump_deprecated_references_files).twice
+
+      configuration = Configuration.new({ "parallel" => false })
+      parse_run = Packwerk::ParseRun.new(files: ["path/of/exile.rb"], configuration: configuration)
+
+      cache_files = Pathname.pwd.join(Cache::CACHE_DIR).glob('**')
+      assert_equal cache_files.count, 0
+
+      result = parse_run.update_deprecations
+
+      cache_files = Pathname.pwd.join(Cache::CACHE_DIR).glob('**')
+      assert_equal cache_files.count, 1
+      
+      file_path = Pathname.new('path/of/exile.rb')
+      FileUtils.mkdir_p(file_path.dirname)
+      file_path.write("some change!")
+      
+      result = parse_run.update_deprecations
+
+      new_cache_files = Pathname.pwd.join(Cache::CACHE_DIR).glob('**')
+      assert_equal cache_files.count, 1
+      refute_equal YAML.load(new_cache_files.first.read), YAML.load(cache_files.first.read)
+    end
+  end
+end

--- a/test/unit/cache_test.rb
+++ b/test/unit/cache_test.rb
@@ -8,7 +8,7 @@ module Packwerk
     include ApplicationFixtureHelper
 
     setup do
-      ENV['EXPERIMENTAL_PACKWERK_CACHE'] = '1'
+      ENV["EXPERIMENTAL_PACKWERK_CACHE"] = "1"
       setup_application_fixture
     end
 
@@ -31,9 +31,9 @@ module Packwerk
       OffenseCollection.any_instance.expects(:dump_deprecated_references_files).once
 
       parse_run = Packwerk::ParseRun.new(files: ["path/of/exile.rb"], configuration: Configuration.from_path)
-      result = parse_run.update_deprecations
+      parse_run.update_deprecations
 
-      cache_files = Pathname.pwd.join(Cache::CACHE_DIR).glob('**')
+      cache_files = Pathname.pwd.join(Cache::CACHE_DIR).glob("**")
       assert_equal cache_files.count, 1
 
       cached_result = YAML.load(cache_files.first.read).result
@@ -60,8 +60,8 @@ module Packwerk
       configuration = Configuration.new({ "parallel" => false })
       parse_run = Packwerk::ParseRun.new(files: ["path/of/exile.rb"], configuration: configuration)
 
-      result = parse_run.update_deprecations
-      result = parse_run.update_deprecations
+      parse_run.update_deprecations
+      parse_run.update_deprecations
     end
 
     test "#update_deprecations does not read from the cache if the constant package YML has changed" do
@@ -81,11 +81,11 @@ module Packwerk
       configuration = Configuration.new({ "parallel" => false })
       parse_run = Packwerk::ParseRun.new(files: ["path/of/exile.rb"], configuration: configuration)
 
-      result = parse_run.update_deprecations
+      parse_run.update_deprecations
       FileUtils.mkdir_p(reference.constant.package.directory)
       reference.constant.package.yml.write("some change!")
 
-      result = parse_run.update_deprecations
+      parse_run.update_deprecations
     end
 
     test "#update_deprecations does not read from the cache if the constant file location has changed" do
@@ -105,12 +105,12 @@ module Packwerk
       configuration = Configuration.new({ "parallel" => false })
       parse_run = Packwerk::ParseRun.new(files: ["path/of/exile.rb"], configuration: configuration)
 
-      result = parse_run.update_deprecations
+      parse_run.update_deprecations
       constant_pathname = Pathname.new(reference.constant.location)
       FileUtils.mkdir_p(constant_pathname.dirname)
       constant_pathname.write("some change!")
 
-      result = parse_run.update_deprecations
+      parse_run.update_deprecations
     end
 
     test "#update_deprecations does not read from the cache if the file itself has changed" do
@@ -130,12 +130,12 @@ module Packwerk
       configuration = Configuration.new({ "parallel" => false })
       parse_run = Packwerk::ParseRun.new(files: ["path/of/exile.rb"], configuration: configuration)
 
-      result = parse_run.update_deprecations
-      file_path = Pathname.new('path/of/exile.rb')
+      parse_run.update_deprecations
+      file_path = Pathname.new("path/of/exile.rb")
       FileUtils.mkdir_p(file_path.dirname)
       file_path.write("some change!")
 
-      result = parse_run.update_deprecations
+      parse_run.update_deprecations
     end
 
     test "#update_deprecations will delete the old cache if it no longer is a hit for the file" do
@@ -155,21 +155,21 @@ module Packwerk
       configuration = Configuration.new({ "parallel" => false })
       parse_run = Packwerk::ParseRun.new(files: ["path/of/exile.rb"], configuration: configuration)
 
-      cache_files = Pathname.pwd.join(Cache::CACHE_DIR).glob('**')
+      cache_files = Pathname.pwd.join(Cache::CACHE_DIR).glob("**")
       assert_equal cache_files.count, 0
 
-      result = parse_run.update_deprecations
+      parse_run.update_deprecations
 
-      cache_files = Pathname.pwd.join(Cache::CACHE_DIR).glob('**')
+      cache_files = Pathname.pwd.join(Cache::CACHE_DIR).glob("**")
       assert_equal cache_files.count, 1
-      
-      file_path = Pathname.new('path/of/exile.rb')
+
+      file_path = Pathname.new("path/of/exile.rb")
       FileUtils.mkdir_p(file_path.dirname)
       file_path.write("some change!")
-      
-      result = parse_run.update_deprecations
 
-      new_cache_files = Pathname.pwd.join(Cache::CACHE_DIR).glob('**')
+      parse_run.update_deprecations
+
+      new_cache_files = Pathname.pwd.join(Cache::CACHE_DIR).glob("**")
       assert_equal cache_files.count, 1
       refute_equal YAML.load(new_cache_files.first.read), YAML.load(cache_files.first.read)
     end

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -62,7 +62,7 @@ module Packwerk
       configuration.stubs(load_paths: [])
 
       result = RunContext::ProcessedFileResult.new(
-        file: 'path/of/exile.rb',
+        file: "path/of/exile.rb",
         references: [build_reference],
         offenses: [offense],
       )

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -6,6 +6,8 @@ require "rails_test_helper"
 
 module Packwerk
   class CliTest < Minitest::Test
+    include FactoryHelper
+
     setup do
       @err_out = StringIO.new
       @cli = ::Packwerk::Cli.new(err_out: @err_out)
@@ -25,7 +27,14 @@ module Packwerk
 
       configuration = Configuration.new({ "parallel" => false })
       configuration.stubs(load_paths: [])
-      RunContext.any_instance.stubs(:process_file).at_least_once.returns([offense])
+
+      result = RunContext::ProcessedFileResult.new(
+        file: file_path,
+        references: [build_reference],
+        offenses: [offense],
+      )
+
+      RunContext.any_instance.stubs(:process_file).at_least_once.returns(result)
 
       string_io = StringIO.new
 
@@ -51,11 +60,17 @@ module Packwerk
       configuration = Configuration.new({ "parallel" => false })
       configuration.stubs(load_paths: [])
 
+      result = RunContext::ProcessedFileResult.new(
+        file: build_reference.relative_path,
+        references: [build_reference],
+        offenses: [offense],
+      )
+
       RunContext.any_instance.stubs(:process_file)
         .at_least(2)
-        .returns([offense])
+        .returns(result)
         .raises(Interrupt)
-        .returns([offense])
+        .returns(result)
 
       string_io = StringIO.new
 
@@ -136,8 +151,15 @@ module Packwerk
 
       configuration = Configuration.new
       configuration.stubs(load_paths: [])
+
+      result = RunContext::ProcessedFileResult.new(
+        file: build_reference.relative_path,
+        references: [build_reference],
+        offenses: [offense],
+      )
+
       RunContext.any_instance.stubs(:process_file)
-        .returns([offense])
+        .returns(result)
 
       string_io = StringIO.new
 

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -16,6 +16,7 @@ module Packwerk
 
     teardown do
       FileUtils.remove_entry(@temp_dir)
+      Cache.bust_cache!
     end
 
     FakeResult = Struct.new(:ok?, :error_value)
@@ -61,7 +62,7 @@ module Packwerk
       configuration.stubs(load_paths: [])
 
       result = RunContext::ProcessedFileResult.new(
-        file: build_reference.relative_path,
+        file: 'path/of/exile.rb',
         references: [build_reference],
         offenses: [offense],
       )


### PR DESCRIPTION
# Summary
This is a proof of concept only. This is an attempt to incorporate caching into packwerk. In what I believe is the ideal strategy, this looks like, for the ideal case (primed cache), it reduces parsing time by 85% (from 3m30s to 30s in our codebase) on all files and by 42% (2.4s to 1.4s in our codebase) on a single file.

To use:
`EXPERIMENTAL_PACKWERK_CACHE=1 bin/packwerk check`

Note -- I'm totally fine with this *not* landing, and I don't think it makes sense yet! This was mostly just a fun side project and I totally understand if it doesn't make sense for us to add this complexity!

I don't think we can consider landing this yet until I can find a way to make the cache smaller (right now its 293M because it stores so much unnecessary data). I think if we want to go about this, we would want to pursue an alternate strategy where we probably want to cache a simpler, lower-level data structure (the results of the AST parse). See below in the comments for more.

# Further Details
I wanted to investigate what it would be like to add a cache to packwerk.
Right now, `bin/packwerk check` takes 3 and a half minutes on our codebase, which makes it quite a chore to run.

Until we get a faster parser (like Sorbet), speeding this up makes updating deprecations less toilsome for engineers.

I was curious to see if we can get this fast enough to be in a pre-commit hook. So far, I don't think we've reached that bar, but the speedup is substantial.

# Why this is complicated
A cache is only (perfectly) accurate if it is a pure function and the cache can be completely (or partially, in a targeted way) busted when one of its inputs changes.

A very simple cache here might be to cache all of the offenses in a file, and the cache is always hit if we can find offenses that are mapped to by the Digest of the file contents.

There are several other inputs into this. Namely, something is only an offense if the source package protects against privacy or dependency violations, so as an additional input, we would need to keep a hash of each package.yml and its digest, and also store the package.ymls that a file depends on to check for offenses. There's more -- if a file has a reference to SomeModel, that SomeModel can be in any package, in theory. If a constant is moved to another pack (something which we encourage with packwerk because reorganizing files is so easy), then the source package would change. For this, we'd also need to cache, alongside the `package.yml` of the package that defines the content, but the source file itself. As long as each file exists, we can assume *that* is the file that defines the constant, because packwerk does not permit multiple files to ambiguously define the same constant (https://github.com/Shopify/constant_resolver/blob/e78af0c8d5782b06292c068cfe4176e016c51b34/lib/constant_resolver.rb#L122). 

Therefore, the cache is pretty complicated. The cache is hit if the following is true:
- The file contents are the same
- The file contents of all of the source locations AND packages of each referenced constant are the same (and those files still exist)

# Approaches
I considered a couple of approaches:

## Approach 1: Per file cache
Pros to this approach:
- Each cached file is smaller, which may avoid some types of scaling issues with this cache. 
- In theory, the cache could be shared per file.  That is, if a team wanted to, they could check this cache into version control so the cache is pre-warmed for users. In practice, I doubt users would do this, as it would create lots of file diffs with each PR.
- Incrementally adding to the cache is *fast*. Instead of having to dump the whole cache file each time, we can just dump the additional things.

Cons to this approach:
- At least three file IOs for *each* file that is being parsed. One to get the digest, one to read the cache, and one the cache -- seems to be a lot slower. There are also file IOs for each file/package that the file depends on. Note that we only read each file contents once in the cache, since the cache holds the file content digests in memory.

## Approach 2: One cache for all files
Pros:
- One file IO for each file (one to get the digest), then two file IOs for the cache (one to read the whole cache, one to write the whole cache)
- Sharing the cache would only result in changes to one file, which is maybe a bit more well compartmentalized since its in one file.

Cons:
- Possibly could create a large file IO operation with very large codebases.
- We have to write the entire cache each time, even if only one file has been changed.
- Even when we only pass in one file (e.g. `bin/packwerk check path/to/filer.b`, we need to load the entire cache). The speed of the cache does not scale with the number of files being checked.

## Approach 3: Hybrid cache
In this approach, I wondered if we could have a hybrid cache where we have one large cache produced by the first run of `update-deprecations`, and then apply the incremental cache on a per file-basis. In theory, we could even merge the two caches if there were more than X (1000?) per file caches. Practically, the user can just run `rm -rf tmp/cache/packwerk` and rerun update deprecations to effectively merge the caches and get a bit of a speedup perhaps. I did not implement this approach.

Pros:
- Could be the fastest, since it reads the fewest files, and only writes what is incrementally necessary.

Cons:
- Very complicated implementation, prone to highly variable performance

# Performance across approaches for `bin/packwerk check`
|                  	| Cold cache (all cache misses) 	| Warm Cache (one cache miss) 	| Hot cache (zero cache misses) 	|
|------------------	|-------------------------------	|-----------------------------	|-------------------------------	|
| No cache         	| ~3m30s                        	| n/a                         	| n/a                           	|
| Monolithic cache 	| ~4m16s                        	| ~1m30s                      	| ~1m30s                        	|
| Cache-per file   	| ~4m24s                        	| 0m30s-0m45s                    	| 0m30s-0m45s                    	|
| Hybrid cache     	| did not investigate           	| did not investigate         	| did not investigate           	|

# Performance across approaches for `bin/packwerk check path/to/file.rb`
|                  	| Cold Cache          	| Hot cache           	|
|------------------	|---------------------	|---------------------	|
| No cache         	| ~2.4s               	| n/a                 	|
| Monolithic cache 	| did not investigate 	| did not investigate 	|
| Cache-per file   	| ~2.8s               	| ~1.4s               	|
| Hybrid cache     	| did not investigate 	| did not investigate 	|

# Memory Usage
We should probably do a quick memory profile of this! With the cache, we allocate a lot of extra objects, so it's possible that this has a non-neglible effect on memory.

# Decision
I went with the per file cache. The monolithic cache is very poorly optimized for `bin/packwerk check path/to/file.rb` and doesn't allow us to only redump the cache when the cache changes. The implementation is simplest and it offers the fastest speeds.

# Deployment
If we are interested in this, we can of course have this be opt-in via a `cache` flag in `packwerk.yml` (similar to `parallel`). This can also be considered an experimental feature that may be removed, and perhaps we can have it activated via an environment variable like `ENABLE_EXPERIMENTAL_PACKWERK_CACHE`. This is the way I have it implemented today, but happy to enable it via the configuration flag too (perhaps `experimental_cache`).

# Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

# Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
