### PR TITLE
Move Dependency validations into DependencyValidator

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -345,7 +345,7 @@ require:
 
 Similar to checkers, you can define your own validator to be executed when `bin/packwerk validate` is invoked. This can be used to support your custom checker (by specifying permitted keys) or to provide any other validations you want to impose on packages.
 
-To create a custom validator, you'll first need to create a validator class that includes `Packwerk::Validator`. Here is an example:
+To create a custom validator, you'll first need to create a validator class that includes `Packwerk::Validator`. You can use [`Packwerk::Validators::DependencyValidator`](lib/packwerk/validators/dependency_validator.rb) as a point of reference for this. Here is an example:
 
 ```ruby
 # ./path/to/file.rb

--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -103,3 +103,5 @@ require "packwerk/formatters/offenses_formatter"
 
 # Required to register the default DependencyChecker
 require "packwerk/reference_checking/checkers/dependency_checker"
+# Required to register the default DependencyValidator
+require "packwerk/validators/dependency_validator"

--- a/lib/packwerk/reference_checking/checkers/dependency_checker.rb
+++ b/lib/packwerk/reference_checking/checkers/dependency_checker.rb
@@ -57,7 +57,7 @@ module Packwerk
 
         sig { params(reference: Reference).returns(String) }
         def standard_help_message(reference)
-          standard_message = <<~EOS.chomp
+          standard_message = <<~EOS
             Inference details: this is a reference to #{reference.constant.name} which seems to be defined in #{reference.constant.location}.
             To receive help interpreting or resolving this error message, see: https://github.com/Shopify/packwerk/blob/main/TROUBLESHOOT.md#Troubleshooting-violations
           EOS

--- a/lib/packwerk/validators/dependency_validator.rb
+++ b/lib/packwerk/validators/dependency_validator.rb
@@ -1,0 +1,153 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Packwerk
+  module Validators
+    class DependencyValidator
+      extend T::Sig
+      include Validator
+
+      sig do
+        override.params(package_set: PackageSet, configuration: Configuration).returns(ApplicationValidator::Result)
+      end
+      def call(package_set, configuration)
+        results = [
+          check_package_manifest_syntax(configuration),
+          check_acyclic_graph(package_set),
+          check_valid_package_dependencies(configuration),
+        ]
+
+        merge_results(results)
+      end
+
+      sig { override.returns(T::Array[String]) }
+      def permitted_keys
+        [
+          "enforce_dependencies",
+          "dependencies",
+        ]
+      end
+
+      private
+
+      sig { params(configuration: Configuration).returns(ApplicationValidator::Result) }
+      def check_package_manifest_syntax(configuration)
+        errors = []
+
+        package_manifests_settings_for(configuration, "enforce_dependencies").each do |config, setting|
+          next if setting.nil?
+
+          unless [TrueClass, FalseClass, "strict"].include?(setting.class)
+            errors << "\tInvalid 'enforce_dependencies' option: #{setting.inspect} in #{config.inspect}"
+          end
+        end
+
+        package_manifests_settings_for(configuration, "dependencies").each do |config, setting|
+          next if setting.nil?
+
+          unless setting.is_a?(Array)
+            errors << "\tInvalid 'dependencies' option: #{setting.inspect} in #{config.inspect}"
+          end
+        end
+
+        if errors.empty?
+          ApplicationValidator::Result.new(ok: true)
+        else
+          merge_results(
+            errors.map { |error| ApplicationValidator::Result.new(ok: false, error_value: error) },
+            separator: "\n",
+            before_errors: "Malformed syntax in the following manifests:\n\n",
+            after_errors: "\n",
+          )
+        end
+      end
+
+      sig { params(package_set: PackageSet).returns(ApplicationValidator::Result) }
+      def check_acyclic_graph(package_set)
+        edges = package_set.flat_map do |package|
+          package.dependencies.map do |dependency|
+            [package.name, package_set.fetch(dependency)&.name]
+          end
+        end
+
+        dependency_graph = Graph.new(edges)
+
+        cycle_strings = build_cycle_strings(dependency_graph.cycles)
+
+        if dependency_graph.acyclic?
+          ApplicationValidator::Result.new(ok: true)
+        else
+          ApplicationValidator::Result.new(
+            ok: false,
+            error_value: <<~EOS
+              Expected the package dependency graph to be acyclic, but it contains the following circular dependencies:
+
+              #{cycle_strings.join("\n")}
+            EOS
+          )
+        end
+      end
+
+      sig { params(configuration: Configuration).returns(ApplicationValidator::Result) }
+      def check_valid_package_dependencies(configuration)
+        packages_dependencies = package_manifests_settings_for(configuration, "dependencies")
+          .delete_if { |_, deps| deps.nil? }
+
+        packages_with_invalid_dependencies =
+          packages_dependencies.each_with_object([]) do |(package, dependencies), invalid_packages|
+            invalid_dependencies = if dependencies.is_a?(Array)
+              dependencies.filter { |path| invalid_package_path?(configuration, path) }
+            else
+              []
+            end
+            invalid_packages << [package, invalid_dependencies] if invalid_dependencies.any?
+          end
+
+        if packages_with_invalid_dependencies.empty?
+          ApplicationValidator::Result.new(ok: true)
+        else
+          error_locations = packages_with_invalid_dependencies.map do |package, invalid_dependencies|
+            package ||= configuration.root_path
+            package_path = Pathname.new(package).relative_path_from(configuration.root_path)
+            all_invalid_dependencies = invalid_dependencies.map { |d| "  - #{d}" }
+
+            <<~EOS
+              \t#{package_path}:
+              \t#{all_invalid_dependencies.join("\n\t")}
+            EOS
+          end
+
+          ApplicationValidator::Result.new(
+            ok: false,
+            error_value: "These dependencies do not point to valid packages:\n\n#{error_locations.join("\n")}"
+          )
+        end
+      end
+
+      sig { params(configuration: Configuration, path: T.untyped).returns(T::Boolean) }
+      def invalid_package_path?(configuration, path)
+        # Packages at the root can be implicitly specified as "."
+        return false if path == "."
+
+        package_path = File.join(configuration.root_path, path, PackageSet::PACKAGE_CONFIG_FILENAME)
+        !File.file?(package_path)
+      end
+
+      # Convert the cycles:
+      #
+      #   [[a, b, c], [b, c]]
+      #
+      # to the string:
+      #
+      #   ["a -> b -> c -> a", "b -> c -> b"]
+      sig { params(cycles: T.untyped).returns(T::Array[String]) }
+      def build_cycle_strings(cycles)
+        cycles.map do |cycle|
+          cycle_strings = cycle.map(&:to_s)
+          cycle_strings << cycle.first.to_s
+          "\t- #{cycle_strings.join(" → ")}"
+        end
+      end
+    end
+  end
+end

--- a/test/unit/dependency_validator_test.rb
+++ b/test/unit/dependency_validator_test.rb
@@ -1,0 +1,68 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Packwerk
+  class DependencyValidatorTest < Minitest::Test
+    include FactoryHelper
+    include RailsApplicationFixtureHelper
+
+    setup do
+      setup_application_fixture
+    end
+
+    teardown do
+      teardown_application_fixture
+    end
+
+    test "returns error when package set contains circular dependencies" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("components/sales/package.yml", { "dependencies" => ["components/timeline"] })
+      merge_into_app_yaml_file("components/timeline/package.yml", { "dependencies" => ["components/sales"] })
+
+      result = dependency_validator.call(package_set, config)
+
+      refute result.ok?
+      assert_match(/Expected the package dependency graph to be acyclic/, result.error_value)
+      assert_match %r{components/sales → components/timeline → components/sales}, result.error_value
+    end
+
+    test "returns error when config contains invalid package dependency" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("components/sales/package.yml", { "dependencies" => ["components/timeline"] })
+
+      result = dependency_validator.call(package_set, config)
+
+      refute result.ok?
+      assert_match(/These dependencies do not point to valid packages:/, result.error_value)
+      assert_match(%r{\n\n\tcomponents/sales/package.yml:\n\t  - components/timeline\n$}m, result.error_value)
+    end
+
+    test "returns error when invalid enforce_dependencies value is in the package.yml file" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("components/sales/package.yml", { "enforce_dependencies" => "yes" })
+
+      result = dependency_validator.call(package_set, config)
+      refute result.ok?
+      assert_match("Malformed syntax in the following manifests:", result.error_value)
+      assert_match("Invalid 'enforce_dependencies' option: \"yes\"", result.error_value)
+    end
+
+    test "returns error when invalid dependencies value is in the package.yml file" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("components/sales/package.yml", { "dependencies" => "yes" })
+
+      result = dependency_validator.call(package_set, config)
+      refute result.ok?
+      assert_match("Malformed syntax in the following manifests:", result.error_value)
+      assert_match("Invalid 'dependencies' option: \"yes\"", result.error_value)
+    end
+
+    private
+
+    def dependency_validator
+      Validators::DependencyValidator.new
+    end
+  end
+end


### PR DESCRIPTION
## What are you trying to accomplish?
I really wanted there to be an example of a "Validator" in `packwerk` other than the monolithic `ApplicationValidator`. This also has the benefit of colocating validations related to dependencies in one place.

## What approach did you choose and why?
I chose to pull the `DependencyValidator` into its own class. I originally pulled it into `DependencyChecker`, however there wasn't much of an advantage of this, and it violated the single responsibility principle. It looks a lot neater in its own class.

## What should reviewers focus on?
Any reason not to colocate these validations?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
