### PR TITLE
Create an offense when an ERB with CDATA tags is parsed

### DIFF
--- a/lib/packwerk/parsers/erb.rb
+++ b/lib/packwerk/parsers/erb.rb
@@ -31,6 +31,17 @@ module Packwerk
       rescue Parser::SyntaxError => e
         result = ParseResult.new(file: file_path, message: "Syntax error: #{e}")
         raise Parsers::ParseError, result
+      rescue RuntimeError => e
+        if e.message.include?("Unhandled token cdata_end")
+          message = <<~MESSAGE
+            Packwerk cannot parse ERB files with CDATA tags.
+            Please add this file to the `exclude` key of `packwerk.yml`
+          MESSAGE
+          result = ParseResult.new(file: file_path, message: message)
+          raise Parsers::ParseError, result
+        else
+          raise
+        end
       end
 
       private

--- a/test/fixtures/formats/erb/with_cdata.erb
+++ b/test/fixtures/formats/erb/with_cdata.erb
@@ -1,0 +1,34 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <%= instrumentation_header %>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="chrome=1">
+  <meta http-equiv="imagetoolbar" content="no">
+
+  <%= tag :meta, name: "referrer", content: "never" %>
+
+  <title><%= @title || "My Test Site" %></title>
+
+  <%= stylesheet_link_tag MyNamespace::MY_CONSTANT, integrity: true, crossorigin: "anonymous" %>
+  <%= javascript_include_tag "jquery", integrity: true, crossorigin: "anonymous" %>
+
+  <%= csrf_meta_tag %>
+
+  <%= yield :header %>
+</head>
+<%# here's the body %>
+<body>
+  <ul>
+  <% @things.each do |thing| %>
+    <li><%= thing %></Li>
+  <% end %>
+  </ul>
+
+  <div id="body">
+
+    <%= yield :body %>
+  </div>
+  <![CDATA[foo]]><![CDATA[bar]]>
+</body>
+</html>


### PR DESCRIPTION
## What are you trying to accomplish?

Fix #212

## What approach did you choose and why?

I decided to explicitly raise an offense, asking the client to explicitly ignore the file. I think this makes the most sense and matches the rest of behavior when we cannot parse a file.

## What should reviewers focus on?

Should we be silently ignoring the ERB instead?

## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
