### PR TITLE
Switch application load path finding to zeitwerk

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ PATH
       parallel
       parser
       sorbet-runtime (>= 0.5.9914)
+      zeitwerk
 
 GEM
   remote: https://rubygems.org/
@@ -258,7 +259,6 @@ DEPENDENCIES
   sorbet-runtime
   spring
   tapioca
-  zeitwerk
 
 BUNDLED WITH
    2.3.5

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We are keeping `packwerk` compatible with current versions of Ruby and Rails, bu
 
 -- _Sandi Metz, Practical Object-Oriented Design in Ruby_
 
-Packwerk is a Ruby gem used to enforce boundaries and modularize Rails applications.
+Packwerk is a Ruby gem used to enforce boundaries and modularize Ruby applications (including Rails apps!).
 
 Packwerk can be used to:
 * Combine groups of files into packages

--- a/lib/packwerk/application_load_paths.rb
+++ b/lib/packwerk/application_load_paths.rb
@@ -20,7 +20,7 @@ module Packwerk
 
       sig { returns(T::Hash[String, Module]) }
       def extract_application_autoload_paths
-        Rails.autoloaders.inject({}) do |h, loader|
+        Zeitwerk::Registry.loaders.inject({}) do |h, loader|
           h.merge(loader.root_dirs)
         end
       end

--- a/lib/packwerk/application_load_paths.rb
+++ b/lib/packwerk/application_load_paths.rb
@@ -9,7 +9,7 @@ module Packwerk
     class << self
       extend T::Sig
 
-      sig { params(root: String, environment: String).returns(T::Hash[String, Module]) }
+      sig { params(root: String, environment: String).returns(T::Array[String]) }
       def extract_relevant_paths(root, environment)
         require_application(root, environment)
         all_paths = extract_application_autoload_paths
@@ -18,30 +18,28 @@ module Packwerk
         relative_path_strings(relevant_paths)
       end
 
-      sig { returns(T::Hash[String, Module]) }
+      sig { returns(T::Array[String]) }
       def extract_application_autoload_paths
-        Zeitwerk::Registry.loaders.inject({}) do |h, loader|
-          h.merge(loader.root_dirs)
-        end
+        Zeitwerk::Loader.all_dirs
       end
 
       sig do
-        params(all_paths: T::Hash[String, Module], bundle_path: Pathname, rails_root: Pathname)
-          .returns(T::Hash[Pathname, Module])
+        params(all_paths: T::Array[String], bundle_path: Pathname, rails_root: Pathname)
+          .returns(T::Array[Pathname])
       end
       def filter_relevant_paths(all_paths, bundle_path: Bundler.bundle_path, rails_root: Rails.root)
         bundle_path_match = bundle_path.join("**")
         rails_root_match = rails_root.join("**")
 
         all_paths
-          .transform_keys { |path| Pathname.new(path).expand_path }
+          .map { |path| Pathname.new(path).expand_path }
           .select { |path| path.fnmatch(rails_root_match.to_s) } # path needs to be in application directory
           .reject { |path| path.fnmatch(bundle_path_match.to_s) } # reject paths from vendored gems
       end
 
-      sig { params(load_paths: T::Hash[Pathname, Module], rails_root: Pathname).returns(T::Hash[String, Module]) }
+      sig { params(load_paths: T::Array[Pathname], rails_root: Pathname).returns(T::Array[String]) }
       def relative_path_strings(load_paths, rails_root: Rails.root)
-        load_paths.transform_keys { |path| Pathname.new(path).relative_path_from(rails_root).to_s }
+        load_paths.map { |path| Pathname.new(path).relative_path_from(rails_root).to_s }
       end
 
       private
@@ -59,7 +57,7 @@ module Packwerk
         end
       end
 
