### PR TITLE
Improve performance of bin/packwerk validate

### DIFF
--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -95,9 +95,10 @@ module Packwerk
     sig { params(package_set: PackageSet).returns(Result) }
     def check_acyclic_graph(package_set)
       edges = package_set.flat_map do |package|
-        package.dependencies.map { |dependency| [package, package_set.fetch(dependency)] }
+        package.dependencies.map { |dependency| [package.name, T.must(package_set.fetch(dependency)).name] }
       end
-      dependency_graph = Graph.new(*T.unsafe(edges))
+
+      dependency_graph = Graph.new(edges)
 
       cycle_strings = build_cycle_strings(dependency_graph.cycles)
 

--- a/lib/packwerk/graph.rb
+++ b/lib/packwerk/graph.rb
@@ -4,8 +4,14 @@
 module Packwerk
   # A general implementation of a graph data structure with the ability to check for - and list - cycles.
   class Graph
-    # @param [Array<Array>] edges The edges of the graph; An edge being represented as an Array of two nodes.
-    def initialize(*edges)
+    extend T::Sig
+    sig do
+      params(
+        # The edges of the graph; An edge being represented as an Array of two nodes.
+        edges: T::Array[T::Array[T.any(String, Integer)]]
+      ).void
+    end
+    def initialize(edges)
       @edges = edges.uniq
       @cycles = Set.new
       process

--- a/test/unit/graph_test.rb
+++ b/test/unit/graph_test.rb
@@ -6,13 +6,13 @@ require "test_helper"
 module Packwerk
   class GraphTest < Minitest::Test
     test "#acyclic? returns true for a directed acyclic graph" do
-      graph = Graph.new([1, 2], [1, 3], [2, 4], [3, 4])
+      graph = Graph.new([[1, 2], [1, 3], [2, 4], [3, 4]])
 
       assert_predicate graph, :acyclic?
     end
 
     test "#acyclic? returns false for a cyclic graph" do
-      graph = Graph.new([1, 2], [2, 3], [3, 1])
+      graph = Graph.new([[1, 2], [2, 3], [3, 1]])
 
       refute_predicate graph, :acyclic?
     end
@@ -27,23 +27,23 @@ module Packwerk
       #       |      |
       #       +- 6 <-
       #
-      graph = Graph.new([1, 2], [2, 3], [3, 2], [1, 4], [4, 5], [5, 6], [6, 4])
+      graph = Graph.new([[1, 2], [2, 3], [3, 2], [1, 4], [4, 5], [5, 6], [6, 4]])
 
       assert_equal [[2, 3], [4, 5, 6]], graph.cycles.sort
     end
 
     test "#cycles returns overlapping cycles in a graph" do
-      graph = Graph.new([1, 2], [2, 3], [1, 4], [4, 3], [3, 1])
+      graph = Graph.new([[1, 2], [2, 3], [1, 4], [4, 3], [3, 1]])
 
       assert_equal [[1, 2, 3], [1, 4, 3]], graph.cycles.sort
     end
 
     test "#cycles returns cycles in a graph with disjoint subgraphs" do
-      graph = Graph.new(
+      graph = Graph.new([
         [1, 2], [2, 3], [3, 1],
         [4, 5], [4, 6], [5, 7], [6, 7],
         [8, 9], [9, 8], [8, 10], [10, 11], [8, 11],
-      )
+      ])
 
       assert_equal [[1, 2, 3], [8, 9]], graph.cycles.sort
     end


### PR DESCRIPTION
## What are you trying to accomplish?
I did some performance analysis of `bin/packwerk validate` and found that the vast majority of the time was in checking acyclicity of the package graph. In Gusto's monolith, this PR represents an 80% performance improvement in `bin/packwerk validate`.

# Performance Benchmarking
I ran `time bin/packwerk validate` 5 times. Here are the results:

## BEFORE: 5x Runs Performance Benchmark on Gusto's monolith
```
real    0m30.920s
real    0m31.423s
real    0m31.106s
real    0m30.494s
real    0m31.340s
```

## AFTER: 5x Runs Performance Benchmark on Gusto's monolith
```
real    0m6.874s
real    0m6.716s
real    0m6.730s
real    0m6.737s
real    0m6.808s
```


## What approach did you choose and why?
I was originally looking into some other approaches, including:
1) Is it necessary to find *all* cycles? Or is it sufficient to find the first cycle that each node is in? I nixed this approach so as to not change behavior.
2) Is there a faster cycle-detection algorithm?

What it came down to is that we didn't need the full on `Packwerk::Package` – the `Graph` abstraction works on `nodes` that are just a `String`. I found that by passing in just the unique package name it massively reduced the computation required, creating a large performance improvement without a more involved rethink of cycle detection. 

## What should reviewers focus on?
- Is there any reason we *would not* want the `Graph` abstraction to take in a plain String and instead we would want a more sophisticated reprepresentation?
- Should we pursue further improvements?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
