### PR TITLE
More strict typing

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -148,13 +148,15 @@ module Packwerk
 
     sig { params(_paths: T::Array[String]).returns(T::Boolean) }
     def validate(_paths)
+      result = T.let(nil, T.nilable(ApplicationValidator::Result))
+
       @progress_formatter.started_validation do
         result = validator.check_all(package_set, @configuration)
 
         list_validation_errors(result)
-
-        return result.ok?
       end
+
+      T.must(result).ok?
     end
 
     sig { returns(ApplicationValidator) }

--- a/lib/packwerk/formatters/progress_formatter.rb
+++ b/lib/packwerk/formatters/progress_formatter.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "benchmark"
@@ -14,6 +14,7 @@ module Packwerk
         @style = style
       end
 
+      sig { params(block: T.proc.void).void }
       def started_validation(&block)
         start_validation
 
@@ -21,6 +22,7 @@ module Packwerk
         finished(execution_time)
       end
 
+      sig { params(target_files: FilesForProcessing::RelativeFileSet, block: T.proc.void).void }
       def started_inspection(target_files, &block)
         start_inspection(target_files)
 
@@ -28,14 +30,17 @@ module Packwerk
         finished(execution_time)
       end
 
+      sig { void }
       def mark_as_inspected
         @out.print(".")
       end
 
+      sig { void }
       def mark_as_failed
         @out.print("#{@style.error}E#{@style.reset}")
       end
 
+      sig { void }
       def interrupted
         @out.puts
         @out.puts("Manually interrupted. Violations caught so far are listed below:")
@@ -43,15 +48,18 @@ module Packwerk
 
       private
 
+      sig { params(execution_time: Float).void }
       def finished(execution_time)
         @out.puts
         @out.puts("📦 Finished in #{execution_time.round(2)} seconds")
       end
 
+      sig { void }
       def start_validation
         @out.puts("📦 Packwerk is running validation...")
       end
 
+      sig { params(target_files: FilesForProcessing::RelativeFileSet).void }
       def start_inspection(target_files)
         files_size = target_files.size
         files_string = "file".pluralize(files_size)

--- a/lib/packwerk/generators/configuration_file.rb
+++ b/lib/packwerk/generators/configuration_file.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "erb"
@@ -11,6 +11,9 @@ module Packwerk
       CONFIGURATION_TEMPLATE_FILE_PATH = "templates/packwerk.yml.erb"
 
       class << self
+        extend T::Sig
+
+        sig { params(root: String, out: T.any(IO, StringIO)).returns(T::Boolean) }
         def generate(root:, out:)
           new(root: root, out: out).generate
         end
@@ -40,10 +43,12 @@ module Packwerk
 
       private
 
+      sig { returns(String) }
       def render
         ERB.new(template, trim_mode: "-").result(binding)
       end
 
+      sig { returns(String) }
       def template
         template_file_path = File.join(__dir__, CONFIGURATION_TEMPLATE_FILE_PATH)
         File.read(template_file_path)

--- a/lib/packwerk/generators/root_package.rb
+++ b/lib/packwerk/generators/root_package.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Packwerk
@@ -7,11 +7,15 @@ module Packwerk
       extend T::Sig
 
       class << self
+        extend T::Sig
+
+        sig { params(root: String, out: T.any(IO, StringIO)).returns(T::Boolean) }
         def generate(root:, out:)
           new(root: root, out: out).generate
         end
       end
 
+      sig { params(root: String, out: T.any(IO, StringIO)).void }
       def initialize(root:, out: $stdout)
         @root = root
         @out = out

--- a/lib/packwerk/parsers/factory.rb
+++ b/lib/packwerk/parsers/factory.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "singleton"
@@ -20,20 +20,29 @@ module Packwerk
       ERB_REGEX = /\.erb\Z/
       private_constant :ERB_REGEX
 
+      sig { void }
+      def initialize
+        @ruby_parser = T.let(nil, T.nilable(ParserInterface))
+        @erb_parser = T.let(nil, T.nilable(ParserInterface))
+        @erb_parser_class = T.let(nil, T.nilable(Class))
+      end
+
       sig { params(path: String).returns(T.nilable(ParserInterface)) }
       def for_path(path)
         case path
         when RUBY_REGEX
           @ruby_parser ||= Ruby.new
         when ERB_REGEX
-          @erb_parser ||= erb_parser_class.new
+          @erb_parser ||= T.unsafe(erb_parser_class).new
         end
       end
 
+      sig { returns(Class) }
       def erb_parser_class
         @erb_parser_class ||= Erb
       end
 
+      sig { params(klass: T.nilable(Class)).void }
       def erb_parser_class=(klass)
         @erb_parser_class = klass
         @erb_parser = nil

--- a/lib/packwerk/parsers/parser_interface.rb
+++ b/lib/packwerk/parsers/parser_interface.rb
@@ -11,7 +11,7 @@ module Packwerk
 
       interface!
 
-      sig { abstract.params(io: File, file_path: String).returns(T.untyped) }
+      sig { abstract.params(io: T.any(IO, StringIO), file_path: String).returns(T.untyped) }
       def call(io:, file_path:)
       end
     end

