### PR TITLE
Filter custom paths according to include

### DIFF
--- a/lib/packwerk/files_for_processing.rb
+++ b/lib/packwerk/files_for_processing.rb
@@ -41,7 +41,7 @@ module Packwerk
       include_files = if custom_files.empty?
         configured_included_files
       else
-        custom_files
+        configured_included_files & custom_files
       end
 
       include_files - configured_excluded_files

--- a/test/unit/files_for_processing_test.rb
+++ b/test/unit/files_for_processing_test.rb
@@ -76,6 +76,19 @@ module Packwerk
       refute_any_match(files, Set.new([File.join(@configuration.root_path, "components/timeline", "**/*.rb")]))
     end
 
+    test "fetch with custom paths for files includes only include glob in custom paths" do
+      files = ::Packwerk::FilesForProcessing.fetch(
+        relative_file_paths: [
+          "components/sales/app/models/order.rb",
+          "components/sales/app/views/order.html.erb",
+        ],
+        configuration: @configuration
+      )
+      included_file_patterns = @configuration.include.map { |pattern| File.join(@configuration.root_path, pattern) }
+
+      assert_all_match(files, included_file_patterns)
+    end
+
     private
 
     def assert_all_match(files, patterns)


### PR DESCRIPTION
## What are you trying to accomplish?

Custom paths are [already filtered by the `exclude` option](https://github.com/Shopify/packwerk/blob/72209689adef3f6c55776a2a948999ef42ec3819/lib/packwerk/files_for_processing.rb#L47), but this commit ensures that the `include` option is respected too. This is particularly useful for the `packwerk-vscode` extension, which [attempts to run](https://github.com/Gusto/packwerk-vscode/blob/b51eb9535dd95e17a7f17fc618dd7beab449a979/package.json#L58) `packwerk check $filename` on save.

For example:

```yml
include:
  - a/**/*.rb
  - b/**/*.rb
```

I would expect `packwerk check c/some/file.rb` to show the "No files found or given" message, as it would if `exclude` was set. This commit ensures that happens.

## What approach did you choose and why?

I chose to always filter custom paths according to the `include` option, because that seemed to mirror the behaviour of the `exclude` option. However, there might be valid use-cases for `packwerk check some/not/included/file.rb` that I haven't considered. If that's a common use-case, maybe I should approach this differently? Maybe the `packwerk-vscode` extension should be making decisions about when to run `packwerk check` instead?

## What should reviewers focus on?

Are there common/valid use-cases for `packwerk check` that I am making impossible with this change? I guess if someone is relying on the existing behaviour then this might be a breaking change?

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