-      sig { params(paths: T::Hash[T.untyped, Module]).void }
+      sig { params(paths: T::Array[Pathname]).void }
       def assert_load_paths_present(paths)
         if paths.empty?
           raise <<~EOS

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -38,7 +38,7 @@ module Packwerk
     sig do
       params(
         root_path: String,
-        load_paths: T::Hash[String, Module],
+        load_paths: T::Array[String],
         inflector: T.class_of(ActiveSupport::Inflector),
         cache_directory: Pathname,
         config_path: T.nilable(String),

--- a/packwerk.gemspec
+++ b/packwerk.gemspec
@@ -45,13 +45,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency("constant_resolver", ">=0.2.0")
   spec.add_dependency("parallel")
   spec.add_dependency("sorbet-runtime", ">=0.5.9914")
+  spec.add_dependency("zeitwerk")
 
   spec.add_development_dependency("m")
   spec.add_development_dependency("rake")
   spec.add_development_dependency("sorbet")
   # https://github.com/ruby/psych/pull/487
   spec.add_development_dependency("psych", "~> 3")
-  spec.add_development_dependency("zeitwerk")
 
   # For Ruby parsing
   spec.add_dependency("ast")

--- a/test/unit/application_load_paths_test.rb
+++ b/test/unit/application_load_paths_test.rb
@@ -11,41 +11,41 @@ module Packwerk
       relative_path = "app/models"
       absolute_path = rails_root.join(relative_path)
       relative_path_strings = ApplicationLoadPaths.relative_path_strings(
-        { absolute_path => Object },
+        [absolute_path],
         rails_root: rails_root
       )
 
-      assert_equal({ relative_path => Object }, relative_path_strings)
+      assert_equal([relative_path], relative_path_strings)
     end
 
     test ".filter_relevant_paths excludes paths outside of the application root" do
       valid_paths = ["/application/app/models"]
       paths = valid_paths + ["/users/tobi/.gems/something/app/models", "/application/../something/"]
-      paths = paths.each_with_object({}) { |p, h| h[p.to_s] = Object }
+      # paths = paths.each_with_object([]) { |p, h| h << p.to_s }
       filtered_paths = ApplicationLoadPaths.filter_relevant_paths(
         paths,
         bundle_path: Pathname.new("/application/vendor/"),
         rails_root: Pathname.new("/application/")
       )
 
-      assert_equal({ "/application/app/models" => Object }, filtered_paths.transform_keys(&:to_s))
+      assert_equal(["/application/app/models"], filtered_paths.map(&:to_s))
     end
 
     test ".filter_relevant_paths excludes paths from vendored gems" do
       valid_paths = ["/application/app/models"]
       paths = valid_paths + ["/application/vendor/something/app/models"]
-      paths = paths.each_with_object({}) { |p, h| h[p.to_s] = Object }
+      # paths = paths.each_with_object({}) { |p, h| h[p.to_s] = Object }
       filtered_paths = ApplicationLoadPaths.filter_relevant_paths(
         paths,
         bundle_path: Pathname.new("/application/vendor/"),
         rails_root: Pathname.new("/application/")
       )
 
-      assert_equal({ "/application/app/models" => Object }, filtered_paths.transform_keys(&:to_s))
+      assert_equal(["/application/app/models"], filtered_paths.map(&:to_s))
     end
 
     test ".extract_relevant_paths calls out to filter the paths" do
-      ApplicationLoadPaths.expects(:filter_relevant_paths).once.returns(Pathname.new("/fake_path").to_s => Object)
+      ApplicationLoadPaths.expects(:filter_relevant_paths).once.returns([Pathname.new("/fake_path").to_s])
       ApplicationLoadPaths.expects(:require_application).with("/application", "test").once.returns(true)
 
       ApplicationLoadPaths.extract_relevant_paths("/application", "test")
@@ -60,7 +60,7 @@ module Packwerk
         "components/timeline/app/models/concerns",
         "vendor/cache/gems/example/models",
       ],
-        result.keys)
+        result)
 
       loader = Zeitwerk::Loader.new
       loader.push_dir("./test/fixtures/skeleton/gems/gem_a")
@@ -74,7 +74,7 @@ module Packwerk
         "vendor/cache/gems/example/models",
         "gems/gem_a",
       ],
-        result.keys)
+        result)
     end
   end
 end

--- a/test/unit/application_load_paths_test.rb
+++ b/test/unit/application_load_paths_test.rb
@@ -54,29 +54,27 @@ module Packwerk
     test ".extract_relevant_paths uses Zeitwerk loaders" do
       result = ApplicationLoadPaths.extract_relevant_paths("./test/fixtures/skeleton", "test")
       assert_equal([
-          "components/sales/app/models", 
-          "components/platform/app/models", 
-          "components/timeline/app/models", 
-          "components/timeline/app/models/concerns", 
-          "vendor/cache/gems/example/models", 
-        ], 
-        result.keys
-      )
+        "components/sales/app/models",
+        "components/platform/app/models",
+        "components/timeline/app/models",
+        "components/timeline/app/models/concerns",
+        "vendor/cache/gems/example/models",
+      ],
+        result.keys)
 
       loader = Zeitwerk::Loader.new
