### PR TITLE
Remove detect-stale-violations subcommand

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -52,8 +52,6 @@ module Packwerk
         init
       when "check"
         output_result(parse_run(args).check)
-      when "detect-stale-violations"
-        output_result(parse_run(args).detect_stale_violations)
       when "update-todo", "update"
         output_result(parse_run(args).update_todo)
       when "validate"

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -33,22 +33,6 @@ module Packwerk
     end
 
     sig { returns(Result) }
-    def detect_stale_violations
-      warn(<<~WARNING.squish)
-        DEPRECATION WARNING: `detect-stale-violation` is deprecated,
-        the output of `check` includes stale references.
-      WARNING
-
-      run_context = Packwerk::RunContext.from_configuration(@configuration)
-      offense_collection = find_offenses(run_context)
-
-      result_status = !offense_collection.stale_violations?(@relative_file_set)
-      message = @offenses_formatter.show_stale_violations(offense_collection, @relative_file_set)
-
-      Result.new(message: message, status: result_status)
-    end
-
-    sig { returns(Result) }
     def update_todo
       run_context = Packwerk::RunContext.from_configuration(@configuration)
       offense_collection = find_offenses(run_context)

--- a/test/unit/parse_run_test.rb
+++ b/test/unit/parse_run_test.rb
@@ -17,40 +17,6 @@ module Packwerk
       teardown_application_fixture
     end
 
-    test "#detect_stale_violations is deprecated" do
-      use_template(:minimal)
-      RunContext.any_instance.stubs(:process_file).returns([])
-
-      parse_run = Packwerk::ParseRun.new(
-        relative_file_set: Set.new(["path/of/exile.rb"]),
-        configuration: Configuration.from_path
-      )
-
-      _, error_message = capture_io do
-        parse_run.detect_stale_violations
-      end
-
-      assert_equal(<<~MSG, error_message)
-        DEPRECATION WARNING: `detect-stale-violation` is deprecated, the output of `check` includes stale references.
-      MSG
-    end
-
-    test "#detect_stale_violations returns expected Result when stale violations present" do
-      use_template(:minimal)
-      OffenseCollection.any_instance.stubs(:stale_violations?).returns(true)
-      RunContext.any_instance.stubs(:process_file).returns([])
-
-      parse_run = Packwerk::ParseRun.new(
-        relative_file_set: Set.new(["path/of/exile.rb"]),
-        configuration: Configuration.from_path
-      )
-      capture_io do
-        result = parse_run.detect_stale_violations
-        assert_equal "There were stale violations found, please run `packwerk update-todo`", result.message
-        refute result.status
-      end
-    end
-
     test "#update-todo returns success when there are no offenses" do
       use_template(:minimal)
       RunContext.any_instance.stubs(:process_file).returns([])


### PR DESCRIPTION
## What are you trying to accomplish?

Remove `detect-stale-violations` subcommand.

## What approach did you choose and why?

Remove since it was deprecated and released in 2.2.2.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
