### PR TITLE
make FilesForProcessing return relative paths

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -128,17 +128,17 @@ module Packwerk
       params(
         relative_file_paths: T::Array[String],
         ignore_nested_packages: T::Boolean
-      ).returns(FilesForProcessing::AbsoluteFileSet)
+      ).returns(FilesForProcessing::RelativeFileSet)
     end
     def fetch_files_to_process(relative_file_paths, ignore_nested_packages)
-      absolute_file_set = FilesForProcessing.fetch(
+      relative_file_set = FilesForProcessing.fetch(
         relative_file_paths: relative_file_paths,
         ignore_nested_packages: ignore_nested_packages,
         configuration: @configuration
       )
       abort("No files found or given. "\
-        "Specify files or check the include and exclude glob in the config file.") if absolute_file_set.empty?
-      absolute_file_set
+        "Specify files or check the include and exclude glob in the config file.") if relative_file_set.empty?
+      relative_file_set
     end
 
     sig { params(_paths: T::Array[String]).returns(T::Boolean) }
@@ -190,7 +190,7 @@ module Packwerk
       end
 
       ParseRun.new(
-        absolute_file_set: fetch_files_to_process(relative_file_paths, ignore_nested_packages),
+        relative_file_set: fetch_files_to_process(relative_file_paths, ignore_nested_packages),
         configuration: @configuration,
         progress_formatter: @progress_formatter,
         offenses_formatter: @offenses_formatter

--- a/lib/packwerk/file_processor.rb
+++ b/lib/packwerk/file_processor.rb
@@ -35,19 +35,19 @@ module Packwerk
     end
 
     sig do
-      params(absolute_file: String).returns(ProcessedFile)
+      params(relative_file: String).returns(ProcessedFile)
     end
-    def call(absolute_file)
-      parser = parser_for(absolute_file)
+    def call(relative_file)
+      parser = parser_for(relative_file)
       if parser.nil?
-        return ProcessedFile.new(offenses: [UnknownFileTypeResult.new(file: absolute_file)])
+        return ProcessedFile.new(offenses: [UnknownFileTypeResult.new(file: relative_file)])
       end
 
-      unresolved_references = @cache.with_cache(absolute_file) do
-        node = parse_into_ast(absolute_file, parser)
+      unresolved_references = @cache.with_cache(relative_file) do
+        node = parse_into_ast(relative_file, parser)
         return ProcessedFile.new unless node
 
-        references_from_ast(node, absolute_file)
+        references_from_ast(node, relative_file)
       end
 
       ProcessedFile.new(unresolved_references: unresolved_references)
@@ -58,22 +58,22 @@ module Packwerk
     private
 
     sig do
-      params(node: Parser::AST::Node, absolute_file: String).returns(T::Array[UnresolvedReference])
+      params(node: Parser::AST::Node, relative_file: String).returns(T::Array[UnresolvedReference])
     end
-    def references_from_ast(node, absolute_file)
+    def references_from_ast(node, relative_file)
       references = []
 
-      node_processor = @node_processor_factory.for(absolute_file: absolute_file, node: node)
+      node_processor = @node_processor_factory.for(relative_file: relative_file, node: node)
       node_visitor = Packwerk::NodeVisitor.new(node_processor: node_processor)
       node_visitor.visit(node, ancestors: [], result: references)
 
       references
     end
 
-    sig { params(absolute_file: String, parser: Parsers::ParserInterface).returns(T.untyped) }
-    def parse_into_ast(absolute_file, parser)
-      File.open(absolute_file, "r", nil, external_encoding: Encoding::UTF_8) do |file|
-        parser.call(io: file, file_path: absolute_file)
+    sig { params(relative_file: String, parser: Parsers::ParserInterface).returns(T.untyped) }
+    def parse_into_ast(relative_file, parser)
+      File.open(relative_file, "r", nil, external_encoding: Encoding::UTF_8) do |file|
+        parser.call(io: file, file_path: relative_file)
       end
     end
 

--- a/lib/packwerk/node_processor.rb
+++ b/lib/packwerk/node_processor.rb
@@ -9,12 +9,12 @@ module Packwerk
     sig do
       params(
         reference_extractor: ReferenceExtractor,
-        absolute_file: String,
+        relative_file: String,
       ).void
     end
-    def initialize(reference_extractor:, absolute_file:)
+    def initialize(reference_extractor:, relative_file:)
       @reference_extractor = reference_extractor
-      @absolute_file = absolute_file
+      @relative_file = relative_file
     end
 
     sig do
@@ -25,7 +25,7 @@ module Packwerk
     end
     def call(node, ancestors)
       return unless Node.method_call?(node) || Node.constant?(node)
-      @reference_extractor.reference_from_node(node, ancestors: ancestors, absolute_file: @absolute_file)
+      @reference_extractor.reference_from_node(node, ancestors: ancestors, relative_file: @relative_file)
     end
   end
 end

--- a/lib/packwerk/node_processor_factory.rb
+++ b/lib/packwerk/node_processor_factory.rb
@@ -9,11 +9,11 @@ module Packwerk
     const :context_provider, Packwerk::ConstantDiscovery
     const :constant_name_inspectors, T::Array[ConstantNameInspector]
 
-    sig { params(absolute_file: String, node: AST::Node).returns(NodeProcessor) }
-    def for(absolute_file:, node:)
+    sig { params(relative_file: String, node: AST::Node).returns(NodeProcessor) }
+    def for(relative_file:, node:)
       ::Packwerk::NodeProcessor.new(
         reference_extractor: reference_extractor(node: node),
-        absolute_file: absolute_file,
+        relative_file: relative_file,
       )
     end
 

--- a/lib/packwerk/reference_extractor.rb
+++ b/lib/packwerk/reference_extractor.rb
@@ -27,10 +27,10 @@ module Packwerk
       params(
         node: Parser::AST::Node,
         ancestors: T::Array[Parser::AST::Node],
-        absolute_file: String
+        relative_file: String
       ).returns(T.nilable(UnresolvedReference))
     end
-    def reference_from_node(node, ancestors:, absolute_file:)
+    def reference_from_node(node, ancestors:, relative_file:)
       constant_name = T.let(nil, T.nilable(String))
 
       @constant_name_inspectors.each do |inspector|
@@ -44,7 +44,7 @@ module Packwerk
           constant_name,
           node: node,
           ancestors: ancestors,
-          absolute_file: absolute_file
+          relative_file: relative_file
         )
       end
     end
