### PR TITLE
Make OffenseCollection and Configuration public

### DIFF
--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -17,6 +17,7 @@ module Packwerk
   autoload :ApplicationLoadPaths
   autoload :Checker
   autoload :Cli
+  autoload :Configuration
   autoload :ConstantContext
   autoload :Node
   autoload :Offense
@@ -66,7 +67,6 @@ module Packwerk
   autoload :ApplicationValidator
   autoload :AssociationInspector
   autoload :Cache
-  autoload :Configuration
   autoload :ConstantDiscovery
   autoload :ConstantNameInspector
   autoload :ConstNodeInspector

--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -20,6 +20,7 @@ module Packwerk
   autoload :ConstantContext
   autoload :Node
   autoload :Offense
+  autoload :OffenseCollection
   autoload :OffensesFormatter
   autoload :OutputStyle
   autoload :Package
@@ -77,7 +78,6 @@ module Packwerk
   autoload :NodeProcessor
   autoload :NodeProcessorFactory
   autoload :NodeVisitor
-  autoload :OffenseCollection
   autoload :ParsedConstantDefinitions
   autoload :ParseRun
   autoload :ReferenceExtractor

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -77,6 +77,4 @@ module Packwerk
       @cache_enabled
     end
   end
-
-  private_constant :Configuration
 end

--- a/lib/packwerk/offense_collection.rb
+++ b/lib/packwerk/offense_collection.rb
@@ -120,6 +120,4 @@ module Packwerk
       File.join(@root_path, package.name, "package_todo.yml")
     end
   end
-
-  private_constant :OffenseCollection
 end


### PR DESCRIPTION
## What are you trying to accomplish?
`OffenseCollection` should be public since it's part of the public API for `OffensesFormatter` and needs to be referenced in the sig when creating another implementation of the `OffensesFormatter`.

`Configuration` should be public since it's part of the public API for `Validator`.

## What approach did you choose and why?
Making constants public by removing `private_constant`.

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
