### PR TITLE
chore: add version command

### DIFF
--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -31,7 +31,6 @@ module Packwerk
   autoload :Reference
   autoload :ReferenceOffense
   autoload :Validator
-  autoload :Version
 
   class Cli
     extend ActiveSupport::Autoload

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -56,6 +56,9 @@ module Packwerk
         output_result(parse_run(args).update_todo)
       when "validate"
         validate(args)
+      when "version"
+        @out.puts(Packwerk::VERSION)
+        true
       when nil, "help"
         usage
       else
@@ -114,6 +117,7 @@ module Packwerk
           check - run all checks
           update-todo - update package_todo.yml files
           validate - verify integrity of packwerk and package configuration
+          version - output packwerk version
           help  - display help information about packwerk
       USAGE
       true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,8 @@
 
 ENV["RAILS_ENV"] = "test"
 
+require "pathname"
+
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 ROOT = Pathname.new(__dir__).join("..").expand_path
 

--- a/test/unit/packwerk/cli_test.rb
+++ b/test/unit/packwerk/cli_test.rb
@@ -130,6 +130,16 @@ module Packwerk
       assert_match(/Subcommands:/, @err_out.string)
     end
 
+    test "#execute_command with version subcommand returns the version" do
+      use_template(:blank)
+      string_io = StringIO.new
+      cli = ::Packwerk::Cli.new(out: string_io)
+
+      cli.execute_command(["version"])
+
+      assert_equal "#{Packwerk::VERSION}\n", string_io.string
+    end
+
     test "#execute_command with an invalid subcommand" do
       use_template(:blank)
       @cli.execute_command(["beep boop"])


### PR DESCRIPTION
## What are you trying to accomplish?
I was debugging issues with the newest 2.3.0 release and was having difficulties knowing what version I was running.

I noticed an error (I can pull this out into another PR if needed) while running `rake`, it failed to run specs because a missing `require "pathname"`.

## What approach did you choose and why?
I choose to add a `version` command in to make it easy for anyone running `bundle exec packwerk` to get the version. It feels like best practice to always provide a `version` command or flag for a CLI application.

## What should reviewers focus on?
The output.  I'm not sure if we'd want to use 'v' prefix in-front of the version number.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes


## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