@@ -95,15 +95,14 @@ module Packwerk
         constant_name: String,
         node: Parser::AST::Node,
         ancestors: T::Array[Parser::AST::Node],
-        absolute_file: String
+        relative_file: String
       ).returns(T.nilable(UnresolvedReference))
     end
-    def reference_from_constant(constant_name, node:, ancestors:, absolute_file:)
+    def reference_from_constant(constant_name, node:, ancestors:, relative_file:)
       namespace_path = Node.enclosing_namespace_path(node, ancestors: ancestors)
 
       return if local_reference?(constant_name, Node.name_location(node), namespace_path)
 
-      relative_file = Pathname.new(absolute_file).relative_path_from(@root_path).to_s
       location = Node.location(node)
 
       UnresolvedReference.new(

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -77,9 +77,9 @@ module Packwerk
       )
     end
 
-    sig { params(absolute_file: String).returns(T::Array[Packwerk::Offense]) }
-    def process_file(absolute_file:)
-      processed_file = file_processor.call(absolute_file)
+    sig { params(relative_file: String).returns(T::Array[Packwerk::Offense]) }
+    def process_file(relative_file:)
+      processed_file = file_processor.call(relative_file)
 
       references = ReferenceExtractor.get_fully_qualified_references_from(
         processed_file.unresolved_references,

--- a/test/unit/cache_test.rb
+++ b/test/unit/cache_test.rb
@@ -41,7 +41,7 @@ module Packwerk
       configuration = Configuration.from_path
       configuration.stubs(cache_enabled?: true)
 
-      parse_run = Packwerk::ParseRun.new(absolute_file_set: Set.new([filepath.to_s]), configuration: configuration)
+      parse_run = Packwerk::ParseRun.new(relative_file_set: Set.new([filepath.to_s]), configuration: configuration)
       parse_run.update_deprecations
       parse_run.update_deprecations
 

--- a/test/unit/files_for_processing_test.rb
+++ b/test/unit/files_for_processing_test.rb
@@ -11,9 +11,10 @@ module Packwerk
     end
 
     test "fetch with custom paths includes only include glob in custom paths" do
-      files = ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [@package_path], configuration: @configuration)
-      included_file_pattern = File.join(@configuration.root_path, @package_path, "**/*.rb")
-
+      files = Dir.chdir("test/fixtures/skeleton") do
+        ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [@package_path], configuration: @configuration)
+      end
+      included_file_pattern = File.join(@package_path, "**/*.rb")
       assert_all_match(files, [included_file_pattern])
     end
 
@@ -26,9 +27,8 @@ module Packwerk
 
     test "fetch with no custom paths includes only include glob across codebase" do
       files = ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [], configuration: @configuration)
-      included_file_patterns = @configuration.include.map { |pattern| File.join(@configuration.root_path, pattern) }
 
-      assert_all_match(files, included_file_patterns)
+      assert_all_match(files, @configuration.include)
     end
 
     test "fetch with no custom paths excludes the exclude glob across codebase" do
@@ -49,20 +49,20 @@ module Packwerk
         configuration: @configuration,
         ignore_nested_packages: false
       )
-      included_file_patterns = @configuration.include.map { |pattern| File.join(@configuration.root_path, pattern) }
 
-      assert_all_match(files, Set.new(included_file_patterns))
+      assert_all_match(files, Set.new(@configuration.include))
     end
 
     test "fetch with no custom paths ignoring nested packages includes only include glob across codebase" do
