### PR TITLE
Remove `digest` dependency from gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,6 @@ PATH
       better_html
       bundler
       constant_resolver (>= 0.2.0)
-      digest
       parallel
       parser
       sorbet-runtime (>= 0.5.9914)
@@ -119,7 +118,6 @@ GEM
     concurrent-ruby (1.1.8)
     constant_resolver (0.2.0)
     crass (1.0.6)
-    digest (3.1.0)
     erubi (1.10.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)

--- a/packwerk.gemspec
+++ b/packwerk.gemspec
@@ -45,7 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency("parallel")
   spec.add_dependency("sorbet-runtime", ">=0.5.9914")
   spec.add_dependency("bundler")
-  spec.add_dependency("digest")
 
   spec.add_development_dependency("rake")
   spec.add_development_dependency("sorbet")


### PR DESCRIPTION
## What are you trying to accomplish?
`digest` is a standard gem and as such is bundled with Ruby 3.0+, while in previous Ruby versions it's part of stdlib.
Having the gem explicitly added to the gemspec can cause issues downstream on projects using older ruby versions.
This is because it's actually possible to load the code twice, once from the stdlib and once from the gem.

## What approach did you choose and why?
Removing the dependency should have absolutely no effect on the code.
For people running Ruby 2.7 or previous, the `require "digest"` in `cache.rb` will load the stdlib file, while for those running Ruby 3.0+ it will load the standard gem.

## What should reviewers focus on?
Cross-compatibility with Ruby 2 and Ruby 3 

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.

cc @rafaelfranca @AlexEvanczuk 