### PR TITLE
Silence sorbet warning when booting with spring

### DIFF
--- a/exe/packwerk
+++ b/exe/packwerk
@@ -1,7 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "packwerk/disable_sorbet"
+unless defined?(Spring)
+  require "packwerk/disable_sorbet"
+end
+
 require "packwerk"
 
 # Needs to be run in test environment in order to have test helper paths available in the autoload paths


### PR DESCRIPTION
## What are you trying to accomplish?

Silence warning when booting with Sorbet.

Before:
```
% bin/packwerk check
Running via Spring preloader in process 904969
Packwerk couldn't disable Sorbet. Please ensure it isn't being used before Packwerk is loaded.
📦 Packwerk is inspecting <n> files
```

After:
```
% bin/packwerk check
Running via Spring preloader in process 904969
📦 Packwerk is inspecting <n> files
```



## What approach did you choose and why?

use `defined?(Spring)`

When booting the Rails app with Spring and the app uses Sorbet, Sorbet cannot be disabled because the app has likely already invoked a typed method.

## What should reviewers focus on?

For now, this silences the error when disabling sorbet while using a spring booted server. It would be nice if we could look at disabling at at the right time in a safer way, but I have no idea how to do that yet reading spring. Maybe we need to boot our own version of a test mode spring server with typechecking disabled. See https://github.com/Shopify/packwerk/issues/327

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
