### PR TITLE
Add missing version require

### DIFF
--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -114,6 +114,8 @@ module Packwerk
   end
 end
 
+require "packwerk/version"
+
 # Required to register the DefaultOffensesFormatter
 # We put this at the *end* of the file to specify all autoloads first
 require "packwerk/formatters/default_offenses_formatter"


### PR DESCRIPTION
## What are you trying to accomplish?

Fix `packwerk version`

## What approach did you choose and why?

The version isn't required, so the version command won't work when the gemspec isn't loaded (eg. when used in an app). #310

## What should reviewers focus on?

I assumed since we depend on bundler, when an app requires gems, the gemspecs would be evaluated. This seems to be incorrect testing in an app. We could add an autoload for it instead, but it is just a string constant.

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
