### PR TITLE
Move checker specific logic into checker

### DIFF
--- a/lib/packwerk/reference_checking/checkers/checker.rb
+++ b/lib/packwerk/reference_checking/checkers/checker.rb
@@ -8,13 +8,26 @@ module Packwerk
         extend T::Sig
         extend T::Helpers
 
-        interface!
+        abstract!
 
         sig { returns(ViolationType).abstract }
         def violation_type; end
 
         sig { params(reference: Reference).returns(T::Boolean).abstract }
         def invalid_reference?(reference); end
+
+        sig { params(reference: Reference).returns(String).abstract }
+        def message(reference); end
+
+        sig { params(reference: Reference).returns(String) }
+        def standard_help_message(reference)
+          standard_mesage = <<~EOS
+            Inference details: this is a reference to #{reference.constant.name} which seems to be defined in #{reference.constant.location}.
+            To receive help interpreting or resolving this error message, see: https://github.com/Shopify/packwerk/blob/main/TROUBLESHOOT.md#Troubleshooting-violations
+          EOS
+
+          standard_mesage.chomp
+        end
       end
     end
   end

--- a/lib/packwerk/reference_checking/checkers/dependency_checker.rb
+++ b/lib/packwerk/reference_checking/checkers/dependency_checker.rb
@@ -25,6 +25,21 @@ module Packwerk
           return false if reference.source_package.dependency?(reference.constant.package)
           true
         end
+
+        sig do
+          override
+            .params(reference: Packwerk::Reference)
+            .returns(String)
+        end
+        def message(reference)
+          <<~EOS
+            Dependency violation: #{reference.constant.name} belongs to '#{reference.constant.package}', but '#{reference.source_package}' does not specify a dependency on '#{reference.constant.package}'.
+            Are we missing an abstraction?
+            Is the code making the reference, and the referenced constant, in the right packages?
+
+            #{standard_help_message(reference)}
+          EOS
+        end
       end
     end
   end

--- a/lib/packwerk/reference_checking/checkers/privacy_checker.rb
+++ b/lib/packwerk/reference_checking/checkers/privacy_checker.rb
@@ -31,6 +31,24 @@ module Packwerk
           true
         end
 
+        sig do
+          override
+            .params(reference: Packwerk::Reference)
+            .returns(String)
+        end
+        def message(reference)
+          source_desc = "'#{reference.source_package}'"
+
+          message = <<~EOS
+            Privacy violation: '#{reference.constant.name}' is private to '#{reference.constant.package}' but referenced from #{source_desc}.
+            Is there a public entrypoint in '#{reference.constant.package.public_path}' that you can use instead?
+
+            #{standard_help_message(reference)}
+          EOS
+
+          message.chomp
+        end
+
         private
 
         sig do

--- a/lib/packwerk/reference_checking/reference_checker.rb
+++ b/lib/packwerk/reference_checking/reference_checker.rb
@@ -22,7 +22,8 @@ module Packwerk
           offense = Packwerk::ReferenceOffense.new(
             location: reference.source_location,
             reference: reference,
-            violation_type: checker.violation_type
+            violation_type: checker.violation_type,
+            message: checker.message(reference)
           )
           violations << offense
         end

--- a/lib/packwerk/reference_offense.rb
+++ b/lib/packwerk/reference_offense.rb
@@ -17,39 +17,15 @@ module Packwerk
       params(
         reference: Packwerk::Reference,
         violation_type: Packwerk::ViolationType,
+        message: String,
         location: T.nilable(Node::Location)
       )
         .void
     end
-    def initialize(reference:, violation_type:, location: nil)
-      super(file: reference.relative_path, message: build_message(reference, violation_type), location: location)
+    def initialize(reference:, violation_type:, message:, location: nil)
+      super(file: reference.relative_path, message: message, location: location)
       @reference = reference
       @violation_type = violation_type
-    end
-
-    private
-
-    sig { params(reference: Reference, violation_type: ViolationType).returns(String) }
-    def build_message(reference, violation_type)
-      violation_message = case violation_type
-      when ViolationType::Privacy
-        source_desc = "'#{reference.source_package}'"
-        "Privacy violation: '#{reference.constant.name}' is private to '#{reference.constant.package}' but " \
-        "referenced from #{source_desc}.\n" \
-        "Is there a public entrypoint in '#{reference.constant.package.public_path}' that you can use instead?"
-      when ViolationType::Dependency
-        "Dependency violation: #{reference.constant.name} belongs to '#{reference.constant.package}', but " \
-        "'#{reference.source_package}' does not specify a dependency on " \
-        "'#{reference.constant.package}'.\n" \
-        "Are we missing an abstraction?\n" \
-        "Is the code making the reference, and the referenced constant, in the right packages?\n"
-      end
-
-      <<~EOS
-        #{violation_message}
-        Inference details: this is a reference to #{reference.constant.name} which seems to be defined in #{reference.constant.location}.
-        To receive help interpreting or resolving this error message, see: https://github.com/Shopify/packwerk/blob/main/TROUBLESHOOT.md#Troubleshooting-violations
-      EOS
     end
   end
 end

