### PR TITLE
Stop deleting old deprecated_references files

### DIFF
--- a/lib/packwerk/package_todo.rb
+++ b/lib/packwerk/package_todo.rb
@@ -91,8 +91,6 @@ module Packwerk
 
     sig { void }
     def dump
-      delete_old_deprecated_references
-
       if @new_entries.empty?
         delete_if_exists
       else
@@ -118,12 +116,6 @@ module Packwerk
     end
 
     private
-
-    sig { void }
-    def delete_old_deprecated_references
-      deprecated_references_filepath = File.join(File.dirname(@filepath), "deprecated_references.yml")
-      File.delete(deprecated_references_filepath) if File.exist?(deprecated_references_filepath)
-    end
 
     sig { returns(EntriesType) }
     def prepare_entries_for_dump

--- a/test/unit/packwerk/package_todo_test.rb
+++ b/test/unit/packwerk/package_todo_test.rb
@@ -232,22 +232,6 @@ module Packwerk
       refute File.exist?(file.path)
     end
 
-    test "#dump deletes old deprecated_references if they exist" do
-      file = Tempfile.new("package_todo.yml")
-      deprecated_file = File.new(
-        File.join(File.dirname(T.must(file.path)), "deprecated_references.yml"),
-        "w",
-      )
-
-      file.write("content: true")
-      deprecated_file.write("content: true")
-
-      package_todo = PackageTodo.new(destination_package, T.must(file.path))
-      package_todo.dump
-
-      refute File.exist?(deprecated_file.path)
-    end
-
     private
 
     def destination_package


### PR DESCRIPTION
## What are you trying to accomplish?

Stop deleting old reference files for the next release.

## What approach did you choose and why?

Since 3.0 is released, this is no longer needed. Everyone should be using package_todo files now. We're removing this because mainly because it is less file IO is faster.

## What should reviewers focus on?

Does this make sense?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
