### PR TITLE
Detect deleted files as stale violations

### DIFF
--- a/lib/packwerk/formatters/default_offenses_formatter.rb
+++ b/lib/packwerk/formatters/default_offenses_formatter.rb
@@ -20,9 +20,9 @@ module Packwerk
         EOS
       end
 
-      sig { override.params(offense_collection: OffenseCollection, fileset: T::Set[String]).returns(String) }
-      def show_stale_violations(offense_collection, fileset)
-        if offense_collection.stale_violations?(fileset)
+      sig { override.params(offense_collection: OffenseCollection, file_set: T::Set[String]).returns(String) }
+      def show_stale_violations(offense_collection, file_set)
+        if offense_collection.stale_violations?(file_set)
           "There were stale violations found, please run `packwerk update-todo`"
         else
           "No stale violations detected"

--- a/lib/packwerk/package_todo.rb
+++ b/lib/packwerk/package_todo.rb
@@ -15,10 +15,10 @@ module Packwerk
       T::Hash[PackageName, Entry]
     end
 
-    sig { params(package: Packwerk::Package, filepath: String).void }
-    def initialize(package, filepath)
+    sig { params(package: Packwerk::Package, path: String).void }
+    def initialize(package, path)
       @package = package
-      @filepath = filepath
+      @path = path
       @new_entries = T.let({}, Entries)
       @old_entries = T.let(nil, T.nilable(Entries))
     end
@@ -86,7 +86,7 @@ module Packwerk
           #
           # bin/packwerk update-todo
         MESSAGE
-        File.open(@filepath, "w") do |f|
+        File.open(@path, "w") do |f|
           f.write(message)
           f.write(new_entries.to_yaml)
         end
@@ -95,7 +95,7 @@ module Packwerk
 
     sig { void }
     def delete_if_exists
-      File.delete(@filepath) if File.exist?(@filepath)
+      File.delete(@path) if File.exist?(@path)
     end
 
     private
@@ -164,16 +164,12 @@ module Packwerk
 
     sig { returns(Entries) }
     def old_entries
-      @old_entries ||= if File.exist?(@filepath)
-        load_yaml(@filepath)
-      else
-        {}
-      end
+      @old_entries ||= load_yaml_file(@path)
     end
 
-    sig { params(filepath: String).returns(Entries) }
-    def load_yaml(filepath)
-      YAML.load_file(filepath) || {}
+    sig { params(path: String).returns(Entries) }
+    def load_yaml_file(path)
+      File.exist?(path) && YAML.load_file(path) || {}
     rescue Psych::Exception
       {}
     end

--- a/test/fixtures/package_todo.yml
+++ b/test/fixtures/package_todo.yml
@@ -5,4 +5,3 @@ buyers:
     - some_checker_type
     files:
     - orders/app/jobs/orders/sweepers/purge_old_document_rows_task.rb
-    - orders/app/models/orders/services/adjustment_engine.rb

--- a/test/unit/packwerk/offense_collection_test.rb
+++ b/test/unit/packwerk/offense_collection_test.rb
@@ -27,19 +27,23 @@ module Packwerk
 
     test "#stale_violations? returns true if there are stale violations" do
       @offense_collection.add_offense(@offense)
+      file_set = Set.new
 
       Packwerk::PackageTodo.any_instance
         .expects(:stale_violations?)
+        .with(file_set)
         .returns(true)
 
-      assert @offense_collection.stale_violations?(Set.new)
+      assert @offense_collection.stale_violations?(file_set)
     end
 
     test "#stale_violations? returns false if no stale violations" do
       @offense_collection.add_offense(@offense)
+      file_set = Set.new
 
       Packwerk::PackageTodo.any_instance
         .expects(:stale_violations?)
+        .with(file_set)
         .returns(false)
 
       refute @offense_collection.stale_violations?(Set.new)

--- a/test/unit/packwerk/package_todo_test.rb
+++ b/test/unit/packwerk/package_todo_test.rb
@@ -123,6 +123,15 @@ module Packwerk
       )
     end
 
+    test "#stale_violations? returns true when deleted files are present" do
+      package = Package.new(name: "buyers", config: { "enforce_dependencies" => true })
+
+      package_todo = PackageTodo.new(package, "test/fixtures/package_todo.yml")
+      assert package_todo.stale_violations?(
+        Set.new(["orders/app/jobs/orders/sweepers/purge_old_document_rows_task.rb"])
+      )
+    end
+
     test "#listed? returns false if constant is not violated" do
       reference = build_reference(destination_package: destination_package)
       package_todo = PackageTodo.new(destination_package, "test/fixtures/package_todo.yml")

--- a/test/unit/packwerk/parse_run_test.rb
+++ b/test/unit/packwerk/parse_run_test.rb
@@ -328,11 +328,11 @@ module Packwerk
 
       expected_message = <<~EOS
         No offenses detected
-        No stale violations detected
+        There were stale violations found, please run `packwerk update-todo`
       EOS
       assert_equal expected_message, result.message
 
-      assert result.status
+      refute result.status
     end
 
     test "#check lists out violations of strict mode" do
@@ -435,7 +435,7 @@ module Packwerk
 
         1 offense detected
 
-        No stale violations detected
+        There were stale violations found, please run `packwerk update-todo`
       EOS
 
       assert_equal expected_message, result.message


### PR DESCRIPTION
## What are you trying to accomplish?

Closes #298 

Detect files deleted in old TODO entries as stale. Also some refactorings along the way.

## What approach did you choose and why?

I took the new and old entries and mapped their files to see the paths that exist in the old TODO, but not the new TODO and added them to the stale check list of files. After implementing this, stale violation checks mean a lot of things, so I think this is a new feature and not a bug.

## What should reviewers focus on?

Does this make sense?

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
