### PR TITLE
Change FilesForProcessing to return a T::Set[String]

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -32,8 +32,10 @@ module Packwerk
       @style = style
       @configuration = T.let(configuration || Configuration.from_path, Configuration)
       @progress_formatter = T.let(Formatters::ProgressFormatter.new(@out, style: style), Formatters::ProgressFormatter)
-      @offenses_formatter = T.let(offenses_formatter || Formatters::OffensesFormatter.new(style: @style),
-        OffensesFormatter)
+      @offenses_formatter = T.let(
+        offenses_formatter || Formatters::OffensesFormatter.new(style: @style),
+        OffensesFormatter
+      )
     end
 
     sig { params(args: T::Array[String]).returns(T.noreturn) }
@@ -122,16 +124,21 @@ module Packwerk
       result.status
     end
 
-    sig { params(relative_file_paths: T::Array[String], ignore_nested_packages: T::Boolean).returns(T::Array[String]) }
+    sig do
+      params(
+        relative_file_paths: T::Array[String],
+        ignore_nested_packages: T::Boolean
+      ).returns(FilesForProcessing::AbsoluteFileSet)
+    end
     def fetch_files_to_process(relative_file_paths, ignore_nested_packages)
-      absolute_files = FilesForProcessing.fetch(
+      absolute_file_set = FilesForProcessing.fetch(
         relative_file_paths: relative_file_paths,
         ignore_nested_packages: ignore_nested_packages,
         configuration: @configuration
       )
       abort("No files found or given. "\
-        "Specify files or check the include and exclude glob in the config file.") if absolute_files.empty?
-      absolute_files
+        "Specify files or check the include and exclude glob in the config file.") if absolute_file_set.empty?
+      absolute_file_set
     end
 
     sig { params(_paths: T::Array[String]).returns(T::Boolean) }
@@ -183,7 +190,7 @@ module Packwerk
       end
 
       ParseRun.new(
-        absolute_files: fetch_files_to_process(relative_file_paths, ignore_nested_packages),
+        absolute_file_set: fetch_files_to_process(relative_file_paths, ignore_nested_packages),
         configuration: @configuration,
         progress_formatter: @progress_formatter,
         offenses_formatter: @offenses_formatter

--- a/test/unit/cache_test.rb
+++ b/test/unit/cache_test.rb
@@ -41,7 +41,7 @@ module Packwerk
       configuration = Configuration.from_path
       configuration.stubs(cache_enabled?: true)
 
-      parse_run = Packwerk::ParseRun.new(absolute_files: [filepath.to_s], configuration: configuration)
+      parse_run = Packwerk::ParseRun.new(absolute_file_set: Set.new([filepath.to_s]), configuration: configuration)
       parse_run.update_deprecations
       parse_run.update_deprecations
 

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -32,7 +32,7 @@ module Packwerk
       cli = ::Packwerk::Cli.new(out: string_io, configuration: configuration)
 
       # TODO: Dependency injection for a "target finder" (https://github.com/Shopify/packwerk/issues/164)
-      ::Packwerk::FilesForProcessing.stubs(fetch: [file_path])
+      ::Packwerk::FilesForProcessing.stubs(fetch: Set.new([file_path]))
 
       success = cli.execute_command(["check", file_path])
 
@@ -61,7 +61,7 @@ module Packwerk
 
       cli = ::Packwerk::Cli.new(out: string_io, configuration: configuration)
 
-      ::Packwerk::FilesForProcessing.stubs(fetch: [file_path, "test.rb", "foo.rb"])
+      ::Packwerk::FilesForProcessing.stubs(fetch: Set.new([file_path, "test.rb", "foo.rb"]))
 
       success = cli.execute_command(["check", file_path])
 
@@ -149,7 +149,7 @@ module Packwerk
         offenses_formatter: offenses_formatter.new
       )
 
-      ::Packwerk::FilesForProcessing.stubs(fetch: [file_path])
+      ::Packwerk::FilesForProcessing.stubs(fetch: Set.new([file_path]))
 
       success = cli.execute_command(["check", file_path])
 

--- a/test/unit/files_for_processing_test.rb
+++ b/test/unit/files_for_processing_test.rb
@@ -35,12 +35,12 @@ module Packwerk
       files = ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [], configuration: @configuration)
       excluded_file_patterns = @configuration.exclude.map { |pattern| File.join(@configuration.root_path, pattern) }
 
-      refute_any_match(files, excluded_file_patterns)
+      refute_any_match(files, Set.new(excluded_file_patterns))
     end
 
     test "fetch does not return duplicated file paths" do
       files = ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [], configuration: @configuration)
