### PR TITLE
handle empty lambda in constant assignments

### DIFF
--- a/lib/packwerk/node.rb
+++ b/lib/packwerk/node.rb
@@ -264,6 +264,7 @@ module Packwerk
         # "Class.new"
         # "Module.new"
         method_call?(node) &&
+          receiver(node) &&
           constant?(receiver(node)) &&
           ["Class", "Module"].include?(constant_name(receiver(node))) &&
           method_name(node) == :new

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -151,6 +151,7 @@ module Packwerk
         "-> x { x * 2 }",
         "Class.new",
         "Class.new do end",
+        "MyConstant = -> {}",
       ].each do |module_definition|
         node = parse(module_definition)
         assert_nil Node.module_name_from_definition(node)


### PR DESCRIPTION
## What are you trying to accomplish?
Fix https://github.com/Shopify/packwerk/issues/170

## What approach did you choose and why?
Traced it back to a problem with the `Node` class, which, for some reason, assumes that method calls in assignments always have a receiver. Lambdas count as method calls and don't have a receiver.

So, I added a check that the node has a receiver.

## Type of Change

- [X] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [ ] ~I have updated the documentation accordingly.~
- [X] I have added tests to cover my changes.
- [X] It is safe to rollback this change.
