### PR TITLE
Remove disable sorbet line from spring command

### DIFF
--- a/lib/packwerk/spring_command.rb
+++ b/lib/packwerk/spring_command.rb
@@ -33,5 +33,3 @@ module Packwerk
 
   Spring.register_command("packwerk", SpringCommand.new)
 end
-
-require "packwerk/disable_sorbet"

--- a/test/unit/packwerk/spring_command_test.rb
+++ b/test/unit/packwerk/spring_command_test.rb
@@ -3,12 +3,9 @@
 
 require "test_helper"
 require "spring/commands"
-require "active_support/testing/isolation"
 
 module Packwerk
   class SpringCommandTest < Minitest::Test
-    include ActiveSupport::Testing::Isolation
-
     test "registers command with Spring when loaded" do
       capture_io do
         require_command
@@ -20,17 +17,6 @@ module Packwerk
       assert_equal("packwerk", command.exec_name)
       assert_equal("packwerk", command.gem_name)
       assert_equal("test", command.env(nil))
-    end
-
-    test "disables Sorbet" do
-      _stdout, stderr = capture_io do
-        require_command
-      end
-
-      assert_equal(
-        "Packwerk couldn't disable Sorbet. Please ensure it isn't being used before Packwerk is loaded.",
-        stderr.strip,
-      )
     end
 
     private


### PR DESCRIPTION
## What are you trying to accomplish?

Fix disabling sorbet when booting spring. Closes #325 

## What approach did you choose and why?

Because spring commands are required for _any_ spring boot of an application, we don't want to disable spring for non-packwerk boots (eg. running tests, running the dev server, etc.). So, we removed the require.

## What should reviewers focus on?

We still need to find a way to disable sorbet for spring loaded packwerk runs, but I think the binstub that is used in the app may need to be changed by the developer manually. We likely cannot account for this in the gem. More investigation needed.

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