-      assert_equal files, files.uniq
+      assert_equal files, Set.new(files)
     end
 
     test "fetch with custom paths without ignoring nested packages includes only include glob in custom paths including nested package files" do
@@ -51,7 +51,7 @@ module Packwerk
       )
       included_file_patterns = @configuration.include.map { |pattern| File.join(@configuration.root_path, pattern) }
 
-      assert_all_match(files, included_file_patterns)
+      assert_all_match(files, Set.new(included_file_patterns))
     end
 
     test "fetch with no custom paths ignoring nested packages includes only include glob across codebase" do
@@ -72,8 +72,8 @@ module Packwerk
         ignore_nested_packages: true
       )
 
-      refute_any_match(files, [File.join(@configuration.root_path, "components/sales", "**/*.rb")])
-      refute_any_match(files, [File.join(@configuration.root_path, "components/timeline", "**/*.rb")])
+      refute_any_match(files, Set.new([File.join(@configuration.root_path, "components/sales", "**/*.rb")]))
+      refute_any_match(files, Set.new([File.join(@configuration.root_path, "components/timeline", "**/*.rb")]))
     end
 
     private

--- a/test/unit/parse_run_test.rb
+++ b/test/unit/parse_run_test.rb
@@ -21,7 +21,7 @@ module Packwerk
       RunContext.any_instance.stubs(:process_file).returns([])
 
       parse_run = Packwerk::ParseRun.new(
-        absolute_files: ["path/of/exile.rb"],
+        absolute_file_set: Set.new(["path/of/exile.rb"]),
         configuration: Configuration.from_path
       )
       result = parse_run.detect_stale_violations
@@ -35,7 +35,7 @@ module Packwerk
       OffenseCollection.any_instance.expects(:dump_deprecated_references_files).once
 
       parse_run = Packwerk::ParseRun.new(
-        absolute_files: ["path/of/exile.rb"],
+        absolute_file_set: Set.new(["path/of/exile.rb"]),
         configuration: Configuration.from_path
       )
       result = parse_run.update_deprecations
@@ -54,7 +54,7 @@ module Packwerk
       OffenseCollection.any_instance.expects(:dump_deprecated_references_files).once
 
       parse_run = Packwerk::ParseRun.new(
-        absolute_files: ["path/of/exile.rb"],
+        absolute_file_set: Set.new(["path/of/exile.rb"]),
         configuration: Configuration.from_path
       )
       result = parse_run.update_deprecations
@@ -77,7 +77,7 @@ module Packwerk
       DeprecatedReferences.any_instance.stubs(:listed?).returns(true)
       out = StringIO.new
       parse_run = Packwerk::ParseRun.new(
-        absolute_files: ["some/path.rb"],
+        absolute_file_set: Set.new(["some/path.rb"]),
         configuration: Configuration.new({ "parallel" => false }),
         progress_formatter: Packwerk::Formatters::ProgressFormatter.new(out)
       )
@@ -106,7 +106,7 @@ module Packwerk
       OffenseCollection.any_instance.stubs(:stale_violations?).returns(true)
       out = StringIO.new
       parse_run = Packwerk::ParseRun.new(
-        absolute_files: ["some/path.rb"],
+        absolute_file_set: Set.new(["some/path.rb"]),
         configuration: Configuration.new({ "parallel" => false }),
         progress_formatter: Packwerk::Formatters::ProgressFormatter.new(out)
       )
@@ -137,7 +137,7 @@ module Packwerk
         violation_type: ViolationType::Privacy
       )
       parse_run = Packwerk::ParseRun.new(
-        absolute_files: ["some/path.rb", "some/other_path.rb"],
+        absolute_file_set: Set.new(["some/path.rb", "some/other_path.rb"]),
         configuration: Configuration.new
       )
       RunContext.any_instance.stubs(:process_file).returns([offense]).returns([offense2])


### PR DESCRIPTION
## What are you trying to accomplish?

Change `FilesForProcessing` to return a Set, which makes fixing https://github.com/Shopify/packwerk/issues/154 simpler (see https://github.com/Shopify/packwerk/pull/178 for more info).

## What approach did you choose and why?
I returned a set, since we are already calling `uniq` on the returned files anyways. This makes testing for inclusion faster.
I used a `T.type_alias` to specify the type rather than a separate class because I wanted to continue to use the same `Set` interface but also be able to more explicitly refer to the types in signatures.

## What should reviewers focus on?
Any reason not to make this a set?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
