### PR TITLE
Improve new test for the `--[no-]parallel` CLI option

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -190,7 +190,7 @@ You can also specify packages for a shorter run time. When checking against pack
 
 Using the following command line option you can also enable or disable parallel processing. It is enabled by default.
 
-    bin/packwerk check --[no-]-parallel
+    bin/packwerk check --[no-]parallel
 
 ![](static/packwerk_check.gif)
 

--- a/test/unit/packwerk/cli_test.rb
+++ b/test/unit/packwerk/cli_test.rb
@@ -301,16 +301,16 @@ module Packwerk
       use_template(:skeleton)
 
       config = Configuration.new({ "parallel" => false })
-      assert_equal false, config.parallel?
-      cli = ::Packwerk::Cli.new(configuration: config)
+      refute config.parallel?
+      cli = ::Packwerk::Cli.new(configuration: config, out: StringIO.new)
       cli.execute_command(["check", "--parallel"])
-      assert_equal true, config.parallel?
+      assert config.parallel?
 
       config = Configuration.new({ "parallel" => true })
-      assert_equal true, config.parallel?
-      cli = ::Packwerk::Cli.new(configuration: config)
+      assert config.parallel?
+      cli = ::Packwerk::Cli.new(configuration: config, out: StringIO.new)
       cli.execute_command(["check", "--no-parallel"])
-      assert_equal false, config.parallel?
+      refute config.parallel?
     end
   end
 end


### PR DESCRIPTION
## What are you trying to accomplish?

Just minor improvements to a test case that was recently added in #349.

## What approach did you choose and why?

1. `assert` and `refute` are terser than `assert_equal true, ` and `assert_equal false, `.
2. Because the test was not passing a `StringIO` out argument to `CLI`, it was polluting the test run output:

```
Run options: --seed 48569

............................................📦 Packwerk is inspecting 14 files
..............
📦 Finished in 0.11 seconds

No offenses detected
No stale violations detected
📦 Packwerk is inspecting 14 files
..............
📦 Finished in 0.02 seconds

No offenses detected
No stale violations detected
...........................................................................................................................................................................................

Finished in 1.846565s, 125.0972 runs/s, 326.0108 assertions/s.
231 runs, 602 assertions, 0 failures, 0 errors, 0 skips
```

## What should reviewers focus on?


## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

<!--
### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.
-->

## Checklist

- [ ] ~~I have updated the documentation accordingly.~~
- [ ] ~~I have added tests to cover my changes.~~
- [x] It is safe to rollback this change.
