### PR TITLE
Require OffensesFormatter in Configuration

### DIFF
--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -94,3 +94,7 @@ module Packwerk
     autoload :Helpers
   end
 end
+
+# Required to register the default OffensesFormatter
+# We put this at the *end* of the file to specify all autoloads first
+require "packwerk/formatters/offenses_formatter"

--- a/lib/packwerk/offenses_formatter.rb
+++ b/lib/packwerk/offenses_formatter.rb
@@ -29,7 +29,6 @@ module Packwerk
 
       sig { returns(T::Array[OffensesFormatter]) }
       def all
-        require "packwerk/formatters/offenses_formatter"
         T.unsafe(@offenses_formatters).map(&:new)
       end
 

--- a/test/support/offenses_formatter_plain.rb
+++ b/test/support/offenses_formatter_plain.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "packwerk/formatters/offenses_formatter"
-
 module Packwerk
   module Formatters
     class OffensesFormatterPlain < OffensesFormatter


### PR DESCRIPTION
I was doing some local `packwerk` development and realized that #266, while working in test, caused the following issue:

```
$ bin/packwerk check path/to/file.rb
[TEST PROF INFO] Spring detected
Running via Spring preloader in process 20184
Traceback (most recent call last):
        24: from -e:1:in `<main>'
        23: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'
        22: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'
        21: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/spring-4.1.0/lib/spring/application/boot.rb:19:in `<top (required)>'
        20: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/spring-4.1.0/lib/spring/application.rb:142:in `run'
        19: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/spring-4.1.0/lib/spring/application.rb:142:in `loop'
        18: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/spring-4.1.0/lib/spring/application.rb:148:in `block in run'
        17: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/spring-4.1.0/lib/spring/application.rb:185:in `serve'
        16: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-7.0.4/lib/active_support/fork_tracker.rb:18:in `fork'
        15: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-7.0.4/lib/active_support/fork_tracker.rb:18:in `fork'
        14: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/activesupport-7.0.4/lib/active_support/fork_tracker.rb:20:in `block in fork'
        13: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/spring-4.1.0/lib/spring/application.rb:221:in `block in serve'
        12: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/spring-4.1.0/lib/spring/command_wrapper.rb:38:in `call'
        11: from /Users/alex.evanczuk/workspace/packwerk/lib/packwerk/spring_command.rb:23:in `call'
        10: from /Users/alex.evanczuk/workspace/packwerk/lib/packwerk/spring_command.rb:23:in `load'
         9: from /Users/alex.evanczuk/workspace/packwerk/exe/packwerk:11:in `<main>'
         8: from /Users/alex.evanczuk/workspace/packwerk/exe/packwerk:11:in `new'
         7: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sorbet-runtime-0.5.10514/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
         6: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sorbet-runtime-0.5.10514/lib/types/private/methods/call_validation.rb:256:in `validate_call'
         5: from /Users/alex.evanczuk/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/sorbet-runtime-0.5.10514/lib/types/private/methods/call_validation.rb:256:in `bind_call'
         4: from /Users/alex.evanczuk/workspace/packwerk/lib/packwerk/cli.rb:33:in `initialize'
         3: from /Users/alex.evanczuk/workspace/packwerk/lib/packwerk/configuration.rb:18:in `from_path'
         2: from /Users/alex.evanczuk/workspace/packwerk/lib/packwerk/configuration.rb:27:in `from_packwerk_config'
         1: from /Users/alex.evanczuk/workspace/packwerk/lib/packwerk/configuration.rb:27:in `new'
/Users/alex.evanczuk/workspace/packwerk/lib/packwerk/configuration.rb:54:in `initialize': uninitialized constant Packwerk::Formatters::OffensesFormatter (NameError)
Did you mean?  Packwerk::OffensesFormatter
```

I'm open also to changing this PR to reproduce the error better in our test suite, but I believe that would require removing constants from the memory space to reproduce a fresh process. Let me know if that's desired!
