### PR TITLE
update explanation in USAGE for packwerk validate

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -204,17 +204,17 @@ It will be a dependency violation when `components/shop_identity` tries to refer
 
 After enforcing the boundary checks for a package, you may execute:
 
-    packwerk check
+    bin/packwerk check
 
 Packwerk will check the entire codebase for any new or stale violations.
 
 You can also specify folders for a shorter run time. When checking against folders all subfolders will be analyzed, irrespective of nested package boundaries.
 
-    packwerk check components/your_package
+    bin/packwerk check components/your_package
 
 You can also specify packages for a shorter run time. When checking against packages any packages nested underneath the specified packages will not be checked. This can be helpful to test packages like the root package, which can have many nested packages.
 
-    packwerk check --packages=components/your_package,components/your_other_package
+    bin/packwerk check --packages=components/your_package,components/your_other_package
 
 ![](static/packwerk_check.gif)
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -115,7 +115,7 @@ We recommend setting up the package system validation for your Rails application
 
 Use the following command to validate the application:
 
-    packwerk validate
+    bin/packwerk validate
 
 ![](static/packwerk_validate.gif)
 


### PR DESCRIPTION
## What are you trying to accomplish?
`packwerk validate` command fails, instead we should use `bin/packwerk validate`
In the "Usage" explanation we mention `packwerk validate` command that will fail, see the [issue](https://github.com/Shopify/packwerk/issues/209) which is closed but not fixed.

## What approach did you choose and why?
changing the explanation is the easiest way to fix

## What should reviewers focus on?
wording

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
