### PR TITLE
Update gemspec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         gemfile:
           - Gemfile
           - gemfiles/Gemfile-rails-6-0
-          - gemfiles/Gemfile-rails-7-0
+          - gemfiles/Gemfile-rails-6-1
         ruby:
           - 2.7
           - 3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     packwerk (2.2.1)
-      activesupport (>= 5.2)
+      activesupport (>= 6.0)
       ast
       better_html
       bundler

--- a/gemfiles/Gemfile-rails-6-1
+++ b/gemfiles/Gemfile-rails-6-1
@@ -7,7 +7,7 @@ gemspec path: ".."
 # Specify the same dependency sources as the application Gemfile
 
 gem("spring")
-gem("rails", "~> 7.0")
+gem("rails", "~> 6.1")
 gem("constant_resolver", require: false)
 gem("sorbet-runtime", require: false)
 gem("rubocop-performance", require: false)

--- a/packwerk.gemspec
+++ b/packwerk.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency("activesupport", ">= 5.2")
   spec.add_dependency("bundler")

--- a/packwerk.gemspec
+++ b/packwerk.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_dependency("activesupport", ">= 5.2")
+  spec.add_dependency("activesupport", ">= 6.0")
   spec.add_dependency("bundler")
   spec.add_dependency("constant_resolver", ">= 0.2.0")
   spec.add_dependency("parallel")


### PR DESCRIPTION
## What are you trying to accomplish?

Followup on https://github.com/Shopify/packwerk/pull/252. I didn't update the gemspec 🤦 

## What approach did you choose and why?

Update the gemspec to drop support for Ruby 2.6, bump minimum activesupport, and revert the rails change since it as already covered by the normal gemfile.

## What should reviewers focus on?

Active Support should've been bumped earlier since we don't have test coverage for Rails 5 anymore. 

Also do we think we should be testing against edge rails / zeitwerk?

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [x] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
