### PR TITLE
Allow extension system to load in custom OffensesFormatter

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -249,6 +249,15 @@ You can prefix local files with a dot to define them relative to `packwerk.yml`,
 You can also reference the name of a gem.
 
 ## Examples
+### Custom `OffensesFormatter`
+While `packwerk` ships with its own `OffensesFormatter`, the extension system provides a mechanism to configure your own to be used when `bin/packwerk check` is run.
+
+Firstly, you'll need to create an `OffensesFormatter` that implements the `Packwerk::OffensesFormatter` interface. You can use [`Packwerk::Formatters::OffensesFormatter`](lib/packwerk/formatters/offenses_formatter.rb) as a model for this. Then, in the `require` directive described above, you'll want to tell `packwerk` about it:
+```ruby
+# ./path/to/file.rb
+Packwerk::Configuration.offenses_formatter = MyOffensesFormatter.new
+```
+
 ### Privacy Checker
 
 [`packwerk-extensions`](https://github.com/rubyatscale/packwerk-extensions) (originally extracted from `packwerk`) can be used to help define and enforce public API boundaries of a package. See the README.md for more details. To use this, add it to your `Gemfile` and then require it via `packwerk.yml`:

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -33,7 +33,7 @@ module Packwerk
       @configuration = T.let(configuration || Configuration.from_path, Configuration)
       @progress_formatter = T.let(Formatters::ProgressFormatter.new(@out, style: style), Formatters::ProgressFormatter)
       @offenses_formatter = T.let(
-        offenses_formatter || Formatters::OffensesFormatter.new(style: @style),
+        offenses_formatter || Configuration.offenses_formatter || Formatters::OffensesFormatter.new(style: @style),
         OffensesFormatter
       )
     end

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -7,6 +7,8 @@ require "yaml"
 module Packwerk
   class Configuration
     class << self
+      extend T::Sig
+
       def from_path(path = Dir.pwd)
         raise ArgumentError, "#{File.expand_path(path)} does not exist" unless File.exist?(path)
 
@@ -18,6 +20,9 @@ module Packwerk
           new
         end
       end
+
+      sig { returns(T.nilable(OffensesFormatter)) }
+      attr_accessor :offenses_formatter
 
       private
 

--- a/test/fixtures/extended/config/my_local_extension.rb
+++ b/test/fixtures/extended/config/my_local_extension.rb
@@ -1,2 +1,16 @@
 module MyLocalExtension
 end
+
+class MyOffensesFormatter
+  include Packwerk::OffensesFormatter
+
+  def show_offenses(offenses)
+    ["hi i am a custom offense formatter", *offenses].join("\n")
+  end
+
+  def show_stale_violations(_offense_collection, _fileset)
+    "stale violations report"
+  end
+end
+
+Packwerk::Configuration.offenses_formatter = MyOffensesFormatter.new

--- a/test/support/application_fixture_helper.rb
+++ b/test/support/application_fixture_helper.rb
@@ -13,6 +13,11 @@ module ApplicationFixtureHelper
     @old_working_dir = Dir.pwd
   end
 
+  def remove_extensions
+    Object.send(:remove_const, :MyLocalExtension) if defined?(MyLocalExtension)
+    Packwerk::Configuration.offenses_formatter = nil
+  end
+
   def teardown_application_fixture
     Dir.chdir(@old_working_dir)
     FileUtils.remove_entry(@app_dir, true) if using_template?

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -7,18 +7,20 @@ require "rails_test_helper"
 module Packwerk
   class CliTest < Minitest::Test
     include TypedMock
+    include ApplicationFixtureHelper
 
     setup do
+      setup_application_fixture
       @err_out = StringIO.new
       @cli = ::Packwerk::Cli.new(err_out: @err_out)
-      @temp_dir = Dir.mktmpdir
     end
 
     teardown do
-      FileUtils.remove_entry(@temp_dir)
+      teardown_application_fixture
     end
 
     test "#execute_command with the subcommand check starts processing files" do
+      use_template(:blank)
       file_path = "path/of/exile.rb"
       violation_message = "This is a violation of code health."
       offense = Offense.new(file: file_path, message: violation_message)
@@ -43,6 +45,7 @@ module Packwerk
     end
 
     test "#execute_command with the subcommand check traps the interrupt signal" do
+      use_template(:blank)
       file_path = "path/of/exile.rb"
       interrupt_message = "Manually interrupted. Violations caught so far are listed below:"
       violation_message = "This is a violation of code health."
@@ -74,12 +77,14 @@ module Packwerk
     end
 
     test "#execute_command with the subcommand help lists all the valid subcommands" do
+      use_template(:blank)
       @cli.execute_command(["help"])
 
       assert_match(/Subcommands:/, @err_out.string)
     end
 
     test "#execute_command with validate subcommand runs application validator and succeeds if no errors" do
+      use_template(:blank)
       string_io = StringIO.new
       cli = ::Packwerk::Cli.new(out: string_io)
 
@@ -93,6 +98,7 @@ module Packwerk
     end
 
     test "#execute_command with validate subcommand runs application validator, fails and prints errors if any" do
+      use_template(:blank)
       string_io = StringIO.new
       cli = ::Packwerk::Cli.new(out: string_io)
 
@@ -107,12 +113,14 @@ module Packwerk
     end
 
     test "#execute_command with empty subcommand lists all the valid subcommands" do
+      use_template(:blank)
       @cli.execute_command([])
 
       assert_match(/Subcommands:/, @err_out.string)
     end
 
     test "#execute_command with an invalid subcommand" do
+      use_template(:blank)
       @cli.execute_command(["beep boop"])
 
       expected_output = "'beep boop' is not a packwerk command. See `packwerk help`.\n"
@@ -120,6 +128,7 @@ module Packwerk
     end
 
     test "#execute_command using a custom offenses class" do
+      use_template(:blank)
       offenses_formatter = Class.new do
         include Packwerk::OffensesFormatter
 

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -13,7 +13,7 @@ module Packwerk
 
     teardown do
       teardown_application_fixture
-      Object.send(:remove_const, :MyLocalExtension) if defined?(MyLocalExtension)
+      remove_extensions
     end
 
     test ".from_path raises ArgumentError if path does not exist" do


### PR DESCRIPTION
## What are you trying to accomplish?
Today, `packwerk` supports a configurable `OffensesFormatter`. However, the only way to configure it is to load the CLI itself. This means that this feature is not usable if a user has run `bundle binstubs packwerk`. Instead, the user needs to copy `exe/packwerk` into their local `bin/packwerk` and pass in a different formatter to `Packwerk::Cli.new`.

This PR makes this more user-friendly by leveraging the extension system to load in a new formatter. This way, a user can use the vanilla `packwerk` binstub and load in their own offenses formatter more easily.

## What approach did you choose and why?
I chose to use the `require` directive in `packwerk.yml` to load in a formatter via a setting on `Packwerk::Configuration`. The system first prioritizes the local input variable, then the configuration, then the default formatter.

## What should reviewers focus on?
Is there a more ideal API to set the custom formatter? Is there any reason we wouldn't want to encourage this via the extension system?

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
