### PR TITLE
Allow strict mode enforcement of violations

### DIFF
--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -100,3 +100,6 @@ end
 # Required to register the default OffensesFormatter
 # We put this at the *end* of the file to specify all autoloads first
 require "packwerk/formatters/offenses_formatter"
+
+# Required to register the default DependencyChecker
+require "packwerk/reference_checking/checkers/dependency_checker"

--- a/lib/packwerk/application_validator.rb
+++ b/lib/packwerk/application_validator.rb
@@ -59,7 +59,7 @@ module Packwerk
         end
 
         if hash.key?("enforce_dependencies")
-          unless [TrueClass, FalseClass].include?(hash["enforce_dependencies"].class)
+          unless [TrueClass, FalseClass, "strict"].include?(hash["enforce_dependencies"].class)
             errors << "Invalid 'enforce_dependencies' option in #{f.inspect}: #{hash["enforce_dependencies"].inspect}"
           end
         end

--- a/lib/packwerk/checker.rb
+++ b/lib/packwerk/checker.rb
@@ -22,10 +22,28 @@ module Packwerk
       def all
         T.unsafe(@checkers).map(&:new)
       end
+
+      sig { params(violation_type: String).returns(Checker) }
+      def find(violation_type)
+        checker_by_violation_type(violation_type)
+      end
+
+      private
+
+      sig { params(name: String).returns(Checker) }
+      def checker_by_violation_type(name)
+        @checker_by_violation_type ||= T.let(Checker.all.to_h do |checker|
+                                               [checker.violation_type, checker]
+                                             end, T.nilable(T::Hash[String, Checker]))
+        @checker_by_violation_type.fetch(name)
+      end
     end
 
     sig { abstract.returns(String) }
     def violation_type; end
+
+    sig { abstract.params(listed_offense: ReferenceOffense).returns(T::Boolean) }
+    def strict_mode_violation?(listed_offense); end
 
     sig { abstract.params(reference: Reference).returns(T::Boolean) }
     def invalid_reference?(reference); end

--- a/lib/packwerk/formatters/offenses_formatter.rb
+++ b/lib/packwerk/formatters/offenses_formatter.rb
@@ -34,11 +34,28 @@ module Packwerk
         IDENTIFIER
       end
 
+      sig { override.params(strict_mode_violations: T::Array[ReferenceOffense]).returns(String) }
+      def show_strict_mode_violations(strict_mode_violations)
+        if strict_mode_violations.any?
+          strict_mode_violations.compact.map { |offense| format_strict_mode_violation(offense) }.join("\n")
+        else
+          ""
+        end
+      end
+
       private
 
       sig { returns(OutputStyle) }
       def style
         @style ||= T.let(Packwerk::OutputStyles::Coloured.new, T.nilable(Packwerk::OutputStyles::Coloured))
+      end
+
+      sig { params(offense: ReferenceOffense).returns(String) }
+      def format_strict_mode_violation(offense)
+        reference_package = offense.reference.package
+        defining_package = offense.reference.constant.package
+        "#{reference_package} cannot have #{offense.violation_type} violations on #{defining_package} "\
+          "because strict mode is enabled for #{offense.violation_type} violations in #{reference_package}/package.yml"
       end
 
       sig { params(offenses: T::Array[T.nilable(Offense)]).returns(String) }

--- a/lib/packwerk/offenses_formatter.rb
+++ b/lib/packwerk/offenses_formatter.rb
@@ -68,5 +68,9 @@ module Packwerk
     sig { abstract.returns(String) }
     def identifier
     end
+
+    sig { abstract.params(strict_mode_violations: T::Array[ReferenceOffense]).returns(String) }
+    def show_strict_mode_violations(strict_mode_violations)
+    end
   end
 end

--- a/lib/packwerk/package.rb
+++ b/lib/packwerk/package.rb
@@ -30,7 +30,7 @@ module Packwerk
 
     sig { returns(T::Boolean) }
     def enforce_dependencies?
-      @config["enforce_dependencies"] == true
+      [true, "strict"].include?(@config["enforce_dependencies"])
     end
 
     sig { params(package: Package).returns(T::Boolean) }

--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -57,8 +57,12 @@ module Packwerk
         @offenses_formatter.show_stale_violations(offense_collection, @relative_file_set),
       ]
 
+      unless offense_collection.strict_mode_violations.empty?
+        messages << @offenses_formatter.show_strict_mode_violations(offense_collection.strict_mode_violations)
+      end
+
       result_status = offense_collection.outstanding_offenses.empty? &&
-        !offense_collection.stale_violations?(@relative_file_set)
+        !offense_collection.stale_violations?(@relative_file_set) && offense_collection.strict_mode_violations.empty?
 
       Result.new(message: messages.join("\n") + "\n", status: result_status)
     end

--- a/lib/packwerk/reference_checking/checkers/dependency_checker.rb
+++ b/lib/packwerk/reference_checking/checkers/dependency_checker.rb
@@ -47,6 +47,12 @@ module Packwerk
           EOS
         end
 
+        sig { override.params(listed_offense: ReferenceOffense).returns(T::Boolean) }
+        def strict_mode_violation?(listed_offense)
+          referencing_package = listed_offense.reference.package
+          referencing_package.config["enforce_dependencies"] == "strict"
+        end
+
         private
 
         sig { params(reference: Reference).returns(String) }

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -8,10 +8,6 @@ module Packwerk
   class RunContext
     extend T::Sig
 
