### PR TITLE
Cleanup CLI

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -50,8 +50,6 @@ module Packwerk
       case subcommand
       when "init"
         init
-      when "generate_configs"
-        generate_configs
       when "check"
         output_result(parse_run(args).check)
       when "detect-stale-violations"

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -56,9 +56,7 @@ module Packwerk
         output_result(parse_run(args).check)
       when "detect-stale-violations"
         output_result(parse_run(args).detect_stale_violations)
-      when "update-todo"
-        output_result(parse_run(args).update_todo)
-      when "update"
+      when "update-todo", "update"
         output_result(parse_run(args).update_todo)
       when "validate"
         validate(args)

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -59,19 +59,11 @@ module Packwerk
       when "validate"
         validate(args)
       when nil, "help"
-        @err_out.puts(<<~USAGE)
-          Usage: #{$PROGRAM_NAME} <subcommand>
-
-          Subcommands:
-            init - set up packwerk
-            check - run all checks
-            update-todo - update package_todo.yml files
-            validate - verify integrity of packwerk and package configuration
-            help  - display help information about packwerk
-        USAGE
-        true
+        usage
       else
-        @err_out.puts("'#{subcommand}' is not a packwerk command. See `packwerk help`.")
+        @err_out.puts(
+          "'#{subcommand}' is not a packwerk command. See `packwerk help`."
+        )
         false
       end
     end
@@ -112,6 +104,21 @@ module Packwerk
 
       @out.puts(result)
       success
+    end
+
+    sig { returns(T::Boolean) }
+    def usage
+      @err_out.puts(<<~USAGE)
+        Usage: #{$PROGRAM_NAME} <subcommand>
+
+        Subcommands:
+          init - set up packwerk
+          check - run all checks
+          update-todo - update package_todo.yml files
+          validate - verify integrity of packwerk and package configuration
+          help  - display help information about packwerk
+      USAGE
+      true
     end
 
     sig { params(result: Result).returns(T::Boolean) }

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -34,6 +34,11 @@ module Packwerk
 
     sig { returns(Result) }
     def detect_stale_violations
+      warn(<<~WARNING.squish)
+        DEPRECATION WARNING: `detect-stale-violation` is deprecated,
+        the output of `check` includes stale references.
+      WARNING
+
       run_context = Packwerk::RunContext.from_configuration(@configuration)
       offense_collection = find_offenses(run_context)
 


### PR DESCRIPTION
## What are you trying to accomplish?

Clean up the CLI class.

## What approach did you choose and why?

Clean up the CLI to declutter the command parsing where clause and clean up  / deprecate old commands that aren't documented.

## What should reviewers focus on?

This removes the `generate_configs` subcommand and deprecates the `detect-stale-violations` subcommand.


## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

This _might_ be a breaking change if anyone is using the undocumented commands. Since we don't mention them anywhere, I think they are safe to delete.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
