### PR TITLE
Stop aborting when no files are input into bin/packwerk check

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -138,7 +138,7 @@ module Packwerk
         ignore_nested_packages: ignore_nested_packages,
         configuration: @configuration
       )
-      abort(<<~MSG.squish) if files_for_processing.files.empty?
+      @out.puts(<<~MSG.squish) if files_for_processing.files.empty?
         No files found or given.
         Specify files or check the include and exclude glob in the config file.
       MSG


### PR DESCRIPTION
## What are you trying to accomplish?
When using `bin/packwerk check` as a pre-commit hook, packwerk will error if only excluded files are passed in.

## What approach did you choose and why?
Instead, I think it makes more sense to simply succeed gracefully if only excluded files are passed in, in which case `bin/packwerk check` should return no errors.
This is more like rubocop's behavior.

I think the intent of the check was to be defensive in case a user is doing something that they maybe shouldn't be doing (testing excluded files). I think it actually ends up producing more confusion than its worth.

## What should reviewers focus on?
Let me know if there are other valid use cases for this check that I should be aware of and if we should solve this another way.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [x] Breaking change (fix or feature that would cause existing functionality to change)

I think this is technically a breaking change if someone depends on packwerk aborting in this case.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
