### PR TITLE
Allow Checker to define the location of its violations

### DIFF
--- a/lib/packwerk/checker.rb
+++ b/lib/packwerk/checker.rb
@@ -6,10 +6,10 @@ module Packwerk
     extend T::Sig
     extend T::Helpers
 
-    class TodoLocation < T::Enum
+    class OffendingPackage < T::Enum
       enums do
-        PackageReferencingConstant = new
-        PackageDefiningConstant = new
+        ReferencePackage = new
+        DefinitionPackage = new
       end
     end
 
@@ -54,18 +54,18 @@ module Packwerk
     sig { abstract.params(reference: Reference).returns(String) }
     def message(reference); end
 
-    sig { returns(TodoLocation) }
+    sig { returns(OffendingPackage) }
     def todo_location
-      TodoLocation::PackageReferencingConstant
+      OffendingPackage::ReferencePackage
     end
 
     sig { params(reference: Reference).returns(Package) }
-    def todo_file_for(reference)
+    def offending_package_for(reference)
       location = todo_location
       case location
-      when TodoLocation::PackageDefiningConstant
+      when OffendingPackage::DefinitionPackage
         reference.constant.package
-      when TodoLocation::PackageReferencingConstant
+      when OffendingPackage::ReferencePackage
         reference.source_package
       else
         T.absurd(location)

--- a/lib/packwerk/checker.rb
+++ b/lib/packwerk/checker.rb
@@ -25,7 +25,16 @@ module Packwerk
 
       sig { params(violation_type: String).returns(Checker) }
       def find(violation_type)
-        T.must(Checker.all.find { |c| c.violation_type == violation_type })
+        checker_by_violation_type(violation_type)
+      end
+
+      private
+
+      sig { params(name: String).returns(Checker) }
+      def checker_by_violation_type(name)
+        @checker_by_violation_type ||= T.let(@checker_by_violation_type, T.nilable(T::Hash[String, T.nilable(Checker)]))
+        @checker_by_violation_type ||= Checker.all.map { |c| [c.violation_type, c] }.to_h
+        T.must(@checker_by_violation_type[name])
       end
     end
 

--- a/lib/packwerk/checker.rb
+++ b/lib/packwerk/checker.rb
@@ -55,21 +55,8 @@ module Packwerk
     def message(reference); end
 
     sig { returns(OffendingPackage) }
-    def todo_location
+    def offending_package
       OffendingPackage::ReferencePackage
-    end
-
-    sig { params(reference: Reference).returns(Package) }
-    def offending_package_for(reference)
-      location = todo_location
-      case location
-      when OffendingPackage::DefinitionPackage
-        reference.constant.package
-      when OffendingPackage::ReferencePackage
-        reference.source_package
-      else
-        T.absurd(location)
-      end
     end
   end
 end

--- a/lib/packwerk/checker.rb
+++ b/lib/packwerk/checker.rb
@@ -6,6 +6,13 @@ module Packwerk
     extend T::Sig
     extend T::Helpers
 
+    class TodoLocation < T::Enum
+      enums do
+        PackageReferencingConstant = new
+        PackageDefiningConstant = new
+      end
+    end
+
     abstract!
 
     class << self
@@ -47,9 +54,22 @@ module Packwerk
     sig { abstract.params(reference: Reference).returns(String) }
     def message(reference); end
 
+    sig { returns(TodoLocation) }
+    def todo_location
+      TodoLocation::PackageReferencingConstant
+    end
+
     sig { params(reference: Reference).returns(Package) }
     def todo_file_for(reference)
-      reference.source_package
+      location = todo_location
+      case location
+      when TodoLocation::PackageDefiningConstant
+        reference.constant.package
+      when TodoLocation::PackageReferencingConstant
+        reference.source_package
+      else
+        T.absurd(location)
+      end
     end
   end
 end

--- a/lib/packwerk/checker.rb
+++ b/lib/packwerk/checker.rb
@@ -27,6 +27,7 @@ module Packwerk
 
       sig { returns(T::Array[Checker]) }
       def all
+        require "packwerk/reference_checking/checkers/dependency_checker"
         T.unsafe(@checkers).map(&:new)
       end
 

--- a/lib/packwerk/checker.rb
+++ b/lib/packwerk/checker.rb
@@ -22,6 +22,11 @@ module Packwerk
       def all
         T.unsafe(@checkers).map(&:new)
       end
+
+      sig { params(violation_type: String).returns(Checker) }
+      def find(violation_type)
+        T.must(Checker.all.find { |c| c.violation_type == violation_type })
+      end
     end
 
     sig { abstract.returns(String) }
@@ -32,5 +37,10 @@ module Packwerk
 
     sig { abstract.params(reference: Reference).returns(String) }
     def message(reference); end
+
+    sig { params(reference: Reference).returns(Package) }
+    def todo_file_for(reference)
+      reference.source_package
+    end
   end
 end

--- a/lib/packwerk/offense_collection.rb
+++ b/lib/packwerk/offense_collection.rb
@@ -76,7 +76,7 @@ module Packwerk
     sig { params(offense: ReferenceOffense).returns(Packwerk::PackageTodo) }
     def package_todo_for_offense(offense)
       checker = Checker.find(offense.violation_type)
-      package_name_where_violation_should_live = checker.offending_package_for(offense.reference)
+      package_name_where_violation_should_live = offending_package_for(checker, offense.reference)
       package_todo_for(package_name_where_violation_should_live)
     end
 
@@ -89,6 +89,19 @@ module Packwerk
           package,
           package_todo_file_for(package),
         ).delete_if_exists
