### PR TITLE
Use a single `OptionParser` instance to parse both possible options

### DIFF
--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -194,25 +194,21 @@ module Packwerk
       ignore_nested_packages = nil
       formatter = @offenses_formatter
 
-      if args.any? { |arg| arg.include?("--packages") }
-        OptionParser.new do |parser|
-          parser.on("--packages=PACKAGESLIST", Array, "package names, comma separated") do |p|
-            relative_file_paths = p
-          end
-        end.parse!(args)
-        ignore_nested_packages = true
-      else
+      OptionParser.new do |parser|
+        parser.on("--packages=PACKAGESLIST", Array, "package names, comma separated") do |p|
+          relative_file_paths = p
+          ignore_nested_packages = true
+        end
+
+        parser.on("--offenses-formatter=FORMATTER", String,
+          "identifier of offenses formatter to use") do |formatter_identifier|
+          formatter = OffensesFormatter.find(formatter_identifier)
+        end
+      end.parse!(args)
+
+      if relative_file_paths.empty?
         relative_file_paths = args
         ignore_nested_packages = false
-      end
-
-      if args.any? { |arg| arg.include?("--offenses-formatter") }
-        OptionParser.new do |parser|
-          parser.on("--offenses-formatter=FORMATTER", String,
-            "identifier of offenses formatter to use") do |formatter_identifier|
-            formatter = OffensesFormatter.find(formatter_identifier)
-          end
-        end.parse!(args)
       end
 
       files_for_processing = fetch_files_to_process(relative_file_paths, ignore_nested_packages)

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -206,10 +206,7 @@ module Packwerk
         end
       end.parse!(args)
 
-      if relative_file_paths.empty?
-        relative_file_paths = args
-        ignore_nested_packages = false
-      end
+      relative_file_paths = args if relative_file_paths.empty?
 
       files_for_processing = fetch_files_to_process(relative_file_paths, ignore_nested_packages)
 

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -191,7 +191,7 @@ module Packwerk
     sig { params(args: T::Array[String]).returns(ParseRun) }
     def parse_run(args)
       relative_file_paths = T.let([], T::Array[String])
-      ignore_nested_packages = nil
+      ignore_nested_packages = T.let(false, T::Boolean)
       formatter = @offenses_formatter
 
       OptionParser.new do |parser|

--- a/test/unit/packwerk/cli_test.rb
+++ b/test/unit/packwerk/cli_test.rb
@@ -275,5 +275,26 @@ module Packwerk
 
       remove_extensions
     end
+
+    test "#execute_command parses multiple options when passed together" do
+      use_template(:skeleton)
+      string_io = StringIO.new
+      cli = ::Packwerk::Cli.new(out: string_io)
+
+      dummy_files_for_processing = FilesForProcessing.fetch(
+        relative_file_paths: [],
+        ignore_nested_packages: false,
+        configuration: Configuration.new
+      )
+
+      FilesForProcessing.expects(:fetch).with(has_entries(
+        relative_file_paths: ["components/platform"],
+        ignore_nested_packages: true,
+      )).returns(dummy_files_for_processing)
+
+      OffensesFormatter.expects(:find).with("default").returns(Formatters::DefaultOffensesFormatter.new)
+
+      cli.execute_command(["check", "--offenses-formatter=default", "--packages=components/platform"])
+    end
   end
 end


### PR DESCRIPTION
## What are you trying to accomplish?

Currently, it is not possible to pass both `--packages` and `--offenses-formatter` options to a single call to the Packwerk CLI:

```
packwerk check --packages ./components/platform --offenses-formatter=default

/home/spin/.bundle/shopify/gems/packwerk-2.3.0/lib/packwerk/cli.rb:199:in `parse_run': invalid option: --offenses-formatter=plain (OptionParser::InvalidOption)
        from /home/spin/.bundle/shopify/gems/sorbet-runtime-0.5.10676/lib/types/private/methods/call_validation.rb:256:in `bind_call'
        from /home/spin/.bundle/shopify/gems/sorbet-runtime-0.5.10676/lib/types/private/methods/call_validation.rb:256:in `validate_call'
        from /home/spin/.bundle/shopify/gems/sorbet-runtime-0.5.10676/lib/types/private/methods/_methods.rb:275:in `block in _on_method_added'
        from /home/spin/.bundle/shopify/gems/packwerk-2.3.0/lib/packwerk/cli.rb:54:in `execute_command'
        from /home/spin/.bundle/shopify/gems/sorbet-runtime-0.5.10676/lib/types/private/methods/call_validation.rb:256:in `bind_call'
        from /home/spin/.bundle/shopify/gems/sorbet-runtime-0.5.10676/lib/types/private/methods/call_validation.rb:256:in `validate_call'
        from /home/spin/.bundle/shopify/gems/sorbet-runtime-0.5.10676/lib/types/private/methods/_methods.rb:275:in `block in _on_method_added'
        from /home/spin/.bundle/shopify/gems/packwerk-2.3.0/lib/packwerk/cli.rb:43:in `run'
```

This is because the first `OptionParser#parse!` will fail if it sees an option it does not know about.

https://github.com/Shopify/packwerk/blob/43ca76f57c5f73aa38a34f3f8d36607e3966edab/lib/packwerk/cli.rb#L197-L216

This PR is trying to fix that.

## What approach did you choose and why?

Parsing both options together in a single `OptionsParser` is, I think the way `OptionsParser` is meant to be used.

## What should reviewers focus on?

Not super happy with the stubbing in the test. Do you have suggestions on how we could improve that?

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

None.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
