### PR TITLE
More cleanly separate out references from offenses when processing a file

### DIFF
--- a/lib/packwerk/parsers/parser_interface.rb
+++ b/lib/packwerk/parsers/parser_interface.rb
@@ -7,6 +7,8 @@ module Packwerk
       extend T::Helpers
       extend T::Sig
 
+      requires_ancestor { Kernel }
+
       interface!
 
       sig { abstract.params(io: File, file_path: String).returns(T.untyped) }

--- a/lib/packwerk/reference_checking/reference_checker.rb
+++ b/lib/packwerk/reference_checking/reference_checker.rb
@@ -13,12 +13,10 @@ module Packwerk
 
       sig do
         params(
-          reference: T.any(Packwerk::Reference, Packwerk::Offense)
+          reference: Reference
         ).returns(T::Array[Packwerk::Offense])
       end
       def call(reference)
-        return [reference] if reference.is_a?(Packwerk::Offense)
-
         @checkers.each_with_object([]) do |checker, violations|
           next unless checker.invalid_reference?(reference)
           offense = Packwerk::ReferenceOffense.new(

--- a/lib/packwerk/reference_extractor.rb
+++ b/lib/packwerk/reference_extractor.rb
@@ -51,20 +51,14 @@ module Packwerk
 
     sig do
       params(
-        unresolved_references_and_offenses: T::Array[T.any(UnresolvedReference, Offense)],
+        unresolved_references: T::Array[UnresolvedReference],
         context_provider: ConstantDiscovery
-      ).returns(T::Array[T.any(Reference, Offense)])
+      ).returns(T::Array[Reference])
     end
-    def self.get_fully_qualified_references_and_offenses_from(unresolved_references_and_offenses, context_provider)
-      fully_qualified_references_and_offenses = T.let([], T::Array[T.any(Reference, Offense)])
+    def self.get_fully_qualified_references_from(unresolved_references, context_provider)
+      fully_qualified_references = T.let([], T::Array[Reference])
 
-      unresolved_references_and_offenses.each do |unresolved_references_or_offense|
-        if unresolved_references_or_offense.is_a?(Offense)
-          fully_qualified_references_and_offenses << unresolved_references_or_offense
-
-          next
-        end
-
+      unresolved_references.each do |unresolved_references_or_offense|
         unresolved_reference = unresolved_references_or_offense
 
         constant =
@@ -83,7 +77,7 @@ module Packwerk
 
         next if source_package == package_for_constant
 
-        fully_qualified_references_and_offenses << Reference.new(
+        fully_qualified_references << Reference.new(
           source_package,
           unresolved_reference.relative_path,
           constant,
@@ -91,7 +85,7 @@ module Packwerk
         )
       end
 
-      fully_qualified_references_and_offenses
+      fully_qualified_references
     end
 
     private

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -79,13 +79,15 @@ module Packwerk
 
     sig { params(absolute_file: String).returns(T::Array[Packwerk::Offense]) }
     def process_file(absolute_file:)
-      unresolved_references_and_offenses = file_processor.call(absolute_file)
-      references_and_offenses = ReferenceExtractor.get_fully_qualified_references_and_offenses_from(
-        unresolved_references_and_offenses,
+      processed_file = file_processor.call(absolute_file)
+
+      references = ReferenceExtractor.get_fully_qualified_references_from(
+        processed_file.unresolved_references,
         context_provider
       )
       reference_checker = ReferenceChecking::ReferenceChecker.new(@checkers)
-      references_and_offenses.flat_map { |reference| reference_checker.call(reference) }
+
+      processed_file.offenses + references.flat_map { |reference| reference_checker.call(reference) }
     end
 
     private

--- a/test/unit/reference_checking/reference_checker_test.rb
+++ b/test/unit/reference_checking/reference_checker_test.rb
@@ -24,14 +24,6 @@ module Packwerk
       end
     end
 
-    test "#call early returns with offense if it is not a reference type" do
-      input_offense = FileProcessor::UnknownFileTypeResult.new(file: "tempfile")
-      offenses = reference_checker.call(input_offense)
-
-      assert_equal 1, offenses.length
-      assert_equal input_offense, offenses.first
-    end
-
     test "#call enumerates the list of checkers to create ReferenceOffense objects" do
       instance = reference_checker([StubChecker.new(
         invalid_reference?: true,

--- a/test/unit/reference_extractor_test.rb
+++ b/test/unit/reference_extractor_test.rb
@@ -254,7 +254,7 @@ module Packwerk
         file_path: file_path
       )
 
-      ::Packwerk::ReferenceExtractor.get_fully_qualified_references_and_offenses_from(
+      ::Packwerk::ReferenceExtractor.get_fully_qualified_references_from(
         unresolved_references,
         @context_provider
       )


### PR DESCRIPTION
## What are you trying to accomplish?
I noticed what felt like a bit of a code smell in the checkers. Namely:
```
return [reference] if reference.is_a?(Packwerk::Offense)
```

It felt like the checkers didn't really want to be receiving `Packwerk::Offense`s at all. I think a design which more clearly represents the intention of the system is that we might have errors related to parsing or otherwise getting references to checkers, and then separately we have `Packwerk::ReferenceOffense` generated by the checkers. I want to represent this by returning a `ProcessedFile` from which we can then more surgically get what we need and pass to other supporting actors.

The main impetus for this change was getting us slightly closer to an extensible interface for checkers. I think this cleans up the interface ever so slightly and thought it would make a nice little tidy up.

## What approach did you choose and why?
I returned a first class object that separately contains offenses and references.

## What should reviewers focus on?
Does this approach make sense? Is there a reason to pass offenses to the checkers that I'm missing?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
