### PR TITLE
Rename `@package_todo` Hash ivar to `@package_todos`

### DIFF
--- a/lib/packwerk/offense_collection.rb
+++ b/lib/packwerk/offense_collection.rb
@@ -11,12 +11,12 @@ module Packwerk
     sig do
       params(
         root_path: String,
-        package_todo: T::Hash[Packwerk::Package, Packwerk::PackageTodo]
+        package_todos: T::Hash[Packwerk::Package, Packwerk::PackageTodo]
       ).void
     end
-    def initialize(root_path, package_todo = {})
+    def initialize(root_path, package_todos = {})
       @root_path = root_path
-      @package_todo = T.let(package_todo, T::Hash[Packwerk::Package, Packwerk::PackageTodo])
+      @package_todos = T.let(package_todos, T::Hash[Packwerk::Package, Packwerk::PackageTodo])
       @new_violations = T.let([], T::Array[Packwerk::ReferenceOffense])
       @strict_mode_violations = T.let([], T::Array[Packwerk::ReferenceOffense])
       @errors = T.let([], T::Array[Packwerk::Offense])
@@ -60,7 +60,7 @@ module Packwerk
 
     sig { params(for_files: T::Set[String]).returns(T::Boolean) }
     def stale_violations?(for_files)
-      @package_todo.values.any? do |package_todo|
+      @package_todos.values.any? do |package_todo|
         package_todo.stale_violations?(for_files)
       end
     end
@@ -92,7 +92,7 @@ module Packwerk
 
     sig { params(package_set: Packwerk::PackageSet).void }
     def cleanup_extra_package_todo_files(package_set)
-      packages_without_todos = (package_set.packages.values - @package_todo.keys)
+      packages_without_todos = (package_set.packages.values - @package_todos.keys)
 
       packages_without_todos.each do |package|
         Packwerk::PackageTodo.new(
@@ -104,12 +104,12 @@ module Packwerk
 
     sig { void }
     def dump_package_todo_files
-      @package_todo.each_value(&:dump)
+      @package_todos.each_value(&:dump)
     end
 
     sig { params(package: Packwerk::Package).returns(Packwerk::PackageTodo) }
     def package_todo_for(package)
-      @package_todo[package] ||= Packwerk::PackageTodo.new(
+      @package_todos[package] ||= Packwerk::PackageTodo.new(
         package,
         package_todo_file_for(package),
       )


### PR DESCRIPTION
## What are you trying to accomplish?

Just renaming an instance variable for it to make a bit more sense.

## What approach did you choose and why?

`@package_todos` is a hash which keys are `Package` instances and values are `PackageTodo` instances.
As `@package_todos.values` are multiple `PackageTodo` instances, it makes sense for the instance variable to have a plural name.
The most telling was this one line:

```rb
@package_todo.values.any? do |package_todo|
```

## What should reviewers focus on?

🤷🏻‍♂️

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

<!--
### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.
-->

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
