### PR TITLE
Commenting out sorbet markup to get successful update-deprecations run

### DIFF
--- a/lib/packwerk/package_set.rb
+++ b/lib/packwerk/package_set.rb
@@ -12,7 +12,7 @@ module Packwerk
     extend T::Generic
     include Enumerable
 
-    Elem = type_member(fixed: Package)
+    # Elem = type_member(fixed: Package)
 
     PACKAGE_CONFIG_FILENAME = "package.yml"
 


### PR DESCRIPTION
This is not (yet) an attempt at a PR, but rather a bug report. With a fresh rails app and dependencies freshly installed, I can no longer run `update-deprecations` without error. Commenting out the line that's changed in this PR allows `update-deprecations` to succeed. Pretty sure that's not the right fix though :) 

```
$ bundle exec packwerk update-deprecations
📦 Packwerk is inspecting 65 files
DEBUGGER: Attaching after process 95816 fork to child process 95820
DEBUGGER[./bin/packwerk#95821]: Attaching after process 95816 fork to child process 95821
DEBUGGER[./bin/packwerk#95822]: Attaching after process 95816 fork to child process 95822
DEBUGGER[./bin/packwerk#95823]: Attaching after process 95816 fork to child process 95823
DEBUGGER[./bin/packwerk#95824]: Attaching after process 95816 fork to child process 95824
DEBUGGER[./bin/packwerk#95825]: Attaching after process 95816 fork to child process 95825
DEBUGGER[./bin/packwerk#95827]: Attaching after process 95816 fork to child process 95827
DEBUGGER[./bin/packwerk#95828]: Attaching after process 95816 fork to child process 95828
DEBUGGER[./bin/packwerk#95829]: Attaching after process 95816 fork to child process 95829
DEBUGGER[./bin/packwerk#95830]: Attaching after process 95816 fork to child process 95830
bundler: failed to load command: packwerk (./bin/packwerk)
./gems/sorbet-runtime-0.5.9905/lib/types/types/type_variable.rb:14:in `initialize': Pass bounds using a block. Got: {:fixed=>Packwerk::Package} (ArgumentError)
	from ./gems/sorbet-runtime-0.5.9905/lib/types/generic.rb:16:in `new'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/generic.rb:16:in `type_member'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/package_set.rb:15:in `<class:PackageSet>'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/package_set.rb:10:in `<module:Packwerk>'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/package_set.rb:6:in `<main>'
	from ./gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from ./gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from ./gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/run_context.rb:126:in `block in <class:RunContext>'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:351:in `instance_exec'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:351:in `run_builder'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:331:in `run_sig'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:241:in `block in _on_method_added'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:440:in `run_sig_block_for_key'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:420:in `maybe_run_sig_block_for_key'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:251:in `block in _on_method_added'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/run_context.rb:113:in `context_provider'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `bind_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `validate_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/run_context.rb:103:in `node_processor_factory'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `bind_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `validate_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/run_context.rb:97:in `file_processor'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `bind_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `validate_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/run_context.rb:82:in `process_file'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `bind_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `validate_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/parse_run.rb:82:in `block in find_offenses'
	from ./gems/parallel-1.22.1/lib/parallel.rb:587:in `call_with_index'
	from ./gems/parallel-1.22.1/lib/parallel.rb:557:in `process_incoming_jobs'
	from ./gems/parallel-1.22.1/lib/parallel.rb:537:in `block in worker'
	from ./gems/debug-1.5.0/lib/debug/session.rb:2163:in `block in fork'
	from ./gems/debug-1.5.0/lib/debug/session.rb:2165:in `fork'
	from ./gems/debug-1.5.0/lib/debug/session.rb:2165:in `fork'
	from ./gems/parallel-1.22.1/lib/parallel.rb:528:in `worker'
	from ./gems/parallel-1.22.1/lib/parallel.rb:519:in `block in create_workers'
	from ./gems/parallel-1.22.1/lib/parallel.rb:518:in `each'
	from ./gems/parallel-1.22.1/lib/parallel.rb:518:in `each_with_index'
	from ./gems/parallel-1.22.1/lib/parallel.rb:518:in `create_workers'
	from ./gems/parallel-1.22.1/lib/parallel.rb:457:in `work_in_processes'
	from ./gems/parallel-1.22.1/lib/parallel.rb:294:in `map'
	from ./gems/parallel-1.22.1/lib/parallel.rb:307:in `flat_map'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/parse_run.rb:90:in `block in find_offenses'
	from /Users/stephan/.rvm/rubies/ruby-3.0.1/lib/ruby/3.0.0/benchmark.rb:308:in `realtime'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/parse_run.rb:88:in `find_offenses'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `bind_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `validate_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/parse_run.rb:47:in `update_deprecations'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `bind_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `validate_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/cli.rb:60:in `execute_command'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `bind_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `validate_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
	from /Users/stephan/Documents/projects/packages/packwerk/lib/packwerk/cli.rb:43:in `run'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `bind_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/call_validation.rb:161:in `validate_call'
	from ./gems/sorbet-runtime-0.5.9905/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
	from /Users/stephan/Documents/projects/packages/packwerk/exe/packwerk:12:in `<top (required)>'
	from ./bin/packwerk:23:in `load'
	from ./bin/packwerk:23:in `<top (required)>'
	from ./gems/bundler-2.3.4/lib/bundler/cli/exec.rb:58:in `load'
	from ./gems/bundler-2.3.4/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from ./gems/bundler-2.3.4/lib/bundler/cli/exec.rb:23:in `run'
	from ./gems/bundler-2.3.4/lib/bundler/cli.rb:484:in `exec'
	from ./gems/bundler-2.3.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from ./gems/bundler-2.3.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from ./gems/bundler-2.3.4/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from ./gems/bundler-2.3.4/lib/bundler/cli.rb:31:in `dispatch'
	from ./gems/bundler-2.3.4/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from ./gems/bundler-2.3.4/lib/bundler/cli.rb:25:in `start'
	from ./gems/bundler-2.3.4/exe/bundle:48:in `block in <top (required)>'
	from ./gems/bundler-2.3.4/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
	from ./gems/bundler-2.3.4/exe/bundle:36:in `<top (required)>'
	from ./bin/bundle:23:in `load'
	from ./bin/bundle:23:in `<main>'
```