### PR TITLE
Colocate privacy API on Packwerk::Package

### DIFF
--- a/lib/packwerk/reference_checking/checkers/privacy_checker.rb
+++ b/lib/packwerk/reference_checking/checkers/privacy_checker.rb
@@ -6,6 +6,9 @@ module Packwerk
     module Checkers
       # Checks whether a given reference references a private constant of another package.
       class PrivacyChecker
+        extend ActiveSupport::Autoload
+        autoload :PrivacyProtectedPackage
+
         extend T::Sig
         include Checker
 

--- a/lib/packwerk/reference_checking/checkers/privacy_checker/privacy_protected_package.rb
+++ b/lib/packwerk/reference_checking/checkers/privacy_checker/privacy_protected_package.rb
@@ -1,0 +1,56 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Packwerk
+  module ReferenceChecking
+    module Checkers
+      # Checks whether a given reference references a private constant of another package.
+      class PrivacyChecker
+        class PrivacyProtectedPackage < T::Struct
+          extend T::Sig
+
+          const :public_path, String
+          const :user_defined_public_path, T.nilable(String)
+          const :enforce_privacy, T.nilable(T.any(T::Boolean, T::Array[String]))
+
+          sig { params(path: String).returns(T::Boolean) }
+          def public_path?(path)
+            path.start_with?(public_path)
+          end
+
+          class << self
+            extend T::Sig
+
+            sig { params(package: Package).returns(PrivacyProtectedPackage) }
+            def from(package)
+              PrivacyProtectedPackage.new(
+                public_path: public_path_for(package),
+                user_defined_public_path: user_defined_public_path(package),
+                enforce_privacy: package.config["enforce_privacy"],
+              )
+            end
+
+            sig { params(package: Package).returns(T.nilable(String)) }
+            def user_defined_public_path(package)
+              return unless package.config["public_path"]
+              return package.config["public_path"] if package.config["public_path"].end_with?("/")
+
+              package.config["public_path"] + "/"
+            end
+
+            sig { params(package: Package).returns(String) }
+            def public_path_for(package)
+              unprefixed_public_path = user_defined_public_path(package) || "app/public/"
+
+              if package.root?
+                unprefixed_public_path
+              else
+                File.join(package.name, unprefixed_public_path)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What are you trying to accomplish?
Much like https://github.com/Shopify/packwerk/pull/232, this moves us closer to #219 by colocating all concerns around privacy on `Packwerk::Package` by putting them in `PrivacyChecker`

## What approach did you choose and why?
I did not yet remove the old API on `Packwerk::Package`, since that would be a breaking API change, which I'd like to do all at once when we move `PrivacyChecker` to its own gem. When that happens, that gem can have a nice and easy to use API that can replace the old APIs folks were using on `Packwerk::Package`.

## What should reviewers focus on?
Let me know if this approach makes sense to you!

I'm wondering if I should just go ahead and remove the old API from `Packwerk::Package`. While it's probably best to assume folks *are* using it, I also wouldn't be surprised if very few or no clients are actually using them (`packwerk` itself is using them in very few places).

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
