### PR TITLE
Remove private_constant from some API with valid use cases

### DIFF
--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -14,8 +14,11 @@ module Packwerk
   extend ActiveSupport::Autoload
 
   # Public APIs
+  autoload :ApplicationLoadPaths
   autoload :Checker
   autoload :Cli
+  autoload :ConstantContext
+  autoload :Node
   autoload :Offense
   autoload :OffensesFormatter
   autoload :OutputStyle
@@ -27,38 +30,6 @@ module Packwerk
   autoload :ReferenceOffense
   autoload :Validator
   autoload :Version
-
-  # Private APIs
-  # Please submit an issue if you have a use-case for these
-  autoload :ApplicationLoadPaths
-  autoload :ApplicationValidator
-  autoload :AssociationInspector
-  autoload :Cache
-  autoload :Configuration
-  autoload :ConstantDiscovery
-  autoload :ConstantNameInspector
-  autoload :ConstNodeInspector
-  autoload :ExtensionLoader
-  autoload :FileProcessor
-  autoload :FilesForProcessing
-  autoload :Graph
-  autoload :Node
-  autoload :NodeHelpers
-  autoload :NodeProcessor
-  autoload :NodeProcessorFactory
-  autoload :NodeVisitor
-  autoload :OffenseCollection
-  autoload :ParsedConstantDefinitions
-  autoload :ParseRun
-  autoload :ReferenceExtractor
-  autoload :RunContext
-  autoload :UnresolvedReference
-
-  module Validator
-    extend ActiveSupport::Autoload
-
-    autoload :Result
-  end
 
   class Cli
     extend ActiveSupport::Autoload
@@ -83,7 +54,35 @@ module Packwerk
     autoload :ProgressFormatter
   end
 
-  private_constant :Formatters
+  module Validator
+    extend ActiveSupport::Autoload
+
+    autoload :Result
+  end
+
+  # Private APIs
+  # Please submit an issue if you have a use-case for these
+  autoload :ApplicationValidator
+  autoload :AssociationInspector
+  autoload :Cache
+  autoload :Configuration
+  autoload :ConstantDiscovery
+  autoload :ConstantNameInspector
+  autoload :ConstNodeInspector
+  autoload :ExtensionLoader
+  autoload :FileProcessor
+  autoload :FilesForProcessing
+  autoload :Graph
+  autoload :NodeHelpers
+  autoload :NodeProcessor
+  autoload :NodeProcessorFactory
+  autoload :NodeVisitor
+  autoload :OffenseCollection
+  autoload :ParsedConstantDefinitions
+  autoload :ParseRun
+  autoload :ReferenceExtractor
+  autoload :RunContext
+  autoload :UnresolvedReference
 
   module Generators
     extend ActiveSupport::Autoload

--- a/lib/packwerk/application_load_paths.rb
+++ b/lib/packwerk/application_load_paths.rb
@@ -70,6 +70,4 @@ module Packwerk
       end
     end
   end
-
-  private_constant :ApplicationLoadPaths
 end

--- a/lib/packwerk/constant_context.rb
+++ b/lib/packwerk/constant_context.rb
@@ -1,0 +1,10 @@
+# typed: true
+# frozen_string_literal: true
+
+require "constant_resolver"
+
+module Packwerk
+  extend T::Sig
+
+  ConstantContext = Struct.new(:name, :location, :package)
+end

--- a/lib/packwerk/constant_discovery.rb
+++ b/lib/packwerk/constant_discovery.rb
@@ -17,8 +17,6 @@ module Packwerk
   class ConstantDiscovery
     extend T::Sig
 
-    ConstantContext = Struct.new(:name, :location, :package)
-
     # @param constant_resolver [ConstantResolver]
     # @param packages [Packwerk::PackageSet]
     sig do
@@ -50,12 +48,12 @@ module Packwerk
     # @param const_name [String] The unresolved constant's name.
     # @param current_namespace_path [Array<String>] (optional) The namespace of the context in which the constant is
     #   used, e.g. ["Apps", "Models"] for `Apps::Models`. Defaults to [] which means top level.
-    # @return [ConstantDiscovery::ConstantContext]
+    # @return [ConstantContext]
     sig do
       params(
         const_name: String,
         current_namespace_path: T.nilable(T::Array[String]),
-      ).returns(T.nilable(ConstantDiscovery::ConstantContext))
+      ).returns(T.nilable(ConstantContext))
     end
     def context_for(const_name, current_namespace_path: [])
       begin

--- a/lib/packwerk/node.rb
+++ b/lib/packwerk/node.rb
@@ -2,9 +2,7 @@
 # frozen_string_literal: true
 
 module Packwerk
-  class Node
+  module Node
     Location = Struct.new(:line, :column)
   end
-
-  private_constant :Node
 end

--- a/sorbet/rbi/shims/packwerk/reference.rbi
+++ b/sorbet/rbi/shims/packwerk/reference.rbi
@@ -6,7 +6,7 @@ module Packwerk
       params(
         package: Package,
         relative_path: String,
-        constant: ConstantDiscovery::ConstantContext,
+        constant: ConstantContext,
         source_location: T.nilable(Node::Location),
       ).void
     end
@@ -24,7 +24,7 @@ module Packwerk
     sig { returns(T.nilable(String)) }
     attr_reader(:relative_path)
 
-    sig { returns(ConstantDiscovery::ConstantContext) }
+    sig { returns(ConstantContext) }
     attr_reader(:constant)
 
     sig { returns(T.nilable(Node::Location)) }

--- a/test/support/factory_helper.rb
+++ b/test/support/factory_helper.rb
@@ -10,7 +10,7 @@ module Packwerk
       constant_name: "::SomeName",
       source_location: Node::Location.new(2, 12)
     )
-      constant = ConstantDiscovery::ConstantContext.new(
+      constant = ConstantContext.new(
         constant_name,
         "some/location.rb",
         destination_package,


### PR DESCRIPTION
## What are you trying to accomplish?
Allow clients to use API that was marked `private_constant` in a recent PR.

## What approach did you choose and why?
I removed `private_constant`.

## What should reviewers focus on?
Any reason not to make these publics?

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
