### PR TITLE
Add stimpack to ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ Read [USAGE.md](USAGE.md) for usage once Packwerk is installed on your project.
 
 ## Ecosystem
 
-You can use these third party tools to enhance your packwerk experience:
+Various third parties have built tooling on top of packwerk. Here's a selection of some that might prove useful:
 
 - https://github.com/bellroy/graphwerk draws a graph of your package dependencies
 - https://github.com/Gusto/packwerk-vscode integrates packwerk into Visual Studio Code so you can see violations right in your editor
+- https://github.com/Gusto/stimpack sets up Rails autoloading, as well as `rspec` and `FactoryBot` integration, for packages arranged in a flat list.
 
 ## Development
 


### PR DESCRIPTION
## What are you trying to accomplish?
Make `stimpack` more discoverable for people that want to use packwerk similarly to how Gusto is using it

## What approach did you choose and why?
I think a pointer makes sense, I don't want to make it a recommendation as that would suggest `stimpack`'s patterns are the one recommended path.

## What should reviewers focus on?

Any drawbacks to adding this shoutout?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] It is safe to rollback this change.
