### PR TITLE
Allow ERB parser to_ruby_ast to return nil

### DIFF
--- a/lib/packwerk/parsers/erb.rb
+++ b/lib/packwerk/parsers/erb.rb
@@ -15,7 +15,7 @@ module Packwerk
 
       sig { params(parser_class: T.untyped, ruby_parser: Ruby).void }
       def initialize(parser_class: BetterHtml::Parser, ruby_parser: Ruby.new)
-        @parser_class = parser_class
+        @parser_class = T.let(parser_class, T.class_of(BetterHtml::Parser))
         @ruby_parser = ruby_parser
       end
 
@@ -26,7 +26,7 @@ module Packwerk
         parse_buffer(buffer, file_path: file_path)
       end
 
-      sig { params(buffer: Parser::Source::Buffer, file_path: String).returns(T.untyped) }
+      sig { params(buffer: Parser::Source::Buffer, file_path: String).returns(T.nilable(AST::Node)) }
       def parse_buffer(buffer, file_path:)
         parser = @parser_class.new(buffer, template_language: :html)
         to_ruby_ast(parser.ast, file_path)
@@ -44,7 +44,7 @@ module Packwerk
         params(
           erb_ast: T.all(::AST::Node, Object),
           file_path: String
-        ).returns(::AST::Node)
+        ).returns(T.nilable(::AST::Node))
       end
       def to_ruby_ast(erb_ast, file_path)
         # Note that we're not using the source location (line/column) at the moment, but if we did

--- a/lib/packwerk/parsers/ruby.rb
+++ b/lib/packwerk/parsers/ruby.rb
@@ -33,10 +33,10 @@ module Packwerk
       sig { params(parser_class: T.untyped).void }
       def initialize(parser_class: RaiseExceptionsParser)
         @builder = T.let(TolerateInvalidUtf8Builder.new, Object)
-        @parser_class = parser_class
+        @parser_class = T.let(parser_class, T.class_of(RaiseExceptionsParser))
       end
 
-      sig { override.params(io: T.any(IO, StringIO), file_path: String).returns(T.untyped) }
+      sig { override.params(io: T.any(IO, StringIO), file_path: String).returns(T.nilable(Parser::AST::Node)) }
       def call(io:, file_path: "<unknown>")
         buffer = Parser::Source::Buffer.new(file_path)
         buffer.source = io.read

--- a/sorbet/rbi/shims/parser.rbi
+++ b/sorbet/rbi/shims/parser.rbi
@@ -1,0 +1,13 @@
+# typed: strict
+
+class Parser::Base < ::Racc::Parser
+  # Parses a source buffer and returns the AST, or `nil` in case of a non fatal error.
+  #
+  # @api public
+  # @param source_buffer [Parser::Source::Buffer] The source buffer to parse.
+  # @return [Parser::AST::Node, nil]
+  #
+  # source://parser-3.1.2.1/lib/parser/base.rb:186
+  sig { params(source_buffer: Parser::Source::Buffer).returns(T.nilable(Parser::AST::Node)) }
+  def parse(source_buffer); end
+end

--- a/test/fixtures/formats/erb/javascript_valid.erb
+++ b/test/fixtures/formats/erb/javascript_valid.erb
@@ -1,0 +1,2 @@
+<script type="text/javascript">
+</script>

--- a/test/unit/parsers/erb_test.rb
+++ b/test/unit/parsers/erb_test.rb
@@ -9,6 +9,8 @@ require "test_helper"
 module Packwerk
   module Parsers
     class ErbTest < Minitest::Test
+      include TypedMock
+
       test "#call returns node with valid file" do
         node = File.open(fixture_path("valid.erb"), "r") do |fixture|
           Erb.new.call(io: fixture)
@@ -17,13 +19,21 @@ module Packwerk
         assert_kind_of(::AST::Node, node)
       end
 
+      test "#call returns node with valid javascript file" do
+        node = File.open(fixture_path("javascript_valid.erb"), "r") do |fixture|
+          Erb.new.call(io: fixture)
+        end
+
+        assert_kind_of(NilClass, node)
+      end
+
       test "#call writes parse error to stdout" do
         error_message = "stub error"
         err = Parser::SyntaxError.new(stub(message: error_message))
         parser = stub
         parser.stubs(:ast).raises(err)
 
-        parser_class_stub = stub(new: parser)
+        parser_class_stub = typed_mock(new: parser, "<=": true)
 
         parser = Erb.new(parser_class: parser_class_stub)
         file_path = fixture_path("invalid.erb")
@@ -44,7 +54,7 @@ module Packwerk
         parser = stub
         parser.stubs(:ast).raises(err)
 
-        parser_class_stub = stub(new: parser)
+        parser_class_stub = typed_mock(new: parser, "<=": true)
 
         parser = Erb.new(parser_class: parser_class_stub)
         file_path = fixture_path("invalid.erb")

--- a/test/unit/parsers/ruby_test.rb
+++ b/test/unit/parsers/ruby_test.rb
@@ -6,6 +6,8 @@ require "test_helper"
 module Packwerk
   module Parsers
     class RubyTest < Minitest::Test
+      include TypedMock
+
       test "#call returns node with valid file" do
         node = File.open(fixture_path("valid.rb"), "r") do |fixture|
           Ruby.new.call(io: fixture)
@@ -20,7 +22,7 @@ module Packwerk
         parser = stub
         parser.stubs(:parse).raises(err)
 
-        parser_class_stub = stub(new: parser)
+        parser_class_stub = typed_mock(new: parser, "<=": true)
 
         parser = Ruby.new(parser_class: parser_class_stub)
         file_path = fixture_path("invalid.rb")
@@ -41,7 +43,7 @@ module Packwerk
         parser = stub
         parser.stubs(:parse).raises(err)
 
-        parser_class_stub = stub(new: parser)
+        parser_class_stub = typed_mock(new: parser, "<=": true)
 
         parser = Ruby.new(parser_class: parser_class_stub)
         file_path = fixture_path("invalid.rb")


### PR DESCRIPTION
## What are you trying to accomplish?
After we added types, I found this method returned `nil` on our monolith sometimes, causing `bin/packwerk update-todo` unable to execute properly.

## What approach did you choose and why?
I updated the sig to ensure it continues to work as expected. We might want to come back later and...
1) figure out when/how its `nil`
2) Add a test for when its `nil` (or possible fix it so its never `nil` if that turns out to be a better approach)

## What should reviewers focus on?


## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] It is safe to rollback this change.
