### PR TITLE
remove broken link from USAGE.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -20,7 +20,6 @@
   * [Understanding how to respond to new violations](#understanding-how-to-respond-to-new-violations)
 * [Recording existing violations](#recording-existing-violations)
   * [Understanding the package todo file](#understanding-the-package-todo-file)
-  * [Understanding the list of deprecated references](#understanding-the-list-of-deprecated-references)
 * [Loading extensions](#loading-extensions)
 
 ## What problem does Packwerk solve?


### PR DESCRIPTION
deprecated_references.yml file was renamed to package_todo.yml, the link to the deprecated references section in the USAGE.md file was broken and is removed in this PR.

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