--- a/test/integration/offense_collection_test.rb
+++ b/test/integration/offense_collection_test.rb
@@ -26,6 +26,7 @@ module Packwerk
             constant_name: "::Foo",
             source_package: Package.new(name: ".", config: nil)
           ),
+          message: "some message",
           violation_type: ViolationType::Dependency
         )
         offense2 = ReferenceOffense.new(
@@ -33,6 +34,7 @@ module Packwerk
             constant_name: "::Bar",
             source_package: Package.new(name: ".", config: nil)
           ),
+          message: "some message",
           violation_type: ViolationType::Dependency
         )
         @offense_collection.add_offense(offense1)

--- a/test/unit/offense_collection_test.rb
+++ b/test/unit/offense_collection_test.rb
@@ -9,7 +9,11 @@ module Packwerk
 
     setup do
       @offense_collection = OffenseCollection.new(".")
-      @offense = ReferenceOffense.new(reference: build_reference, violation_type: ViolationType::Dependency)
+      @offense = ReferenceOffense.new(
+        reference: build_reference,
+        violation_type: ViolationType::Dependency,
+        message: "some message"
+      )
     end
 
     test "#add_violation adds entry and returns true" do
@@ -53,12 +57,22 @@ module Packwerk
         .with(package, "./buyer/deprecated_references.yml")
         .returns(deprecated_references)
 
-      offense = Packwerk::ReferenceOffense.new(reference: reference, violation_type: ViolationType::Dependency)
+      offense = Packwerk::ReferenceOffense.new(
+        reference: reference,
+        violation_type: ViolationType::Dependency,
+        message: "some message"
+      )
+
       assert @offense_collection.listed?(offense)
     end
 
     test "#listed? returns false if constant is not listed in file " do
-      offense = Packwerk::ReferenceOffense.new(reference: build_reference, violation_type: ViolationType::Dependency)
+      offense = Packwerk::ReferenceOffense.new(
+        reference: build_reference,
+        violation_type: ViolationType::Dependency,
+        message: "some message"
+      )
+
       refute @offense_collection.listed?(offense)
     end
   end

--- a/test/unit/parse_run_test.rb
+++ b/test/unit/parse_run_test.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 require "test_helper"
 require "rails_test_helper"
@@ -73,7 +74,12 @@ module Packwerk
 
     test "#check only reports error progress for unlisted violations" do
       use_template(:minimal)
