### PR TITLE
Fix constant redefinition errors when stubbing constants

### DIFF
--- a/test/support/stub_const.rb
+++ b/test/support/stub_const.rb
@@ -1,12 +1,25 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module StubConst
-  def with_stubbed_const(klass, const, val)
-    original_value = klass.const_get(const) # rubocop:disable Sorbet/ConstantsFromStrings
-    klass.const_set(const, val)
-    yield
-  ensure
-    klass.const_set(const, original_value)
+  extend T::Sig
+
+  sig do
+    params(
+      mod: Module,
+      const: T.any(Symbol, String),
+      value: Object,
+      block: T.proc.void
+    ).void
+  end
+  def with_stubbed_const(mod, const, value, &block)
+    original_value = mod.const_get(const) # rubocop:disable Sorbet/ConstantsFromStrings
+
+    Kernel.silence_warnings do
+      mod.const_set(const, value)
+      yield
+    ensure
+      mod.const_set(const, original_value)
+    end
   end
 end


### PR DESCRIPTION
## What are you trying to accomplish?

Fix constant redefinition errors when running tests. 


## What approach did you choose and why?

Type the stub_const module and silence warnings when performing const_sets.

## What should reviewers focus on?



## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
