### PR TITLE
Application using Packwerk and Spring fails to start 

### DIFF
--- a/lib/packwerk/spring_command.rb
+++ b/lib/packwerk/spring_command.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "spring/commands"
+require "sorbet-runtime"
 
 module Packwerk
   class SpringCommand


### PR DESCRIPTION
## What are you trying to accomplish?

When `packwerk/spring_command` gets required from an application's `config/spring.rb`,
chances are Sorbet was not required, and running the application will
fail this way:

```
(snip)/packwerk/lib/packwerk/spring_command.rb:9:in `<class:SpringCommand>': uninitialized constant Packwerk::SpringCommand::T (NameError)

    extend T::Sig
            ^^^^^
        from (snip)/packwerk/lib/packwerk/spring_command.rb:8:in `<module:Packwerk>'
        from (snip)/packwerk/lib/packwerk/spring_command.rb:7:in `<top (required)>'
        from (snip)/my_app/config/spring.rb:4:in `require'
```

It is possible to reproduce the error above in a fresh new Rails 7 `rails new --minimal` application with the following changes:


```diff
diff --git c/Gemfile w/Gemfile
index a329896..acca730 100644
--- c/Gemfile
+++ w/Gemfile
@@ -25,6 +25,6 @@ end
 
 group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
-  # gem "spring"
+  gem "spring"
+  gem "packwerk", github: "Shopify/packwerk", branch: "main"
 end
-
diff --git c/bin/rails w/bin/rails
index efc0377..c8b5338 100755
--- c/bin/rails
+++ w/bin/rails
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+load File.expand_path("spring", __dir__)
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
 require "rails/commands"
diff --git c/bin/rake w/bin/rake
index 4fbf10b..7327f47 100755
--- c/bin/rake
+++ w/bin/rake
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+load File.expand_path("spring", __dir__)
 require_relative "../config/boot"
 require "rake"
 Rake.application.run
diff --git c/bin/spring w/bin/spring
new file mode 100755
index 0000000..37f429b
--- /dev/null
+++ w/bin/spring
@@ -0,0 +1,14 @@
+#!/usr/bin/env ruby
+
+# This file loads Spring without using loading other gems in the Gemfile, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
+  require "bundler"
+
+  Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem "spring", spring.version
+    require "spring/binstub"
+  end
+end
diff --git c/config/spring.rb w/config/spring.rb
new file mode 100644
index 0000000..a485fb4
--- /dev/null
+++ w/config/spring.rb
@@ -0,0 +1 @@
+require "packwerk/spring_command"
```
(Changes to `Gemfile.lock` excluded from this diff.)

## What approach did you choose and why?

Requiring `sorbet-runtime` at the top of `spring_command.rb` seems to be the right fix to me.

## What should reviewers focus on?

Is this the proper way to fix my problem? Did I miss anything in the setup of Packwerk HEAD?

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] It is safe to rollback this change.