-      loader.push_dir('./test/fixtures/skeleton/gems/gem_a')
+      loader.push_dir("./test/fixtures/skeleton/gems/gem_a")
 
       result = ApplicationLoadPaths.extract_relevant_paths("./test/fixtures/skeleton", "test")
       assert_equal([
-          "components/sales/app/models", 
-          "components/platform/app/models", 
-          "components/timeline/app/models", 
-          "components/timeline/app/models/concerns", 
-          "vendor/cache/gems/example/models", 
-          "gems/gem_a",
-        ], 
-        result.keys
-      )
+        "components/sales/app/models",
+        "components/platform/app/models",
+        "components/timeline/app/models",
+        "components/timeline/app/models/concerns",
+        "vendor/cache/gems/example/models",
+        "gems/gem_a",
+      ],
+        result.keys)
     end
   end
 end

--- a/test/unit/application_load_paths_test.rb
+++ b/test/unit/application_load_paths_test.rb
@@ -50,5 +50,33 @@ module Packwerk
 
       ApplicationLoadPaths.extract_relevant_paths("/application", "test")
     end
+
+    test ".extract_relevant_paths uses Zeitwerk loaders" do
+      result = ApplicationLoadPaths.extract_relevant_paths("./test/fixtures/skeleton", "test")
+      assert_equal([
+          "components/sales/app/models", 
+          "components/platform/app/models", 
+          "components/timeline/app/models", 
+          "components/timeline/app/models/concerns", 
+          "vendor/cache/gems/example/models", 
+        ], 
+        result.keys
+      )
+
+      loader = Zeitwerk::Loader.new
+      loader.push_dir('./test/fixtures/skeleton/gems/gem_a')
+
+      result = ApplicationLoadPaths.extract_relevant_paths("./test/fixtures/skeleton", "test")
+      assert_equal([
+          "components/sales/app/models", 
+          "components/platform/app/models", 
+          "components/timeline/app/models", 
+          "components/timeline/app/models/concerns", 
+          "vendor/cache/gems/example/models", 
+          "gems/gem_a",
+        ], 
+        result.keys
+      )
+    end
   end
 end

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -24,7 +24,7 @@ module Packwerk
       offense = Offense.new(file: file_path, message: violation_message)
 
       configuration = Configuration.new({ "parallel" => false })
-      configuration.stubs(load_paths: {})
+      configuration.stubs(load_paths: [])
       RunContext.any_instance.stubs(:process_file).at_least_once.returns([offense])
 
       string_io = StringIO.new
@@ -49,7 +49,7 @@ module Packwerk
       offense = Offense.new(file: file_path, message: violation_message)
 
       configuration = Configuration.new({ "parallel" => false })
-      configuration.stubs(load_paths: {})
+      configuration.stubs(load_paths: [])
 
       RunContext.any_instance.stubs(:process_file)
         .at_least(2)
@@ -137,7 +137,7 @@ module Packwerk
       offense = Offense.new(file: file_path, message: violation_message)
 
       configuration = Configuration.new
-      configuration.stubs(load_paths: {})
+      configuration.stubs(load_paths: [])
       RunContext.any_instance.stubs(:process_file)
         .returns([offense])
 


### PR DESCRIPTION
## What are you trying to accomplish?
Packwerk currently uses `Rails.autoloaders` to determine the load paths it should include in its analysis.

For unbuilt gems that are added to the application via the `path:` option in the `Gemfile`, this means that they have be turned into an engine for their paths to be picked up. One can either fully turn the gem into an engine or do so opportunistically when Rails is defined like so:

```
if defined?(Rails)
  require 'testgem/engine'
else
  require 'zeitwerk'
  loader = Zeitwerk::Loader.new
  loader.tag = File.basename(__FILE__, '.rb')
  loader.inflector = Zeitwerk::GemInflector.new(__FILE__)
  app_paths = Dir.glob(File.expand_path(File.join(__dir__, '../app', '/*')))
  app_paths.each { |k| loader.push_dir(k) }
  loader.setup
end
```

Here, for tests, `zeitwerk` is used to ensure that loading is the same (similar?) between tests and prod.

That `if` statement is quite gross ... and unnecessary!

This PR switches path finding from `Rails.autoloaders` to `Zeitwerk::Registry.loaders`, with which the `if` statement is no longer necessary and the gem doesn't need to be turned into an engine.

## What approach did you choose and why?
This PR makes `zeitwerk` a runtime dependency of `packwerk`. By switching from `Rails.autoloaders` to `Zeitwerk::Registry.loaders` any gem that uses zeitwerk for its file loading will be included in hackwork's analysis.

## What should reviewers focus on?
I have checked this against a large codebase at gusto. Performance and results are the same. I think it makes sense for others to do the same.

## Type of Change

- [ ] Bugfix
- [X] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [X] Breaking change (fix or feature that would cause existing functionality to change)

Unbuilt gems in a codebase that use zeitwerk will not show up in packwerk violations before this and will show up in violations afterwards.

## Checklist

- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] It is safe to rollback this change.
