### PR TITLE
Fix bug with dependency validator strict mode

### DIFF
--- a/lib/packwerk/validators/dependency_validator.rb
+++ b/lib/packwerk/validators/dependency_validator.rb
@@ -34,10 +34,11 @@ module Packwerk
       def check_package_manifest_syntax(configuration)
         errors = []
 
+        valid_settings = [true, false, "strict"]
         package_manifests_settings_for(configuration, "enforce_dependencies").each do |config, setting|
           next if setting.nil?
 
-          unless [TrueClass, FalseClass, "strict"].include?(setting.class)
+          unless valid_settings.include?(setting)
             errors << "\tInvalid 'enforce_dependencies' option: #{setting.inspect} in #{config.inspect}"
           end
         end

--- a/test/unit/packwerk/dependency_validator_test.rb
+++ b/test/unit/packwerk/dependency_validator_test.rb
@@ -59,6 +59,14 @@ module Packwerk
       assert_match("Invalid 'dependencies' option: \"yes\"", result.error_value)
     end
 
+    test "returns success when enforce_dependencies is set to strict in the package.yml file" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("components/sales/package.yml", { "enforce_dependencies" => "strict" })
+
+      result = dependency_validator.call(package_set, config)
+      assert result.ok?
+    end
+
     private
 
     def dependency_validator


### PR DESCRIPTION
## What are you trying to accomplish?
Allow strict mode to work for dependency validator.

## What approach did you choose and why?
Compare value (instead of the class) against the string `strict`.

## What should reviewers focus on?
n/a

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
