### PR TITLE
Fix issues where running `check` on a single file mistakenly reports stale violations

### DIFF
--- a/lib/packwerk/formatters/offenses_formatter.rb
+++ b/lib/packwerk/formatters/offenses_formatter.rb
@@ -23,9 +23,9 @@ module Packwerk
         EOS
       end
 
-      sig { override.params(offense_collection: Packwerk::OffenseCollection).returns(String) }
-      def show_stale_violations(offense_collection)
-        if offense_collection.stale_violations?
+      sig { override.params(offense_collection: Packwerk::OffenseCollection, fileset: T::Set[String]).returns(String) }
+      def show_stale_violations(offense_collection, fileset)
+        if offense_collection.stale_violations?(fileset)
           "There were stale violations found, please run `packwerk update-deprecations`"
         else
           "No stale violations detected"

--- a/lib/packwerk/offense_collection.rb
+++ b/lib/packwerk/offense_collection.rb
@@ -50,9 +50,11 @@ module Packwerk
       end
     end
 
-    sig { returns(T::Boolean) }
-    def stale_violations?
-      @deprecated_references.values.any?(&:stale_violations?)
+    sig { params(for_files: T::Set[String]).returns(T::Boolean) }
+    def stale_violations?(for_files)
+      @deprecated_references.values.any? do |deprecated_references|
+        deprecated_references.stale_violations?(for_files)
+      end
     end
 
     sig { void }

--- a/lib/packwerk/offenses_formatter.rb
+++ b/lib/packwerk/offenses_formatter.rb
@@ -12,8 +12,8 @@ module Packwerk
     def show_offenses(offenses)
     end
 
-    sig { abstract.params(offense_collection: Packwerk::OffenseCollection).returns(String) }
-    def show_stale_violations(offense_collection)
+    sig { abstract.params(offense_collection: Packwerk::OffenseCollection, for_files: T::Set[String]).returns(String) }
+    def show_stale_violations(offense_collection, for_files)
     end
   end
 end

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -36,8 +36,8 @@ module Packwerk
     def detect_stale_violations
       offense_collection = find_offenses
 
-      result_status = !offense_collection.stale_violations?
-      message = @offenses_formatter.show_stale_violations(offense_collection)
+      result_status = !offense_collection.stale_violations?(@relative_file_set)
+      message = @offenses_formatter.show_stale_violations(offense_collection, @relative_file_set)
 
       Result.new(message: message, status: result_status)
     end
@@ -61,9 +61,11 @@ module Packwerk
 
       messages = [
         @offenses_formatter.show_offenses(offense_collection.outstanding_offenses),
-        @offenses_formatter.show_stale_violations(offense_collection),
+        @offenses_formatter.show_stale_violations(offense_collection, @relative_file_set),
       ]
-      result_status = offense_collection.outstanding_offenses.empty? && !offense_collection.stale_violations?
+
+      result_status = offense_collection.outstanding_offenses.empty? &&
+        !offense_collection.stale_violations?(@relative_file_set)
 
       Result.new(message: messages.join("\n") + "\n", status: result_status)
     end

--- a/test/support/application_fixture_helper.rb
+++ b/test/support/application_fixture_helper.rb
@@ -59,6 +59,16 @@ module ApplicationFixtureHelper
     File.open(expanded_path, mode, &block)
   end
 
+  # This gets cleaned up by `teardown_application_fixture`
+  def write_app_file(path, content)
+    expanded_path = to_app_path(File.join(*path))
+    FileUtils.mkdir_p(Pathname.new(expanded_path).dirname)
+    File.open(expanded_path, "w+") do |file|
+      file.write(content)
+      file.flush
+    end
+  end
+
   private
 
   def using_template?

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -127,7 +127,7 @@ module Packwerk
           ["hi i am a custom offense formatter", *offenses].join("\n")
         end
 
-        def show_stale_violations(_offense_collection)
+        def show_stale_violations(_offense_collection, _fileset)
           "stale violations report"
         end
       end

--- a/test/unit/offense_collection_test.rb
+++ b/test/unit/offense_collection_test.rb
@@ -31,7 +31,7 @@ module Packwerk
         .expects(:stale_violations?)
         .returns(true)
 
-      assert_predicate @offense_collection, :stale_violations?
+      assert @offense_collection.stale_violations?(Set.new)
     end
 
     test "#stale_violations? returns false if no stale violations" do
@@ -41,7 +41,7 @@ module Packwerk
         .expects(:stale_violations?)
         .returns(false)
 
-      refute_predicate @offense_collection, :stale_violations?
+      refute @offense_collection.stale_violations?(Set.new)
     end
 
     test "#listed? returns true if constant is listed in file" do


### PR DESCRIPTION
# Summary

Resolves https://github.com/Shopify/packwerk/issues/154 by only determining if a violation is stale if `bin/packwerk check` is called with input variables including the potentially stale violation.

## What are you trying to accomplish?

Resolve this bug to support `bin/packwerk check` on a single file behaving as expected.

## What approach did you choose and why?

Comparing potentially stale violations against input vars.

## What should reviewers focus on?

Is there a simpler way to accomplish this?

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
