### PR TITLE
Type structs

### DIFF
--- a/lib/packwerk/cache.rb
+++ b/lib/packwerk/cache.rb
@@ -21,10 +21,10 @@ module Packwerk
           cache_contents_json = JSON.parse(serialized_cache_contents)
           unresolved_references = cache_contents_json["unresolved_references"].map do |json|
             UnresolvedReference.new(
-              json["constant_name"],
-              json["namespace_path"],
-              json["relative_path"],
-              Node::Location.new(json["source_location"]["line"], json["source_location"]["column"],)
+              constant_name: json["constant_name"],
+              namespace_path: json["namespace_path"],
+              relative_path: json["relative_path"],
+              source_location: Node::Location.new(json["source_location"]["line"], json["source_location"]["column"],)
             )
           end
 

--- a/lib/packwerk/offense_collection.rb
+++ b/lib/packwerk/offense_collection.rb
@@ -35,7 +35,7 @@ module Packwerk
       return false unless offense.is_a?(ReferenceOffense)
 
       reference = offense.reference
-      package_todo_for(reference.source_package).listed?(reference, violation_type: offense.violation_type)
+      package_todo_for(reference.package).listed?(reference, violation_type: offense.violation_type)
     end
 
     sig do
@@ -46,7 +46,7 @@ module Packwerk
         @errors << offense
         return
       end
-      package_todo = package_todo_for(offense.reference.source_package)
+      package_todo = package_todo_for(offense.reference.package)
       unless package_todo.add_entries(offense.reference, offense.violation_type)
         new_violations << offense
       end

--- a/lib/packwerk/reference.rb
+++ b/lib/packwerk/reference.rb
@@ -3,5 +3,11 @@
 
 module Packwerk
   # A reference from a file in one package to a constant that may be defined in a different package.
-  Reference = Struct.new(:source_package, :relative_path, :constant, :source_location)
+  Reference = Struct.new(
+    :package,
+    :relative_path,
+    :constant,
+    :source_location,
+    keyword_init: true,
+  )
 end

--- a/lib/packwerk/reference_checking/checkers/dependency_checker.rb
+++ b/lib/packwerk/reference_checking/checkers/dependency_checker.rb
@@ -22,9 +22,8 @@ module Packwerk
             .returns(T::Boolean)
         end
         def invalid_reference?(reference)
-          return false unless reference.source_package
-          return false unless reference.source_package.enforce_dependencies?
-          return false if reference.source_package.dependency?(reference.constant.package)
+          return false unless reference.package.enforce_dependencies?
+          return false if reference.package.dependency?(reference.constant.package)
 
           true
         end
@@ -35,8 +34,12 @@ module Packwerk
             .returns(String)
         end
         def message(reference)
+          const_name = reference.constant.name
+          const_package = reference.constant.package
+          ref_package = reference.package
+
           <<~EOS
-            Dependency violation: #{reference.constant.name} belongs to '#{reference.constant.package}', but '#{reference.source_package}' does not specify a dependency on '#{reference.constant.package}'.
+            Dependency violation: #{const_name} belongs to '#{const_package}', but '#{ref_package}' does not specify a dependency on '#{const_package}'.
             Are we missing an abstraction?
             Is the code making the reference, and the referenced constant, in the right packages?
 

--- a/lib/packwerk/reference_extractor.rb
+++ b/lib/packwerk/reference_extractor.rb
@@ -38,10 +38,10 @@ module Packwerk
           next if source_package == package_for_constant
 
           fully_qualified_references << Reference.new(
-            source_package,
-            unresolved_reference.relative_path,
-            constant,
-            unresolved_reference.source_location
+            package: source_package,
+            relative_path: unresolved_reference.relative_path,
+            constant: constant,
+            source_location: unresolved_reference.source_location,
           )
         end
 

--- a/lib/packwerk/reference_extractor.rb
+++ b/lib/packwerk/reference_extractor.rb
@@ -110,10 +110,10 @@ module Packwerk
       location = NodeHelpers.location(node)
 
       UnresolvedReference.new(
-        constant_name,
-        namespace_path,
-        relative_file,
-        location
+        constant_name: constant_name,
+        namespace_path: namespace_path,
+        relative_path: relative_file,
+        source_location: location
       )
     end
 

--- a/lib/packwerk/unresolved_reference.rb
+++ b/lib/packwerk/unresolved_reference.rb
@@ -6,5 +6,11 @@ module Packwerk
   # Unresolved means that we know how it's referred to in the file,
   # and we have enough context on that reference to figure out the fully qualified reference such that we
   # can produce a Reference in a separate pass. However, we have not yet resolved it to its fully qualified version.
-  UnresolvedReference = Struct.new(:constant_name, :namespace_path, :relative_path, :source_location)
+  UnresolvedReference = Struct.new(
+    :constant_name,
+    :namespace_path,
+    :relative_path,
+    :source_location,
+    keyword_init: true,
+  )
 end

