### PR TITLE
Rescue StandardError when processing file

### DIFF
--- a/lib/packwerk/file_processor.rb
+++ b/lib/packwerk/file_processor.rb
@@ -53,6 +53,17 @@ module Packwerk
       ProcessedFile.new(unresolved_references: unresolved_references)
     rescue Parsers::ParseError => e
       ProcessedFile.new(offenses: [e.result])
+    rescue StandardError => e
+      message = <<~MSG
+        Packwerk encountered an internal error.
+        For now, you can add this file to `packwerk.yml` `exclude` list.
+        Please file an issue and include this error message and stacktrace:
+
+        #{e.message} #{e.backtrace}"
+      MSG
+
+      offense = Parsers::ParseResult.new(file: relative_file, message: message)
+      ProcessedFile.new(offenses: [offense])
     end
 
     private

--- a/test/unit/packwerk/file_processor_test.rb
+++ b/test/unit/packwerk/file_processor_test.rb
@@ -109,9 +109,14 @@ module Packwerk
         )
       )
 
-      tempfile(name: "foo", content: "def error") do |file_path|
+      processed_file = tempfile(name: "foo", content: "def error") do |file_path|
         file_processor.call(file_path)
       end
+
+      assert_equal 0, processed_file.unresolved_references.count
+      offenses = processed_file.offenses
+      assert_equal 1, offenses.length
+      assert_equal "Syntax error: unexpected token $end", offenses.first.message
     end
 
     test "#call with a path that can't be parsed outputs error message" do


### PR DESCRIPTION
## What are you trying to accomplish?
This should help https://github.com/Shopify/packwerk/issues/299.

While it doesn't solve the parsing error, it should improve debug reports by printing out which files are erroring with the error message.

Right now, when there is a `NodeHelpers::TypeError` OR a Sorbet `TypeError` (the test case I added reproduces this by creating a false positive AR association), Packwerk just crashes with a messy message:

```
$ bin/packwerk check
Running via Spring preloader in process 8043
📦 Packwerk is inspecting 100 files
......................................................................................................................................................................................................................................................................................./Users/alex.evanczuk/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10773/lib/types/_types.rb:218:in `must': Passed `nil` into T.must (TypeError)
        from /Users/alex.evanczuk/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/packwerk-816c080d296e/lib/packwerk/association_inspector.rb:67:in `association_name'
        from /Users/alex.evanczuk/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10773/lib/types/private/methods/call_validation_2_7.rb:703:in `bind_call'
        from /Users/alex.evanczuk/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10773/lib/types/private/methods/call_validation_2_7.rb:703:in `block in create_validator_method_medium1'
        from /Users/alex.evanczuk/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/packwerk-816c080d296e/lib/packwerk/association_inspector.rb:38:in `constant_name_from_node'
        from /Users/alex.evanczuk/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10773/lib/types/private/methods/call_validation.rb:153:in `bind_call'
        from /Users/alex.evanczuk/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10773/lib/types/private/methods/call_validation.rb:153:in `validate_call_skip_block_type'
        from /Users/alex.evanczuk/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10773/lib/types/private/methods/call_validation.
```

It's not clear what file is causing `packwerk` to break. It might be better to list out the files that have issues to exclude them, fix the issues, or better report the issue to packwerk maintainers.


## What approach did you choose and why?
I decided to rescue all of `StandardError`, because there are a number of possibly unexpected things that can cause packwerk parsing to break. In theory we could target more specific errors, but then we wouldn't be catching all possible errors and ambiguous errors continue to be reported ambiguously.

## What should reviewers focus on?
I wasn't able to reproduce the specific case in the issue – any thoughts on what is going on there?
Let me know if I should approach this a different way.

## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
