### PR TITLE
Don't allow update on specific files

### DIFF
--- a/lib/packwerk/parse_run.rb
+++ b/lib/packwerk/parse_run.rb
@@ -16,6 +16,7 @@ module Packwerk
       params(
         relative_file_set: FilesForProcessing::RelativeFileSet,
         configuration: Configuration,
+        file_set_specified: T::Boolean,
         offenses_formatter: T.nilable(OffensesFormatter),
         progress_formatter: Formatters::ProgressFormatter,
       ).void
@@ -23,6 +24,7 @@ module Packwerk
     def initialize(
       relative_file_set:,
       configuration:,
+      file_set_specified: false,
       offenses_formatter: nil,
       progress_formatter: Formatters::ProgressFormatter.new(StringIO.new)
     )
@@ -31,10 +33,19 @@ module Packwerk
       @progress_formatter = progress_formatter
       @offenses_formatter = T.let(offenses_formatter || configuration.offenses_formatter, Packwerk::OffensesFormatter)
       @relative_file_set = relative_file_set
+      @file_set_specified = file_set_specified
     end
 
     sig { returns(Result) }
     def update_todo
+      if @file_set_specified
+        message = <<~MSG.squish
+          ⚠️ update-todo must be called without any file arguments.
+        MSG
+
+        return Result.new(message: message, status: false)
+      end
+
       run_context = Packwerk::RunContext.from_configuration(@configuration)
       offense_collection = find_offenses(run_context)
       offense_collection.persist_package_todo_files(run_context.package_set)

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -21,6 +21,7 @@ module Packwerk
 
     test "#execute_command with the subcommand check starts processing files" do
       use_template(:blank)
+
       file_path = "path/of/exile.rb"
       violation_message = "This is a violation of code health."
       offense = Offense.new(file: file_path, message: violation_message)
@@ -34,7 +35,9 @@ module Packwerk
       cli = ::Packwerk::Cli.new(out: string_io, configuration: configuration)
 
       # TODO: Dependency injection for a "target finder" (https://github.com/Shopify/packwerk/issues/164)
-      ::Packwerk::FilesForProcessing.stubs(fetch: Set.new([file_path]))
+      FilesForProcessing.any_instance.stubs(
+        files: Set.new([file_path])
+      )
 
       success = cli.execute_command(["check", file_path])
 
@@ -46,6 +49,7 @@ module Packwerk
 
     test "#execute_command with the subcommand check traps the interrupt signal" do
       use_template(:blank)
+
       file_path = "path/of/exile.rb"
       interrupt_message = "Manually interrupted. Violations caught so far are listed below:"
       violation_message = "This is a violation of code health."
@@ -64,7 +68,9 @@ module Packwerk
 
       cli = ::Packwerk::Cli.new(out: string_io, configuration: configuration)
 
-      ::Packwerk::FilesForProcessing.stubs(fetch: Set.new([file_path, "test.rb", "foo.rb"]))
+      FilesForProcessing.any_instance.stubs(
+        files: Set.new([file_path, "test.rb", "foo.rb"])
+      )
 
       success = cli.execute_command(["check", file_path])
 
@@ -85,6 +91,7 @@ module Packwerk
 
     test "#execute_command with validate subcommand runs application validator and succeeds if no errors" do
       use_template(:blank)
+
       string_io = StringIO.new
       cli = ::Packwerk::Cli.new(out: string_io)
 
@@ -129,6 +136,7 @@ module Packwerk
 
     test "#execute_command using a custom offenses class" do
       use_template(:blank)
+
       offenses_formatter = Class.new do
         include Packwerk::OffensesFormatter
 
@@ -144,7 +152,6 @@ module Packwerk
           "custom"
         end
       end
-
       file_path = "path/of/exile.rb"
       violation_message = "This is a violation of code health."
       offense = Offense.new(file: file_path, message: violation_message)
@@ -162,7 +169,9 @@ module Packwerk
         offenses_formatter: T.unsafe(offenses_formatter).new
       )
 
-      ::Packwerk::FilesForProcessing.stubs(fetch: Set.new([file_path]))
+      FilesForProcessing.any_instance.stubs(
+        files: Set.new([file_path])
+      )
 
       success = cli.execute_command(["check", file_path])
 
@@ -196,7 +205,9 @@ module Packwerk
         cli = ::Packwerk::Cli.new(out: string_io)
       end
 
-      ::Packwerk::FilesForProcessing.stubs(fetch: Set.new([file_path]))
+      FilesForProcessing.any_instance.stubs(
+        files: Set.new([file_path])
+      )
 
       success = T.must(cli).execute_command(["check", file_path])
 
