### PR TITLE
Remove documentation suggesting that update-todo can be run with specificed files

### DIFF
--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -14,9 +14,8 @@ You can specify folders or packages in Packwerk commands for a shorter run time:
 
      bin/packwerk check components/your_package
 
-     bin/packwerk update-todo components/your_package
-
-_Note: You cannot specify folders or packages for `bin/packwerk validate` because the command runs for the entire application._
+_Note: You cannot specify folders or packages for `bin/packwerk validate` and `bin/packwerk update-todo` because the 
+command runs for the entire application._
 
 ![](static/packwerk_check_violation.gif)
 


### PR DESCRIPTION
## What are you trying to accomplish?

`TROUBLESHOOTING.md` still says that you can run `packwerk update-todo` with a package specified as an option. This capability was removed in by #272.

## What approach did you choose and why?

Removed it from the documentation.

## What should reviewers focus on?

Everything.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] It is safe to rollback this change.
