### PR TITLE
Add command line option to toggle parallel execution

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -188,7 +188,7 @@ You can also specify packages for a shorter run time. When checking against pack
 
     bin/packwerk check --packages=components/your_package,components/your_other_package
 
-You cal also specify enable or disable parallel processing by a command line option that overrides the configuration file.
+Using the following command line option you can also enable or disable parallel processing. It is enabled by default.
 
     bin/packwerk check --[no-]-parallel
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -188,6 +188,10 @@ You can also specify packages for a shorter run time. When checking against pack
 
     bin/packwerk check --packages=components/your_package,components/your_other_package
 
+You cal also specify enable or disable parallel processing by a command line option that overrides the configuration file.
+
+    bin/packwerk check --[no-]-parallel
+
 ![](static/packwerk_check.gif)
 
 In order to keep the package system valid at each version of the application, we recommend running `bin/packwerk check` in your CI pipeline.

--- a/lib/packwerk/cli.rb
+++ b/lib/packwerk/cli.rb
@@ -207,6 +207,10 @@ module Packwerk
           "identifier of offenses formatter to use") do |formatter_identifier|
           formatter = OffensesFormatter.find(formatter_identifier)
         end
+
+        parser.on("--[no-]parallel", TrueClass, "parallel processing") do |parallel|
+          @configuration.parallel = parallel
+        end
       end.parse!(args)
 
       relative_file_paths = args if relative_file_paths.empty?

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -60,6 +60,9 @@ module Packwerk
     sig { returns(Pathname) }
     attr_reader(:cache_directory)
 
+    sig { returns(T::Boolean) }
+    attr_accessor(:parallel)
+
     sig do
       params(
         configs: T::Hash[String, T.untyped],

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -60,8 +60,8 @@ module Packwerk
     sig { returns(Pathname) }
     attr_reader(:cache_directory)
 
-    sig { returns(T::Boolean) }
-    attr_accessor(:parallel)
+    sig { params(parallel: T::Boolean).returns(T::Boolean) }
+    attr_writer(:parallel)
 
     sig do
       params(

--- a/test/unit/packwerk/cli_test.rb
+++ b/test/unit/packwerk/cli_test.rb
@@ -297,16 +297,20 @@ module Packwerk
       cli.execute_command(["check", "--offenses-formatter=default", "--packages=components/platform"])
     end
 
-    test "#parse_run (private) parses parallel option and overrides the configuration" do
+    test "#execute_command parses parallel option and overrides the configuration" do
+      use_template(:skeleton)
+
       config = Configuration.new({ "parallel" => false })
+      assert_equal false, config.parallel?
       cli = ::Packwerk::Cli.new(configuration: config)
-      parse_run = cli.send(:parse_run, ["check", "--parallel"])
-      assert_equal true, parse_run.instance_variable_get(:@configuration).parallel?
+      cli.execute_command(["check", "--parallel"])
+      assert_equal true, config.parallel?
 
       config = Configuration.new({ "parallel" => true })
+      assert_equal true, config.parallel?
       cli = ::Packwerk::Cli.new(configuration: config)
-      parse_run = cli.send(:parse_run, ["check", "--no-parallel"])
-      assert_equal false, parse_run.instance_variable_get(:@configuration).parallel?
+      cli.execute_command(["check", "--no-parallel"])
+      assert_equal false, config.parallel?
     end
   end
 end

--- a/test/unit/packwerk/cli_test.rb
+++ b/test/unit/packwerk/cli_test.rb
@@ -296,5 +296,17 @@ module Packwerk
 
       cli.execute_command(["check", "--offenses-formatter=default", "--packages=components/platform"])
     end
+
+    test "#parse_run (private) parses parallel option and overrides the configuration" do
+      config = Configuration.new({ "parallel" => false })
+      cli = ::Packwerk::Cli.new(configuration: config)
+      parse_run = cli.send(:parse_run, ["check", "--parallel"])
+      assert_equal true, parse_run.instance_variable_get(:@configuration).parallel?
+
+      config = Configuration.new({ "parallel" => true })
+      cli = ::Packwerk::Cli.new(configuration: config)
+      parse_run = cli.send(:parse_run, ["check", "--no-parallel"])
+      assert_equal false, parse_run.instance_variable_get(:@configuration).parallel?
+    end
   end
 end


### PR DESCRIPTION
## What are you trying to accomplish?

Allows parallel configuration to be overridden by command line options.
This is useful if you want to switch parallel options between different execution environments, such as local and CI environments.

## What approach did you choose and why?

I added the --parallel / --no-parallel option to the process of parsing command-line options by OptionParse.

## What should reviewers focus on?

- Changes adding an attr_ accessor to `@parallel` in the Configuration class.
- ~~That the test is against private methods.~~ (fixed)

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