+      end
+    end
+
+    sig { params(checker: Checker, reference: Reference).returns(Package) }
+    def offending_package_for(checker, reference)
+      location = checker.offending_package
+      case location
+      when Checker::OffendingPackage::DefinitionPackage
+        reference.constant.package
+      when Checker::OffendingPackage::ReferencePackage
+        reference.source_package
+      else
+        T.absurd(location)
       end
     end
 

--- a/lib/packwerk/offense_collection.rb
+++ b/lib/packwerk/offense_collection.rb
@@ -76,7 +76,7 @@ module Packwerk
     sig { params(offense: ReferenceOffense).returns(Packwerk::PackageTodo) }
     def package_todo_for_offense(offense)
       checker = Checker.find(offense.violation_type)
-      package_name_where_violation_should_live = checker.todo_file_for(offense.reference)
+      package_name_where_violation_should_live = checker.offending_package_for(offense.reference)
       package_todo_for(package_name_where_violation_should_live)
     end
 

--- a/lib/packwerk/offense_collection.rb
+++ b/lib/packwerk/offense_collection.rb
@@ -35,9 +35,7 @@ module Packwerk
       return false unless offense.is_a?(ReferenceOffense)
 
       reference = offense.reference
-      checker = Checker.find(offense.violation_type)
-      package_name_where_violation_should_live = checker.todo_file_for(reference)
-      package_todo_for(package_name_where_violation_should_live).listed?(reference,
+      package_todo_for_offense(offense).listed?(reference,
         violation_type: offense.violation_type)
     end
 
@@ -49,10 +47,8 @@ module Packwerk
         @errors << offense
         return
       end
-      checker = Checker.find(offense.violation_type)
-      package_name_where_violation_should_live = checker.todo_file_for(offense.reference)
-      package_todo = package_todo_for(package_name_where_violation_should_live)
-      unless package_todo.add_entries(offense.reference, offense.violation_type)
+
+      unless package_todo_for_offense(offense).add_entries(offense.reference, offense.violation_type)
         new_violations << offense
       end
     end
@@ -76,6 +72,13 @@ module Packwerk
     end
 
     private
+
+    sig { params(offense: ReferenceOffense).returns(Packwerk::PackageTodo) }
+    def package_todo_for_offense(offense)
+      checker = Checker.find(offense.violation_type)
+      package_name_where_violation_should_live = checker.todo_file_for(offense.reference)
+      package_todo_for(package_name_where_violation_should_live)
+    end
 
     sig { params(package_set: Packwerk::PackageSet).void }
     def cleanup_extra_package_todo_files(package_set)

--- a/lib/packwerk/offense_collection.rb
+++ b/lib/packwerk/offense_collection.rb
@@ -35,7 +35,10 @@ module Packwerk
       return false unless offense.is_a?(ReferenceOffense)
 
       reference = offense.reference
-      package_todo_for(reference.source_package).listed?(reference, violation_type: offense.violation_type)
+      checker = Checker.find(offense.violation_type)
+      package_name_where_violation_should_live = checker.todo_file_for(reference)
+      package_todo_for(package_name_where_violation_should_live).listed?(reference,
+        violation_type: offense.violation_type)
     end
 
     sig do
@@ -46,7 +49,9 @@ module Packwerk
         @errors << offense
         return
       end
-      package_todo = package_todo_for(offense.reference.source_package)
+      checker = Checker.find(offense.violation_type)
+      package_name_where_violation_should_live = checker.todo_file_for(offense.reference)
+      package_todo = package_todo_for(package_name_where_violation_should_live)
       unless package_todo.add_entries(offense.reference, offense.violation_type)
         new_violations << offense
       end

--- a/test/unit/checker_test.rb
+++ b/test/unit/checker_test.rb
@@ -8,7 +8,7 @@ module Packwerk
     include FactoryHelper
 
     test "#find is correctly able to find the right checker" do
-      found_checker = Checker.find('dependency')
+      found_checker = Checker.find("dependency")
       assert T.unsafe(found_checker).is_a?(Packwerk::ReferenceChecking::Checkers::DependencyChecker)
     end
   end

--- a/test/unit/checker_test.rb
+++ b/test/unit/checker_test.rb
@@ -1,0 +1,15 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Packwerk
+  class CheckerTest < Minitest::Test
+    include FactoryHelper
+
+    test "#find is correctly able to find the right checker" do
+      found_checker = Checker.find('dependency')
+      assert T.unsafe(found_checker).is_a?(Packwerk::ReferenceChecking::Checkers::DependencyChecker)
+    end
+  end
+end

--- a/test/unit/reference_checking/reference_checker_test.rb
+++ b/test/unit/reference_checking/reference_checker_test.rb
@@ -17,7 +17,7 @@ module Packwerk
       end
 
       def violation_type
-        @violation_type || ReferenceChecking::Checkers::DependencyChecker::VIOLATION_TYPE
+        @violation_type || "stubbed_violation_type"
       end
 
       def invalid_reference?(_reference)


### PR DESCRIPTION
## What are you trying to accomplish?
This allows a `Checker` implementation to define the location of its own violations. This is important for the extracted privacy checker, which we discuss [here](https://github.com/rubyatscale/packwerk-extensions/discussions/2) about changing violations so a package's `package_todo.yml` file shows *inbound* privacy violations rather than the default *outbound* violations.

## What approach did you choose and why?
I delegated this behavior to the `Checker` as a method with a default implementation (equal to today's implementation). This made sense to me since the idea is that a checker would decide this. However, we could also choose other implementations, such as having a checker specify in a method whether its violations are listed in the outbound package or the inbound, and then have the implementation of that be hidden.

## What should reviewers focus on?
Does this make sense as the API to specify location of violation?

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly => We probably want to have some general documentation on adding a new checker, although I think a user could always just look at the dependency checker
- [x] I have added tests to cover my changes => I believe everything is covered by the existing tests for the dependency checker
- [x] It is safe to rollback this change.
