### PR TITLE
make package_todo comment less confusing

### DIFF
--- a/lib/packwerk/package_todo.rb
+++ b/lib/packwerk/package_todo.rb
@@ -96,8 +96,9 @@ module Packwerk
       else
         prepare_entries_for_dump
         message = <<~MESSAGE
-          # This file contains a list of dependencies that are not part of the long term plan for #{@package.name}.
-          # We should generally work to reduce this list, but not at the expense of actually getting work done.
+          # This file contains a list of dependencies that are not part of the long term plan for the
+          # '#{@package.name}' package.
+          # We should generally work to reduce this list over time.
           #
           # You can regenerate this file using the following command:
           #


### PR DESCRIPTION
## What are you trying to accomplish?
While reading https://github.com/Shopify/packwerk/pull/321, I was confused by the message as reflected in the test. It wasn't obvious that the term `buyers` was referring to a package.

When looking into a fix, I also stumbled over the following sentence, which
- makes assumptions on how the development process works in the user's organization
- uses the phrasing "actual work", which I could not more strongly disagree with - maintenance and refactoring are actual work.

## What approach did you choose and why?
- Add a few words to make obvious that the package name is indeed referring to a package
- Make the following sentence less specific. I think it still gets the gist across; we want the list to become smaller over time, but it's likely (we don't actually know that) not the top priority.

## What should reviewers focus on?
Has this now somehow become _more_ confusing?

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [ ] It is safe to rollback this change.
