### PR TITLE
Add to ecosystem section to support non-Rails, non-Zeitwerk apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Various third parties have built tooling on top of packwerk. Here's a selection 
 - https://github.com/rubyatscale/packs-rails sets up Rails autoloading, as well as `rspec` and `FactoryBot` integration, for packages arranged in a flat list. packs-rails is quite convenient, but for autoloading we recommend to use `Rails::Engine`s instead.
 - https://github.com/rubyatscale/danger-packwerk integrates packwerk with [danger.systems](https://danger.systems) to provide packwerk feedback as Github inline PR comments
 - https://github.com/rubyatscale/packwerk-extensions contains extensions for packwerk, including a checker for packwerk that allows you to enforce public API boundaries. This was originally extracted from `packwerk` itself.
+- https://github.com/alexevanczuk/packs is a Rust implementation of packwerk that has experimental support for non-Rails, non-Zeitwerk applications.
 
 ## Development
 


### PR DESCRIPTION
I've been working on https://github.com/alexevanczuk/packs, which is a Rust-implementation of `packwerk`.

This implementation supports non-Rails and non-Zeitwerk apps, so I wanted to add a pointer to it for folks wishing they could use `packwerk` but are unable to currently due to compatibility issues.