-      offense = ReferenceOffense.new(reference: build_reference, violation_type: ViolationType::Privacy)
+      offense = ReferenceOffense.new(
+        reference: build_reference,
+        message: "some message",
+        violation_type: ViolationType::Privacy
+      )
+
       DeprecatedReferences.any_instance.stubs(:listed?).returns(true)
       out = StringIO.new
       parse_run = Packwerk::ParseRun.new(
@@ -101,7 +107,12 @@ module Packwerk
 
     test "#check result has failure status when stale violations exist" do
       use_template(:minimal)
-      offense = ReferenceOffense.new(reference: build_reference, violation_type: ViolationType::Privacy)
+      offense = ReferenceOffense.new(
+        reference: build_reference,
+        message: "some message",
+        violation_type: ViolationType::Privacy
+      )
+
       DeprecatedReferences.any_instance.stubs(:listed?).returns(true)
       OffenseCollection.any_instance.stubs(:stale_violations?).returns(true)
       out = StringIO.new
@@ -131,9 +142,15 @@ module Packwerk
 
     test "runs in parallel" do
       use_template(:minimal)
-      offense = ReferenceOffense.new(reference: build_reference, violation_type: ViolationType::Privacy)
+      offense = ReferenceOffense.new(
+        reference: build_reference,
+        message: "some message",
+        violation_type: ViolationType::Privacy
+      )
+
       offense2 = ReferenceOffense.new(
         reference: build_reference(path: "some/other_path.rb"),
+        message: "some message",
         violation_type: ViolationType::Privacy
       )
       parse_run = Packwerk::ParseRun.new(

--- a/test/unit/reference_checking/reference_checker_test.rb
+++ b/test/unit/reference_checking/reference_checker_test.rb
@@ -13,6 +13,7 @@ module Packwerk
       def initialize(**options)
         @is_invalid_reference = options[:invalid_reference?]
         @violation_type = options[:violation_type]
+        @message = options[:message]
       end
 
       def violation_type
@@ -22,14 +23,20 @@ module Packwerk
       def invalid_reference?(_reference)
         @is_invalid_reference
       end
+
+      def message(_reference)
+        @message
+      end
     end
 
     test "#call enumerates the list of checkers to create ReferenceOffense objects" do
+      input_reference = build_reference
+      message = ReferenceChecking::Checkers::PrivacyChecker.new.message(input_reference)
       instance = reference_checker([StubChecker.new(
         invalid_reference?: true,
+        message: message,
         violation_type: ViolationType::Privacy
       )])
-      input_reference = build_reference
       offenses = instance.call(input_reference)
 
       assert_equal 1, offenses.length

--- a/test/unit/reference_offense_test.rb
+++ b/test/unit/reference_offense_test.rb
@@ -1,4 +1,4 @@
-# typed: ignore
+# typed: true
 # frozen_string_literal: true
 
 require "test_helper"
@@ -13,12 +13,18 @@ module Packwerk
     end
 
     test "has its file attribute set to the relative path of the reference" do
-      offense = ReferenceOffense.new(reference: @reference, violation_type: ViolationType::Privacy)
+      offense = ReferenceOffense.new(
+        reference: @reference,
+        message: "some message",
+        violation_type: ViolationType::Privacy
+      )
+
       assert_equal(@reference.relative_path, offense.file)
     end
 
     test "generates a sensible message for privacy violations" do
-      offense = ReferenceOffense.new(reference: @reference, violation_type: ViolationType::Privacy)
+      message = ReferenceChecking::Checkers::PrivacyChecker.new.message(@reference)
+      offense = ReferenceOffense.new(reference: @reference, message: message, violation_type: ViolationType::Privacy)
 
       assert_match(
         "Privacy violation: '::SomeName' is private to 'destination_package' but referenced from " \
@@ -27,7 +33,8 @@ module Packwerk
     end
 
     test "generates a sensible message for dependency violations" do
-      offense = ReferenceOffense.new(reference: @reference, violation_type: ViolationType::Dependency)
+      message = ReferenceChecking::Checkers::DependencyChecker.new.message(@reference)
+      offense = ReferenceOffense.new(reference: @reference, message: message, violation_type: ViolationType::Dependency)
 
       expected = <<~EXPECTED
         Dependency violation: ::SomeName belongs to 'destination_package', but 'components/source' does not specify a dependency on 'destination_package'.


### PR DESCRIPTION
## What are you trying to accomplish?
The idea of packwerk being extendible to incorporate new "checkers" has been bounced around for a while now. 

Certain new issues that have come up (e.g. https://github.com/Shopify/packwerk/issues/192) demonstrate the desire for this sort of capability (in this case, the checker would enforce that we only list dependencies if there is at least one reference to a pack).

Other interesting checkers could be:
- visibility checker: allow packages to specify who they are visible to support using packages to divide up subsystems where only one pack contains the externally facing public API
- layered architecture: allow packages to specify what "layer" they are, such as "utilities," "platform", "business logic" and more. The user could configure the permitted order and the checker could ensure that utilities never rely on the business logic.
- serializable types at the boundaries: if we added a piece of data into reference (if the reference is defined in a sorbet signature), a client could configure a checker to ensure that public APIs only expose serializable types, such as `T::Struct`, at the boundaries, rather than ActiveRecord objects.

To make this possible, we need to make sure a couple of things are true:
### ✅ We want to make sure any part any checker logic is colocated within the checker. 

`lib/packwerk/reference_offense.rb` right now builds a message based on the violation type. We want this because in a world where the other checkers can exist, those checkers define their own message. Similarly, we want to make sure that no other part of the system is coupled to checker *implementation* and only to the interface.

### Packwerk contains an API to inject new checkers.
There are a variety of ways to support this. The simplest might be to support a `Packwerk.configure { |config| config.checkers << [...] }` type of API.

### The interface for a checker is sufficiently flexible to support a variety of checks.
Note that file processing runs in parallel, but checking happens in serial. This means each checker ends up receiving every reference. I have a PR to change the interface for a checker to receive the array of every single reference. This would support checkers that can do things like the above (e.g. check if pack A refers to any constants in pack B and if not, creates a stale dependency offense).

## What should reviewers focus on?
Is there any reason why we wouldn't want this behavior in the checker itself?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
