### PR TITLE
Remove reference to privacy violations from TROUBLESHOOT.md

### DIFF
--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -2,8 +2,6 @@
 
 * [Troubleshooting violations](#Troubleshooting-violations)
   * [Feedback loop](#Feedback-loop)
-  * [Package Privacy violation](#Package-Privacy-violation)
-    * [Interpreting Privacy violation](#Interpreting-Privacy-violation)
   * [Package Dependency violation](#Package-Dependency-violation)
     * [Interpreting Dependency violation](#Interpreting-Dependency-violation)
 


### PR DESCRIPTION
## What are you trying to accomplish?
Follow up to: https://github.com/Shopify/packwerk/pull/247

I noticed when reading the docs recently that we were still linking to privacy violations at the start of the troubleshooting docs. 

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [X] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] It is safe to rollback this change.
