### PR TITLE
Use Zeitwerk for autoloading

### DIFF
--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -8,81 +8,9 @@ require "fileutils"
 # Provides String#pluralize
 require "active_support/core_ext/string"
 
+require "zeitwerk"
+loader = Zeitwerk::Loader.for_gem
+loader.setup
+
 module Packwerk
-  extend ActiveSupport::Autoload
-
-  autoload :ApplicationLoadPaths
-  autoload :ApplicationValidator
-  autoload :AssociationInspector
-  autoload :OffenseCollection
-  autoload :Cache
-  autoload :Cli
-  autoload :Configuration
-  autoload :ConstantDiscovery
-  autoload :ConstantNameInspector
-  autoload :ConstNodeInspector
-  autoload :DeprecatedReferences
-  autoload :FileProcessor
-  autoload :FilesForProcessing
-  autoload :Graph
-  autoload :Node
-  autoload :NodeHelpers
-  autoload :NodeProcessor
-  autoload :NodeProcessorFactory
-  autoload :NodeVisitor
-  autoload :Offense
-  autoload :OffensesFormatter
-  autoload :OutputStyle
-  autoload :Package
-  autoload :PackageSet
-  autoload :ParsedConstantDefinitions
-  autoload :Parsers
-  autoload :ParseRun
-  autoload :UnresolvedReference
-  autoload :Reference
-  autoload :ReferenceExtractor
-  autoload :ReferenceOffense
-  autoload :Result
-  autoload :RunContext
-  autoload :Version
-  autoload :ViolationType
-
-  module OutputStyles
-    extend ActiveSupport::Autoload
-
-    autoload :Coloured
-    autoload :Plain
-  end
-
-  autoload_under "commands" do
-    autoload :OffenseProgressMarker
-  end
-
-  module Formatters
-    extend ActiveSupport::Autoload
-
-    autoload :OffensesFormatter
-    autoload :ProgressFormatter
-  end
-
-  module Generators
-    extend ActiveSupport::Autoload
-
-    autoload :ConfigurationFile
-    autoload :RootPackage
-  end
-
-  module ReferenceChecking
-    extend ActiveSupport::Autoload
-
-    autoload :ReferenceChecker
-
-    module Checkers
-      extend ActiveSupport::Autoload
-
-      autoload :Checker
-      autoload :DependencyChecker
-      autoload :PrivacyChecker
-    end
-  end
 end


### PR DESCRIPTION
## What are you trying to accomplish?
`packwerk` is based on the `zeitwerk` autoloader – figured we might as well use it!
We're already using `autoload`, which `zeitwerk` does for us automatically.

## What approach did you choose and why?
I followed the instructions in https://github.com/fxn/zeitwerk#synopsis

## What should reviewers focus on?
Any reason we don't want to do this?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
