### PR TITLE
strict_for_new mode: fail check only for violations unlisted in package_todo.yml

### DIFF
--- a/lib/packwerk/checker.rb
+++ b/lib/packwerk/checker.rb
@@ -51,8 +51,8 @@ module Packwerk
     sig { abstract.returns(String) }
     def violation_type; end
 
-    sig { abstract.params(listed_offense: ReferenceOffense).returns(T::Boolean) }
-    def strict_mode_violation?(listed_offense); end
+    sig { abstract.params(offense: ReferenceOffense, already_listed: T::Boolean).returns(T::Boolean) }
+    def strict_mode_violation?(offense, already_listed:); end
 
     sig { abstract.params(reference: Reference).returns(T::Boolean) }
     def invalid_reference?(reference); end

--- a/lib/packwerk/offense_collection.rb
+++ b/lib/packwerk/offense_collection.rb
@@ -59,7 +59,7 @@ module Packwerk
 
       new_violations << offense unless already_listed
 
-      if strict_mode_violation?(offense)
+      if strict_mode_violation?(offense, already_listed)
         add_to_package_todo(offense) if already_listed
         strict_mode_violations << offense
       else
@@ -104,10 +104,10 @@ module Packwerk
         offense.violation_type)
     end
 
-    sig { params(offense: ReferenceOffense).returns(T::Boolean) }
-    def strict_mode_violation?(offense)
+    sig { params(offense: ReferenceOffense, already_listed: T::Boolean).returns(T::Boolean) }
+    def strict_mode_violation?(offense, already_listed)
       checker = Checker.find(offense.violation_type)
-      checker.strict_mode_violation?(offense)
+      checker.strict_mode_violation?(offense, already_listed: already_listed)
     end
 
     sig { params(package_set: Packwerk::PackageSet).void }

--- a/lib/packwerk/package.rb
+++ b/lib/packwerk/package.rb
@@ -30,7 +30,7 @@ module Packwerk
 
     sig { returns(T::Boolean) }
     def enforce_dependencies?
-      [true, "strict"].include?(@config["enforce_dependencies"])
+      [true, "strict", "strict_for_new"].include?(@config["enforce_dependencies"])
     end
 
     sig { params(package: Package).returns(T::Boolean) }

--- a/lib/packwerk/reference_checking/checkers/dependency_checker.rb
+++ b/lib/packwerk/reference_checking/checkers/dependency_checker.rb
@@ -47,10 +47,20 @@ module Packwerk
           EOS
         end
 
-        sig { override.params(listed_offense: ReferenceOffense).returns(T::Boolean) }
-        def strict_mode_violation?(listed_offense)
-          referencing_package = listed_offense.reference.package
-          referencing_package.config["enforce_dependencies"] == "strict"
+        sig { override.params(offense: ReferenceOffense, already_listed: T::Boolean).returns(T::Boolean) }
+        def strict_mode_violation?(offense, already_listed:)
+          referencing_package = offense.reference.package
+
+          case referencing_package.config["enforce_dependencies"]
+          when nil, false, true
+            false
+          when "strict"
+            true
+          when "strict_for_new"
+            !already_listed
+          else
+            raise "Unknown value for 'enforce_dependencies': #{referencing_package.config["enforce_dependencies"]}"
+          end
         end
 
         private

--- a/lib/packwerk/validators/dependency_validator.rb
+++ b/lib/packwerk/validators/dependency_validator.rb
@@ -34,7 +34,7 @@ module Packwerk
       def check_package_manifest_syntax(configuration)
         errors = []
 
-        valid_settings = [true, false, "strict"]
+        valid_settings = [true, false, "strict", "strict_for_new"]
         package_manifests_settings_for(configuration, "enforce_dependencies").each do |config, setting|
           next if setting.nil?
 

--- a/test/unit/packwerk/dependency_checker_test.rb
+++ b/test/unit/packwerk/dependency_checker_test.rb
@@ -34,6 +34,51 @@ module Packwerk
       refute checker.invalid_reference?(reference)
     end
 
+    test "does not report any violation as strict in non strict mode" do
+      source_package = Package.new(name: "components/sales", config: { "enforce_dependencies" => true })
+      checker = dependency_checker
+
+      offense = Packwerk::ReferenceOffense.new(
+        reference: build_reference(source_package: source_package),
+        violation_type: ReferenceChecking::Checkers::DependencyChecker::VIOLATION_TYPE,
+        message: "some message"
+      )
+
+      assert checker.invalid_reference?(offense.reference)
+      refute checker.strict_mode_violation?(offense, already_listed: true)
+      refute checker.strict_mode_violation?(offense, already_listed: false)
+    end
+
+    test "reports any violation as strict in strict mode" do
+      source_package = Package.new(name: "components/sales", config: { "enforce_dependencies" => "strict" })
+      checker = dependency_checker
+
+      offense = Packwerk::ReferenceOffense.new(
+        reference: build_reference(source_package: source_package),
+        violation_type: ReferenceChecking::Checkers::DependencyChecker::VIOLATION_TYPE,
+        message: "some message"
+      )
+
+      assert checker.invalid_reference?(offense.reference)
+      assert checker.strict_mode_violation?(offense, already_listed: true)
+      assert checker.strict_mode_violation?(offense, already_listed: false)
+    end
+
+    test "only reports unlisted violations as strict in strict_for_new mode" do
+      source_package = Package.new(name: "components/sales", config: { "enforce_dependencies" => "strict_for_new" })
+      checker = dependency_checker
+
+      offense = Packwerk::ReferenceOffense.new(
+        reference: build_reference(source_package: source_package),
+        violation_type: ReferenceChecking::Checkers::DependencyChecker::VIOLATION_TYPE,
+        message: "some message"
+      )
+
+      assert checker.invalid_reference?(offense.reference)
+      refute checker.strict_mode_violation?(offense, already_listed: true)
+      assert checker.strict_mode_violation?(offense, already_listed: false)
+    end
+
     private
 
     def dependency_checker

--- a/test/unit/packwerk/dependency_validator_test.rb
+++ b/test/unit/packwerk/dependency_validator_test.rb
@@ -67,6 +67,14 @@ module Packwerk
       assert result.ok?
     end
 
+    test "returns success when enforce_dependencies is set to strict_for_new in the package.yml file" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("components/sales/package.yml", { "enforce_dependencies" => "strict_for_new" })
+
+      result = dependency_validator.call(package_set, config)
+      assert result.ok?
+    end
+
     private
 
     def dependency_validator

--- a/test/unit/packwerk/reference_checking/reference_checker_test.rb
+++ b/test/unit/packwerk/reference_checking/reference_checker_test.rb
@@ -29,7 +29,7 @@ module Packwerk
           @message
         end
 
-        def strict_mode_violation?(_listed_offense)
+        def strict_mode_violation?(_offense, already_listed:)
           false
         end
       end


### PR DESCRIPTION
## What are you trying to accomplish?

Following https://github.com/Shopify/packwerk/pull/367, this PR introduces a new mode for the dependency checker: 'strict_for_new'.
With this mode, only new violations, unlisted in the package_todo.yml file will result in an error when using the 'check' command.

## What approach did you choose and why?

Let the checker know whether an offense was listed or not in the package_todo.yml to let it decide whether it should be a strict violation.

## What should reviewers focus on?


## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [x] Breaking change (fix or feature that would cause existing functionality to change)

While the change is not breaking for this gem alone, it is a breaking change for the API that's used by packwerk extensions. So a major version bump will be required.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change. (any 'strict_for_new' configuration will need to be rolled back as well)
