### PR TITLE
Add PackageTrie as a packwerk performance optimization

### DIFF
--- a/lib/packwerk/package_set.rb
+++ b/lib/packwerk/package_set.rb
@@ -6,8 +6,32 @@ require "pathname"
 module Packwerk
   PathSpec = T.type_alias { T.any(String, T::Array[String]) }
 
-  # Copied from https://leetcode.com/problems/implement-trie-prefix-tree/discuss/327234/ruby-solution-for-trie
-  # This helps us performantly find the package for a given path
+  # This trie performantly allows us to identify what file a package is in.
+  # It stores packages in a Trie data structure. A Trie places each "entry" in a package path
+  # into one node, with pointers to child nodes that contain the subsequent entries.
+  # For example, if our packs are:
+  # `app/services/my_pack`, `app/services/my_other_pack`, `packs/my_pack`, `packs/my_other_pack`, and `packs/my_pack/nested/my_nested_pack`,
+  # then our trie looks like this (created using https://asciiflow.com)
+  #
+  #                      ┌────┐
+  #             ┌────────┤root├───────────┐
+  #             │        └────┘           │
+  #             │                         │
+  #           ┌─▼─┐                  ┌────▼───┐
+  #           │app│                  │packages├──┐
+  #           └─┬─┘                  └┬───────┘  │
+  #             │                     │          │
+  #      ┌──────▼──┐     ┌────────────▼───┐  ┌───▼──┐
+  #      │services │     │my_other_package│  │nested├───┐
+  #      └─┬───────┘     └────────────────┘  └──────┘   │
+  #        │                                            │
+  # ┌──────▼───┐                                 ┌──────▼──────────┐
+  # │my_package│                                 │my_nested_package│
+  # └──────────┘                                 └─────────────────┘
+  #
+  # When we need to identify what pack a file belongs to, we split it up into its entries, and the most jumps through the tree we will have to make is proportional
+  # to the height of the tree, won't be greater than the length of the longest package.
+  #
   class PackageNameTrie
     extend T::Sig
 


### PR DESCRIPTION
# Closing in favor of https://github.com/Shopify/packwerk/pull/175

# Summary

This PR adds a `PackageTrie`. This shaves off ~20 seconds from the total amount of time to run `bin/packwerk check` on our main monolith.

# Performance Analysis Summary

I benchmarked four situations:
- Baseline
- PackageTrie with memoization
- PackageTrie without memoization
- Memoization only

Results:
**Plain memoization is very close to the performance of the more complex package trie**
Since this implementation is dramatically simpler, I am going 

# Deeper Analysis
Before this PR, we called: `packages.values.find { |package| package.package_path?(path_string) }` to determine the package for a given string.
We called this in `context_for`, which happens every single time we want to produce context for a parsed constant. This happens *a lot*! For each run, we iterate over all packages and then call `starts_with?`. I don't know the runtime of `starts_with?` but in the best case scenario, it's O(1) time, which means that every call to `package_from_path` runs in O(N) time, where N is the number of packages.

I initially wanted to optimize two things:
1) Whatever implementation of finding the package for a path we use, we only want to call it once per path. We have a lot more constant references than files, so we are going to be calling this a lot of times with the same filepath. We want this to be O(1) after the initial run.
2) We want a fast implementation to find the package for a path. A Trie helps us achieve this, because now instead of looking at every single package, we instead traverse down a tree that's the height of the max length of any package. For our codebase, all of our packs are in `packs/*/package.yml`, so this would only ever go down two hops before it found a match. Mileage may vary in other codebases, but overall I expect this to be more performant than iterating over all packages in any codebase.

I found that focusing on (1) gets us the majority of the benefits.

## What are you trying to accomplish?

Improve packwerk speed of `check` and `update-deprecations`

## What approach did you choose and why?

Add a memoized trie, see more info above.

## What should reviewers focus on?

Correctness of implementation, performance characteristics

## Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly (no doc changes needed)
- [x] I have added tests to cover my changes (does not change behavior of code -- only implementation -- and tests continue to pass)
- [x] It is safe to rollback this change.