-    DEFAULT_CHECKERS = T.let([
-      ::Packwerk::ReferenceChecking::Checkers::DependencyChecker.new,
-    ], T::Array[Checker])
-
     class << self
       extend T::Sig
 

--- a/test/fixtures/extended/config/my_local_extension.rb
+++ b/test/fixtures/extended/config/my_local_extension.rb
@@ -15,4 +15,8 @@ class MyOffensesFormatter
   def identifier
     'my_offenses_formatter'
   end
+
+  def show_strict_mode_violations(offenses)
+    "strict mode violations report"
+  end
 end

--- a/test/unit/checker_test.rb
+++ b/test/unit/checker_test.rb
@@ -1,0 +1,13 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Packwerk
+  class CheckerTest < Minitest::Test
+    test "#find is correctly able to find the right checker" do
+      found_checker = Checker.find("dependency")
+      assert T.unsafe(found_checker).is_a?(Packwerk::ReferenceChecking::Checkers::DependencyChecker)
+    end
+  end
+end

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -143,6 +143,10 @@ module Packwerk
         def identifier
           "custom"
         end
+
+        def show_strict_mode_violations(_offenses)
+          "strict mode violations report"
+        end
       end
 
       file_path = "path/of/exile.rb"

--- a/test/unit/offense_collection_test.rb
+++ b/test/unit/offense_collection_test.rb
@@ -20,6 +20,7 @@ module Packwerk
       Packwerk::PackageTodo.any_instance
         .expects(:add_entries)
         .with(@offense.reference, @offense.violation_type)
+        .returns(true)
 
       @offense_collection.add_offense(@offense)
     end

--- a/test/unit/parse_run_test.rb
+++ b/test/unit/parse_run_test.rb
@@ -320,6 +320,54 @@ module Packwerk
       assert result.status
     end
 
+    test "#check lists out violations of strict mode" do
+      use_template(:minimal)
+
+      source_package = Packwerk::Package.new(name: "components/source", config: { "enforce_dependencies" => "strict" })
+      write_app_file("#{source_package.name}/package_todo.yml", <<~YML.strip)
+        ---
+        "components/destination":
+          "::SomeName":
+            violations:
+            - dependency
+            files:
+            - components/source/some/path.rb
+      YML
+
+      out = StringIO.new
+      parse_run = Packwerk::ParseRun.new(
+        relative_file_set: Set.new(["components/source/some/path.rb"]),
+        configuration: Configuration.new({ "parallel" => false }),
+        progress_formatter: Packwerk::Formatters::ProgressFormatter.new(out)
+      )
+
+      offense = ReferenceOffense.new(
+        reference: build_reference(path: "components/source/some/path.rb", source_package: source_package),
+        message: "some message",
+        violation_type: Packwerk::ReferenceChecking::Checkers::DependencyChecker::VIOLATION_TYPE
+      )
+
+      RunContext.any_instance.stubs(:process_file).returns([offense])
+      result = parse_run.check
+
+      expected_output = <<~EOS
+        📦 Packwerk is inspecting 1 file
+        .
+        📦 Finished in \\d+\\.\\d+ seconds
+      EOS
+
+      assert_match(/#{expected_output}/, out.string)
+
+      expected_message = <<~EOS
+        No offenses detected
+        No stale violations detected
+        components/source cannot have dependency violations on components/destination because strict mode is enabled for dependency violations in components/source/package.yml
+      EOS
+      assert_equal expected_message, result.message
+
+      refute result.status
+    end
+
     test "#check does not list stale violations when run on a single file with no exising violations, but one new violation" do
       use_template(:minimal)
       file_to_check = "components/source/some/path.rb"

--- a/test/unit/reference_checking/reference_checker_test.rb
+++ b/test/unit/reference_checking/reference_checker_test.rb
@@ -17,7 +17,7 @@ module Packwerk
       end
 
       def violation_type
-        @violation_type || ReferenceChecking::Checkers::DependencyChecker::VIOLATION_TYPE
+        @violation_type || "custom_violation_type"
       end
 
       def invalid_reference?(_reference)
@@ -26,6 +26,10 @@ module Packwerk
 
       def message(_reference)
         @message
+      end
+
+      def strict_mode_violation?(_listed_offense)
+        false
       end
     end
 


### PR DESCRIPTION
## What are you trying to accomplish?
More info here: https://github.com/Shopify/packwerk/discussions/241
TLDR: This enables `strict` mode for checkers so that packages can disallow new violations, even if they're listed in `package_todo.yml` files.

## What approach did you choose and why?
I chose to delegate the question to the checker as it's closely coupled to *where* a violation is being stored. That is, if package A has a new dependency violation on package B, we need to check package A `enforce_dependencies` to determine if the violation when listed violates strict mode. If package A has a new *privacy* violation on package B, we need to check the `enforce_privacy` property for package B. Since this is determined by the checker, it needs to be a checker interface method.

## What should reviewers focus on?
Let me know if there is a better way to implement this, or a better UX (e.g. the output, the API to turn it on, etc.). Also let me know if I'm missing any edge cases!

## Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