@@ -232,7 +243,9 @@ module Packwerk
         cli = ::Packwerk::Cli.new(out: string_io)
       end
 
-      ::Packwerk::FilesForProcessing.stubs(fetch: Set.new([file_path]))
+      FilesForProcessing.any_instance.stubs(
+        files: Set.new([file_path])
+      )
 
       success = T.must(cli).execute_command(["check", "--offenses-formatter=default", file_path])
 

--- a/test/unit/files_for_processing_test.rb
+++ b/test/unit/files_for_processing_test.rb
@@ -19,33 +19,39 @@ module Packwerk
     end
 
     test "fetch with custom paths includes only include glob in custom paths" do
-      files = ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [@package_path], configuration: @configuration)
+      files = ::Packwerk::FilesForProcessing.fetch(
+        relative_file_paths: [@package_path],
+        configuration: @configuration,
+      ).files
       included_file_pattern = File.join(@package_path, "**/*.rb")
       assert_all_match(files, [included_file_pattern])
     end
 
     test "fetch with custom paths excludes the exclude glob in custom paths" do
-      files = ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [@package_path], configuration: @configuration)
+      files = ::Packwerk::FilesForProcessing.fetch(
+        relative_file_paths: [@package_path],
+        configuration: @configuration
+      ).files
       excluded_file_pattern = File.join(@configuration.root_path, @package_path, "**/temp.rb")
 
       refute_any_match(files, [excluded_file_pattern])
     end
 
     test "fetch with no custom paths includes only include glob across codebase" do
-      files = ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [], configuration: @configuration)
+      files = ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [], configuration: @configuration).files
 
       assert_all_match(files, @configuration.include)
     end
 
     test "fetch with no custom paths excludes the exclude glob across codebase" do
-      files = ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [], configuration: @configuration)
+      files = ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [], configuration: @configuration).files
       excluded_file_patterns = @configuration.exclude.map { |pattern| File.join(@configuration.root_path, pattern) }
 
       refute_any_match(files, Set.new(excluded_file_patterns))
     end
 
     test "fetch does not return duplicated file paths" do
-      files = ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [], configuration: @configuration)
+      files = ::Packwerk::FilesForProcessing.fetch(relative_file_paths: [], configuration: @configuration).files
       assert_equal files, Set.new(files)
     end
 
@@ -54,7 +60,7 @@ module Packwerk
         relative_file_paths: ["."],
         configuration: @configuration,
         ignore_nested_packages: false
-      )
+      ).files
 
       assert_all_match(files, Set.new(@configuration.include))
     end
@@ -64,7 +70,7 @@ module Packwerk
         relative_file_paths: [],
         configuration: @configuration,
         ignore_nested_packages: true
-      )
+      ).files
 
       assert_all_match(files, @configuration.include)
     end
@@ -74,7 +80,7 @@ module Packwerk
         relative_file_paths: ["."],
         configuration: @configuration,
         ignore_nested_packages: true
-      )
+      ).files
 
       refute_any_match(files, Set.new([File.join(@configuration.root_path, "components/sales", "**/*.rb")]))
       refute_any_match(files, Set.new([File.join(@configuration.root_path, "components/timeline", "**/*.rb")]))
@@ -87,7 +93,7 @@ module Packwerk
           "components/sales/app/views/order.html.erb",
         ],
         configuration: @configuration
-      )
+      ).files
 
       included_file_patterns = @configuration.include
 

--- a/test/unit/parse_run_test.rb
+++ b/test/unit/parse_run_test.rb
@@ -59,6 +59,21 @@ module Packwerk
       refute result.status
     end
 
+    test "#update-todo returns exit code 1 when ran with file args" do
+      use_template(:minimal)
+
+      parse_run = Packwerk::ParseRun.new(
+        relative_file_set: Set.new(["path/of/exile.rb"]),
+        file_set_specified: true,
+        configuration: Configuration.from_path
+      )
+      result = parse_run.update_todo
+
+      expected = "⚠️ update-todo must be called without any file arguments."
+      assert_equal expected, result.message
+      refute result.status
+    end
+
     test "#update_todo cleans up old package_todo files" do
       use_template(:minimal)
 


### PR DESCRIPTION
## What are you trying to accomplish?

When updating the todo, Packwerk should know about all packages in an application. Most of the time, running update-todo with arguments doesn't make sense and is prone to errors. So, let's stop this usage and make sure developers are always updating todos without arguments.


## What approach did you choose and why?

Pass the `FilesForProcessing` object instead of the file set specifically to provide more info about the file-set, and to lazily fetch / filter the files.

## What should reviewers focus on?

Does this make sense?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