-      files = ::Packwerk::FilesForProcessing.fetch(
-        relative_file_paths: [],
-        configuration: @configuration,
-        ignore_nested_packages: true
-      )
-      included_file_patterns = @configuration.include.map { |pattern| File.join(@configuration.root_path, pattern) }
+      files = Dir.chdir("test/fixtures/skeleton") do
+        ::Packwerk::FilesForProcessing.fetch(
+          relative_file_paths: [],
+          configuration: @configuration,
+          ignore_nested_packages: true
+        )
+      end
 
-      assert_all_match(files, included_file_patterns)
+      assert_all_match(files, @configuration.include)
     end
 
     test "fetch with custom paths ignoring nested packages includes only include glob in custom paths without nested package files" do

--- a/test/unit/parse_run_test.rb
+++ b/test/unit/parse_run_test.rb
@@ -21,7 +21,7 @@ module Packwerk
       RunContext.any_instance.stubs(:process_file).returns([])
 
       parse_run = Packwerk::ParseRun.new(
-        absolute_file_set: Set.new(["path/of/exile.rb"]),
+        relative_file_set: Set.new(["path/of/exile.rb"]),
         configuration: Configuration.from_path
       )
       result = parse_run.detect_stale_violations
@@ -35,7 +35,7 @@ module Packwerk
       OffenseCollection.any_instance.expects(:dump_deprecated_references_files).once
 
       parse_run = Packwerk::ParseRun.new(
-        absolute_file_set: Set.new(["path/of/exile.rb"]),
+        relative_file_set: Set.new(["path/of/exile.rb"]),
         configuration: Configuration.from_path
       )
       result = parse_run.update_deprecations
@@ -54,7 +54,7 @@ module Packwerk
       OffenseCollection.any_instance.expects(:dump_deprecated_references_files).once
 
       parse_run = Packwerk::ParseRun.new(
-        absolute_file_set: Set.new(["path/of/exile.rb"]),
+        relative_file_set: Set.new(["path/of/exile.rb"]),
         configuration: Configuration.from_path
       )
       result = parse_run.update_deprecations
@@ -77,7 +77,7 @@ module Packwerk
       DeprecatedReferences.any_instance.stubs(:listed?).returns(true)
       out = StringIO.new
       parse_run = Packwerk::ParseRun.new(
-        absolute_file_set: Set.new(["some/path.rb"]),
+        relative_file_set: Set.new(["some/path.rb"]),
         configuration: Configuration.new({ "parallel" => false }),
         progress_formatter: Packwerk::Formatters::ProgressFormatter.new(out)
       )
@@ -106,7 +106,7 @@ module Packwerk
       OffenseCollection.any_instance.stubs(:stale_violations?).returns(true)
       out = StringIO.new
       parse_run = Packwerk::ParseRun.new(
-        absolute_file_set: Set.new(["some/path.rb"]),
+        relative_file_set: Set.new(["some/path.rb"]),
         configuration: Configuration.new({ "parallel" => false }),
         progress_formatter: Packwerk::Formatters::ProgressFormatter.new(out)
       )
@@ -137,7 +137,7 @@ module Packwerk
         violation_type: ViolationType::Privacy
       )
       parse_run = Packwerk::ParseRun.new(
-        absolute_file_set: Set.new(["some/path.rb", "some/other_path.rb"]),
+        relative_file_set: Set.new(["some/path.rb", "some/other_path.rb"]),
         configuration: Configuration.new
       )
       RunContext.any_instance.stubs(:process_file).returns([offense]).returns([offense2])

--- a/test/unit/reference_extractor_test.rb
+++ b/test/unit/reference_extractor_test.rb
@@ -251,7 +251,7 @@ module Packwerk
         root_node,
         ancestors: [],
         extractor: extractor,
-        file_path: file_path
+        file_path: Pathname.new(file_path).relative_path_from(app_dir).to_s
       )
 
       ::Packwerk::ReferenceExtractor.get_fully_qualified_references_from(
@@ -261,7 +261,7 @@ module Packwerk
     end
 
     def find_references_in_ast(root_node, ancestors:, extractor:, file_path:)
-      references = [extractor.reference_from_node(root_node, ancestors: ancestors, absolute_file: file_path)]
+      references = [extractor.reference_from_node(root_node, ancestors: ancestors, relative_file: file_path)]
 
       child_references = Node.each_child(root_node).flat_map do |child|
         find_references_in_ast(child, ancestors: [root_node] + ancestors, extractor: extractor, file_path: file_path)


### PR DESCRIPTION
## What are you trying to accomplish?


The intent of this PR is to get us closer to being able to fix the issue with `bin/packwerk check` not working when run on a single file (it mistakenly picks up stale violations).

## What approach did you choose and why?

To do this, we want to compare the files passed into `ParseRun` against what is in the `deprecated_references.yml` files.

All file references in `deprecated_references.yml` files are paths *relative to the root*. Therefore by changing parse run to use relative paths, we:
A) Simplify some of the code which no longer has to deal with translating to and from absolute paths.
B) Allows us to compare against `deprecated_references.yml` in a follow-up PR.

## What should reviewers focus on?
Am I missing something where the behavior relies on absolute paths?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