--- a/sorbet/rbi/shims/packwerk/reference.rbi
+++ b/sorbet/rbi/shims/packwerk/reference.rbi
@@ -1,0 +1,33 @@
+# typed: true
+
+module Packwerk
+  class Reference
+    sig do
+      params(
+        package: Package,
+        relative_path: String,
+        constant: ConstantDiscovery::ConstantContext,
+        source_location: T.nilable(Node::Location),
+      ).void
+    end
+    def initialize(
+      package:,
+      relative_path:,
+      constant:,
+      source_location:
+    )
+    end
+
+    sig { returns(Package) }
+    attr_reader(:package)
+
+    sig { returns(T.nilable(String)) }
+    attr_reader(:relative_path)
+
+    sig { returns(ConstantDiscovery::ConstantContext) }
+    attr_reader(:constant)
+
+    sig { returns(T.nilable(Node::Location)) }
+    attr_reader(:source_location)
+  end
+end

--- a/sorbet/rbi/shims/packwerk/unresolved_reference.rbi
+++ b/sorbet/rbi/shims/packwerk/unresolved_reference.rbi
@@ -1,0 +1,33 @@
+# typed: true
+
+module Packwerk
+  class UnresolvedReference
+    sig do
+      params(
+        constant_name: String,
+        namespace_path: T.nilable(T::Array[String]),
+        relative_path: String,
+        source_location: T.nilable(Node::Location),
+      ).void
+    end
+    def initialize(
+      constant_name:,
+      namespace_path:,
+      relative_path:,
+      source_location:
+    )
+    end
+
+    sig { returns(String) }
+    attr_reader(:constant_name)
+
+    sig { returns(T.nilable(T::Array[String])) }
+    attr_reader(:namespace_path)
+
+    sig { returns(String) }
+    attr_reader(:relative_path)
+
+    sig { returns(T.nilable(Node::Location)) }
+    attr_reader(:source_location)
+  end
+end

--- a/test/support/factory_helper.rb
+++ b/test/support/factory_helper.rb
@@ -14,6 +14,11 @@ module FactoryHelper
       "some/location.rb",
       destination_package,
     )
-    Packwerk::Reference.new(source_package, path, constant, source_location)
+    Packwerk::Reference.new(
+      package: source_package,
+      relative_path: path,
+      constant: constant,
+      source_location: source_location,
+    )
   end
 end

--- a/test/unit/cache_test.rb
+++ b/test/unit/cache_test.rb
@@ -32,10 +32,10 @@ module Packwerk
 
       unresolved_references = [
         UnresolvedReference.new(
-          "MyConstant",
-          [],
-          "path/of_exile.rb",
-          Node::Location.new(5, 5)
+          constant_name: "MyConstant",
+          namespace_path: [],
+          relative_path: "path/of_exile.rb",
+          source_location: Node::Location.new(5, 5)
         ),
       ]
 

--- a/test/unit/file_processor_test.rb
+++ b/test/unit/file_processor_test.rb
@@ -32,7 +32,12 @@ module Packwerk
     end
 
     test "#call visits a node in file path with an reference" do
-      unresolved_reference = UnresolvedReference.new("SomeName", [], "tempfile", Node::Location.new(3, 22))
+      unresolved_reference = UnresolvedReference.new(
+        constant_name: "SomeName",
+        namespace_path: [],
+        relative_path: "tempfile",
+        source_location: Node::Location.new(3, 22),
+      )
       @node_processor_factory.expects(:for).returns(@node_processor)
       @node_processor.expects(:call).returns(unresolved_reference)
 

--- a/test/unit/reference_extractor_test.rb
+++ b/test/unit/reference_extractor_test.rb
@@ -39,7 +39,7 @@ module Packwerk
       assert_equal 1, references.count
 
       reference = references.first
-      assert_equal "components/timeline", reference.source_package.name
+      assert_equal "components/timeline", reference.package.name
       assert_equal "::Order", reference.constant.name
       assert_equal "components/sales", reference.constant.package.name
       assert_equal "components/sales/app/models/order.rb", reference.constant.location
@@ -87,7 +87,7 @@ module Packwerk
       assert_equal 1, references.count
 
       reference = references.first
-      assert_equal "components/timeline", reference.source_package.name
+      assert_equal "components/timeline", reference.package.name
       assert_equal "::Order", reference.constant.name
       assert_equal "components/sales", reference.constant.package.name
       assert_equal "components/sales/app/models/order.rb", reference.constant.location


### PR DESCRIPTION
## What are you trying to accomplish?

Type previously untyped structs. Also rename source_package to package in `Reference` struct.


## What approach did you choose and why?

Use `T::Struct` because we get better type safety than using `T.untyped`.

## What should reviewers focus on?

I did this while trying to add transitive dependencies to Packwerk, which may not happen. This however I think is a good change.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