--- a/lib/packwerk/parsers/ruby.rb
+++ b/lib/packwerk/parsers/ruby.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "parser"
@@ -7,9 +7,14 @@ require "parser/current"
 module Packwerk
   module Parsers
     class Ruby
+      extend T::Sig
+
       include ParserInterface
 
       class RaiseExceptionsParser < Parser::CurrentRuby
+        extend T::Sig
+
+        sig { params(builder: T.untyped).void }
         def initialize(builder)
           super(builder)
           super.diagnostics.all_errors_are_fatal = true
@@ -17,16 +22,21 @@ module Packwerk
       end
 
       class TolerateInvalidUtf8Builder < Parser::Builders::Default
+        extend T::Sig
+
+        sig { params(token: T.untyped).returns(T.untyped) }
         def string_value(token)
           value(token)
         end
       end
 
+      sig { params(parser_class: T.untyped).void }
       def initialize(parser_class: RaiseExceptionsParser)
-        @builder = TolerateInvalidUtf8Builder.new
+        @builder = T.let(TolerateInvalidUtf8Builder.new, Object)
         @parser_class = parser_class
       end
 
+      sig { override.params(io: T.any(IO, StringIO), file_path: String).returns(T.untyped) }
       def call(io:, file_path: "<unknown>")
         buffer = Parser::Source::Buffer.new(file_path)
         buffer.source = io.read

--- a/lib/packwerk/reference_extractor.rb
+++ b/lib/packwerk/reference_extractor.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Packwerk
@@ -63,7 +63,10 @@ module Packwerk
     )
       @constant_name_inspectors = constant_name_inspectors
       @root_path = root_path
-      @local_constant_definitions = ParsedConstantDefinitions.new(root_node: root_node)
+      @local_constant_definitions = T.let(
+        ParsedConstantDefinitions.new(root_node: root_node),
+        ParsedConstantDefinitions,
+      )
     end
 
     sig do
@@ -117,6 +120,13 @@ module Packwerk
       )
     end
 
+    sig do
+      params(
+        constant_name: String,
+        name_location: T.nilable(Node::Location),
+        namespace_path: T::Array[String],
+      ).returns(T::Boolean)
+    end
     def local_reference?(constant_name, name_location, namespace_path)
       @local_constant_definitions.local_reference?(
         constant_name,

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -100,7 +100,9 @@ module Packwerk
 
       success = cli.execute_command(["validate"])
 
-      assert_includes string_io.string, "Validation successful 🎉\n"
+      assert_match "📦 Packwerk is running validation...", string_io.string
+      assert_match "Validation successful 🎉", string_io.string
+      assert_match(/📦 Finished in \d+.\d{1,2} seconds/, string_io.string)
       assert success
     end
 
@@ -114,8 +116,10 @@ module Packwerk
 
       success = cli.execute_command(["validate"])
 
-      assert_includes string_io.string, "Validation failed ❗\n"
-      assert_includes string_io.string, "I'm an error"
+      assert_match "📦 Packwerk is running validation...", string_io.string
+      assert_match "Validation failed ❗", string_io.string
+      assert_match "I'm an error", string_io.string
+      assert_match(/📦 Finished in \d+.\d{1,2} seconds/, string_io.string)
       refute success
     end
 

--- a/test/unit/formatters/progress_formatter_test.rb
+++ b/test/unit/formatters/progress_formatter_test.rb
@@ -12,7 +12,7 @@ module Packwerk
       end
 
       test "#started_inspection yields control to code block" do
-        @progress_formatter.started_inspection([]) do
+        @progress_formatter.started_inspection(Set[]) do
           @string_io.puts("This block has been run")
         end
 
@@ -20,23 +20,23 @@ module Packwerk
       end
 
       test "#started_inspection prints the right file size for multiple files" do
-        @progress_formatter.started_inspection([1, 2, 3, 4, 5]) {}
+        @progress_formatter.started_inspection(Set["1", "2", "3", "4", "5"]) {}
         assert_match "5 files", @string_io.string
       end
 
       test "#started_inspection prints the right file size for single files" do
-        @progress_formatter.started_inspection([1]) {}
+        @progress_formatter.started_inspection(Set["1"]) {}
         assert_match "1 file", @string_io.string
       end
 
       test "#started_inspection prints the right file size for no files" do
-        @progress_formatter.started_inspection([]) {}
+        @progress_formatter.started_inspection(Set[]) {}
         assert_match "0 files", @string_io.string
       end
 
       test "#started_inspection prints the correct time" do
         Benchmark.expects(:realtime).returns(4.5678)
-        @progress_formatter.started_inspection([]) {}
+        @progress_formatter.started_inspection(Set[]) {}
 
         assert_match "4.57 seconds", @string_io.string
       end


### PR DESCRIPTION
## What are you trying to accomplish?

Convert more files to typed: strict. Also fix a bug in `Cli#validate` unveiled by new sigs where `validation_started` is returning early (before the block starts). This adds extra text to the validation step, which I can remove if we don't like it. It seems we always wanted it to act like this, but never tested it.

## What approach did you choose and why?

Convert more files to `typed: strict`. I found dead code (an unreachable IF statement) and investigated an interesting regression in `T::Struct` in the last strong typing PR, so I think this work is worth doing. 

## What should reviewers focus on?

Does the parser approach make sense? I've never used generics in Sorbet before.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
