### PR TITLE
Memoize package_from_path to improve performance

### DIFF
--- a/lib/packwerk/package_set.rb
+++ b/lib/packwerk/package_set.rb
@@ -79,6 +79,7 @@ module Packwerk
       sorted_packages = packages.sort_by { |package| -package.name.length }
       packages = sorted_packages.each_with_object({}) { |package, hash| hash[package.name] = package }
       @packages = T.let(packages, T::Hash[String, Package])
+      @package_from_path = T.let({}, T::Hash[String, T.nilable(Package)])
     end
 
     sig { override.params(blk: T.proc.params(arg0: Package).returns(T.untyped)).returns(T.untyped) }
@@ -94,7 +95,7 @@ module Packwerk
     sig { params(file_path: T.any(Pathname, String)).returns(T.nilable(Package)) }
     def package_from_path(file_path)
       path_string = file_path.to_s
-      packages.values.find { |package| package.package_path?(path_string) }
+      @package_from_path[path_string] ||= packages.values.find { |package| package.package_path?(path_string) }
     end
   end
 end


### PR DESCRIPTION
# Summary

This PR memoizes `package_from_path` to shave off ~20 seconds from the total amount of time to run `bin/packwerk check` on our main monolith.

# Performance Analysis Summary

I benchmarked four situations:
- Baseline
- PackageTrie with memoization (implementation here: https://github.com/Shopify/packwerk/pull/174)
- PackageTrie without memoization
- Memoization only

Results:
**Plain memoization is very close to the performance of the more complex package trie**
Since this implementation is dramatically simpler, and results are comparable, I think we should land this one more quickly to deliver value and then focus on other things for now.
<img width="947" alt="Screen Shot 2022-02-16 at 2 37 47 PM" src="https://user-images.githubusercontent.com/3311200/154342496-62ef08cd-a64d-4fd0-a76d-7d9ffdd0dafd.png">

# Deeper Analysis
Before this PR, we called: `packages.values.find { |package| package.package_path?(path_string) }` to determine the package for a given string.
We called this in `context_for`, which happens every single time we want to produce context for a parsed constant. This happens *a lot*! For each run, we iterate over all packages and then call `starts_with?`. I don't know the runtime of `starts_with?` but in the best case scenario, it's O(1) time, which means that every call to `package_from_path` runs in O(N) time, where N is the number of packages.

I initially wanted to optimize two things:
1) Whatever implementation of finding the package for a path we use, we only want to call it once per path. We have a lot more constant references than files, so we are going to be calling this a lot of times with the same filepath. We want this to be O(1) after the initial run.
2) We want a fast implementation to find the package for a path. A Trie helps us achieve this, because now instead of looking at every single package, we instead traverse down a tree that's the height of the max length of any package. For our codebase, all of our packs are in `packs/*/package.yml`, so this would only ever go down two hops before it found a match. Mileage may vary in other codebases, but overall I expect this to be more performant than iterating over all packages in any codebase.

I found that focusing on (1) gets us the majority of the benefits.

## What are you trying to accomplish?

Improve packwerk speed of `check` and `update-deprecations`

## What approach did you choose and why?

Simple memoization, see more info above.

## What should reviewers focus on?

Correctness of implementation, performance characteristics

## Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly (no doc changes needed)
- [x] I have added tests to cover my changes (does not change behavior of code -- only implementation -- and tests continue to pass)
- [x] It is safe to rollback this change.
