### PR TITLE
Fix error message for strict mode

### DIFF
--- a/lib/packwerk/formatters/default_offenses_formatter.rb
+++ b/lib/packwerk/formatters/default_offenses_formatter.rb
@@ -55,7 +55,8 @@ module Packwerk
         reference_package = offense.reference.package
         defining_package = offense.reference.constant.package
         "#{reference_package} cannot have #{offense.violation_type} violations on #{defining_package} "\
-          "because strict mode is enabled for #{offense.violation_type} violations in #{reference_package}/package.yml"
+          "because strict mode is enabled for #{offense.violation_type} violations in "\
+          "the enforcing package's package.yml"
       end
 
       sig { params(offenses: T::Array[T.nilable(Offense)]).returns(String) }

--- a/test/unit/packwerk/parse_run_test.rb
+++ b/test/unit/packwerk/parse_run_test.rb
@@ -376,7 +376,7 @@ module Packwerk
       expected_message = <<~EOS
         No offenses detected
         No stale violations detected
-        components/source cannot have dependency violations on components/destination because strict mode is enabled for dependency violations in components/source/package.yml
+        components/source cannot have dependency violations on components/destination because strict mode is enabled for dependency violations in the enforcing package's package.yml
       EOS
       assert_equal expected_message, result.message
 


### PR DESCRIPTION
## What are you trying to accomplish?
Since a checker can produce a violation if the referencing OR the defining package declares a violation AND we have no way of knowing which (referencing or defining) package is the one that produces the violation, the error message on strict mode cannot suggest exactly which `package.yml` file is at cause.

## What approach did you choose and why?
I chose the route of just making the reference to the `package.yml` file ambiguous and leaving the reader to determine which `package.yml` to look at if they want to see where `strict` mode is set.

An alternative to this would be to look at https://github.com/Shopify/packwerk/pull/261, which allows the checker to define which package is the one that enforces violations and then to use that package in the error message. Since that change has less general agreement, I thought this would be a simpler stopgap.

## What should reviewers focus on?
Let me know if there's anything I'm missing.

## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
