### PR TITLE
✏️ including new update-todo command in CLI help

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -125,7 +125,7 @@ module Packwerk
           init - set up packwerk
           check - run all checks
           update-todo - update package_todo.yml files
-          update-deprecations - (deprecated) update package_todo.yml files
+          update-deprecations - update package_todo.yml files (deprecated, use update-todo instead)
           validate - verify integrity of packwerk and package configuration
           help  - display help information about packwerk
       USAGE


### PR DESCRIPTION
## What are you trying to accomplish?

This PR updates the 2.3.x CLI `packwerk help` documentation to mention the new `packwerk update-todo` command and adds a deprecation note to the help text for `packwerk update-deprecations`.

## What approach did you choose and why?

If we're going to maintain 2.3.x for a bit, it's useful for devs to know about the new command via the `packwerk help` command and to know about the command deprecation (although executing the command shows the deprecation).

It's probably best to cut a new 2.3.x release with this in it... no need to merge this into `main` or include it in the 3.0.x line.

## What should reviewers focus on?

Grammar, punctuation, and spelling of the text change.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] ~I have added tests to cover my changes.~
- [x] It is safe to rollback this change.
