### PR TITLE
Add missing require for Object#to_json

### DIFF
--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -7,6 +7,8 @@ require "fileutils"
 
 # Provides String#pluralize
 require "active_support/core_ext/string"
+# Provides Object#to_json
+require "active_support/core_ext/object/json"
 
 module Packwerk
   extend ActiveSupport::Autoload


### PR DESCRIPTION
## What are you trying to accomplish?

Add missing require for `Object#to_json`.

## What approach did you choose and why?

In #263, I was trying to benchmark serialization (without loading rails) and it wasn't working. This is because we didn't load the core extension for `Object#to_json`. I think it is important we add this if we want to support non-rails usage one day and require everything we actually use.

## What should reviewers focus on?

You can run the benchmark script I wrote in the PR linked above to reproduce the error.

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
