### PR TITLE
Add assocaitions_exclude to exclude files from association inspection

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -77,6 +77,7 @@ Packwerk reads from the `packwerk.yml` configuration file in the root directory.
 |----------------------|-------------------------------------------|--------------|
 | include              | **/*.{rb,rake,erb}                        | list of patterns for folder paths to include |
 | exclude              | {bin,node_modules,script,tmp,vendor}/**/* | list of patterns for folder paths to exclude |
+| associations_exclude | N/A                                       | list of patterns for folder paths to exclude from association inspection |
 | package_paths        | **/                                       | a single pattern or a list of patterns to find package configuration files, see: [Defining packages](#Defining-packages) |
 | custom_associations  | N/A                                       | list of custom associations, if any |
 | parallel             | true                                      | when true, fork code parsing out to subprocesses |

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -54,6 +54,9 @@ module Packwerk
     sig { returns(T::Array[Symbol]) }
     attr_reader(:custom_associations)
 
+    sig { returns(T::Array[String]) }
+    attr_reader(:associations_exclude)
+
     sig { returns(T.nilable(String)) }
     attr_reader(:config_path)
 
@@ -76,6 +79,7 @@ module Packwerk
       @root_path = T.let(File.expand_path(root), String)
       @package_paths = T.let(configs["package_paths"] || "**/", T.any(String, T::Array[String]))
       @custom_associations = T.let((configs["custom_associations"] || []).map(&:to_sym), T::Array[Symbol])
+      @associations_exclude = T.let(configs["associations_exclude"] || [], T::Array[String])
       @parallel = T.let(configs.key?("parallel") ? configs["parallel"] : true, T::Boolean)
       @cache_enabled = T.let(configs.key?("cache") ? configs["cache"] : false, T::Boolean)
       @cache_directory = T.let(Pathname.new(configs["cache_directory"] || "tmp/cache/packwerk"), Pathname)

--- a/lib/packwerk/const_node_inspector.rb
+++ b/lib/packwerk/const_node_inspector.rb
@@ -9,10 +9,10 @@ module Packwerk
 
     sig do
       override
-        .params(node: AST::Node, ancestors: T::Array[AST::Node])
+        .params(node: AST::Node, ancestors: T::Array[AST::Node], relative_file: String)
         .returns(T.nilable(String))
     end
-    def constant_name_from_node(node, ancestors:)
+    def constant_name_from_node(node, ancestors:, relative_file:)
       return nil unless NodeHelpers.constant?(node)
 
       parent = ancestors.first

--- a/lib/packwerk/constant_name_inspector.rb
+++ b/lib/packwerk/constant_name_inspector.rb
@@ -13,10 +13,10 @@ module Packwerk
 
     sig do
       abstract
-        .params(node: ::AST::Node, ancestors: T::Array[::AST::Node])
+        .params(node: ::AST::Node, ancestors: T::Array[::AST::Node], relative_file: String)
         .returns(T.nilable(String))
     end
-    def constant_name_from_node(node, ancestors:); end
+    def constant_name_from_node(node, ancestors:, relative_file:); end
   end
 
   private_constant :ConstantNameInspector

--- a/lib/packwerk/reference_extractor.rb
+++ b/lib/packwerk/reference_extractor.rb
@@ -80,7 +80,11 @@ module Packwerk
       constant_name = T.let(nil, T.nilable(String))
 
       @constant_name_inspectors.each do |inspector|
-        constant_name = inspector.constant_name_from_node(node, ancestors: ancestors)
+        constant_name = inspector.constant_name_from_node(
+          node,
+          ancestors: ancestors,
+          relative_file: relative_file
+        )
 
         break if constant_name
       end

--- a/test/unit/packwerk/association_inspector_test.rb
+++ b/test/unit/packwerk/association_inspector_test.rb
@@ -14,49 +14,62 @@ module Packwerk
       node = parse("has_lots :order")
       inspector = AssociationInspector.new(inflector: @inflector, custom_associations: [:has_lots])
 
-      assert_equal "Order", inspector.constant_name_from_node(node, ancestors: [])
+      assert_equal "Order", inspector.constant_name_from_node(node, ancestors: [], relative_file: "")
     end
 
     test "finds target constant for simple association" do
       node = parse("has_one :order")
       inspector = AssociationInspector.new(inflector: @inflector)
 
-      assert_equal "Order", inspector.constant_name_from_node(node, ancestors: [])
+      assert_equal "Order", inspector.constant_name_from_node(node, ancestors: [], relative_file: "")
     end
 
     test "finds target constant for association that pluralizes" do
       node = parse("has_many :orders")
       inspector = AssociationInspector.new(inflector: @inflector)
 
-      assert_equal "Order", inspector.constant_name_from_node(node, ancestors: [])
+      assert_equal "Order", inspector.constant_name_from_node(node, ancestors: [], relative_file: "")
     end
 
     test "finds target constant for association if explicitly specified" do
       node = parse("has_one :cool_order, { class_name: 'Order' }")
       inspector = AssociationInspector.new(inflector: @inflector)
 
-      assert_equal "Order", inspector.constant_name_from_node(node, ancestors: [])
+      assert_equal "Order", inspector.constant_name_from_node(node, ancestors: [], relative_file: "")
     end
 
     test "rejects method calls that are not associations" do
       node = parse('puts "Hello World"')
       inspector = AssociationInspector.new(inflector: @inflector)
 
-      assert_nil inspector.constant_name_from_node(node, ancestors: [])
+      assert_nil inspector.constant_name_from_node(node, ancestors: [], relative_file: "")
     end
 
     test "gives up on metaprogrammed associations" do
       node = parse("has_one association_name")
       inspector = AssociationInspector.new(inflector: @inflector)
 
-      assert_nil inspector.constant_name_from_node(node, ancestors: [])
+      assert_nil inspector.constant_name_from_node(node, ancestors: [], relative_file: "")
     end
 
     test "gives up on dynamic class name" do
       node = parse("has_one :order, class_name: Order.name")
       inspector = AssociationInspector.new(inflector: @inflector)
 
-      assert_nil inspector.constant_name_from_node(node, ancestors: [])
+      assert_nil inspector.constant_name_from_node(node, ancestors: [], relative_file: "")
+    end
+
+    test "gives up on excluded file node" do
+      node = parse("has_one :order")
+      inspector = AssociationInspector.new(
+        inflector: @inflector, excluded_files: Set["app/serializers/my_serializer.rb"]
+      )
+
+      assert_nil inspector.constant_name_from_node(
+        node,
+        ancestors: [],
+        relative_file: "app/serializers/my_serializer.rb",
+      )
     end
 
     private

--- a/test/unit/packwerk/const_node_inspector_test.rb
+++ b/test/unit/packwerk/const_node_inspector_test.rb
@@ -13,7 +13,7 @@ module Packwerk
     test "#constant_name_from_node should ignore any non-const nodes" do
       node = parse("a = 1 + 1")
 
-      constant_name = @inspector.constant_name_from_node(node, ancestors: [])
+      constant_name = @inspector.constant_name_from_node(node, ancestors: [], relative_file: "")
 
       assert_nil constant_name
     end
@@ -21,7 +21,7 @@ module Packwerk
     test "#constant_name_from_node should return correct name for const node" do
       node = parse("Order")
 
-      constant_name = @inspector.constant_name_from_node(node, ancestors: [])
+      constant_name = @inspector.constant_name_from_node(node, ancestors: [], relative_file: "")
 
       assert_equal "Order", constant_name
     end
@@ -29,7 +29,7 @@ module Packwerk
     test "#constant_name_from_node should return correct name for fully-qualified const node" do
       node = parse("::Order")
 
-      constant_name = @inspector.constant_name_from_node(node, ancestors: [])
+      constant_name = @inspector.constant_name_from_node(node, ancestors: [], relative_file: "")
 
       assert_equal "::Order", constant_name
     end
@@ -37,7 +37,7 @@ module Packwerk
     test "#constant_name_from_node should return correct name for compact const node" do
       node = parse("Sales::Order")
 
-      constant_name = @inspector.constant_name_from_node(node, ancestors: [])
+      constant_name = @inspector.constant_name_from_node(node, ancestors: [], relative_file: "")
 
       assert_equal "Sales::Order", constant_name
     end
@@ -46,7 +46,7 @@ module Packwerk
       parent = parse("class Order; end")
       node = NodeHelpers.each_child(parent).entries[0]
 
-      constant_name = @inspector.constant_name_from_node(node, ancestors: [parent])
+      constant_name = @inspector.constant_name_from_node(node, ancestors: [parent], relative_file: "")
 
       assert_equal "::Order", constant_name
     end
@@ -58,7 +58,7 @@ module Packwerk
       ) # module node; second child is the body of the module
       node = NodeHelpers.each_child(parent).entries[0] # class node; first child is constant
 
-      constant_name = @inspector.constant_name_from_node(node, ancestors: [parent, grandparent])
+      constant_name = @inspector.constant_name_from_node(node, ancestors: [parent, grandparent], relative_file: "")
 
       assert_equal "::Foo::Bar::Sales::Order", constant_name
     end
@@ -68,7 +68,7 @@ module Packwerk
       parent = T.must(NodeHelpers.each_child(grandparent).entries[1]) # setup do self.class::HEADERS end
       node = NodeHelpers.each_child(parent).entries[2] # self.class::HEADERS
 
-      constant_name = @inspector.constant_name_from_node(node, ancestors: [parent, grandparent])
+      constant_name = @inspector.constant_name_from_node(node, ancestors: [parent, grandparent], relative_file: "")
 
       assert_nil constant_name
     end

--- a/test/unit/packwerk/reference_extractor_test.rb
+++ b/test/unit/packwerk/reference_extractor_test.rb
@@ -211,6 +211,21 @@ module Packwerk
       assert_equal "::Order", reference.constant.name
     end
 
+    test "constant name inspector without file name kwarg is deprecated but works" do
+      _, error_output = capture_io do
+        process(
+          ":orders",
+          "components/timeline/app/models/entry.rb",
+          [DeprecatedInspector.new],
+        )
+      end
+
+      assert_equal(<<~MSG.squish, error_output.chomp)
+        Packwerk::ReferenceExtractorTest::DeprecatedInspector#reference_from_node without
+        a relative_file: keyword argument is deprecated and will be required in Packwerk 3.1.1.
+      MSG
+    end
+
     private
 
     class DummyAssociationInspector
@@ -232,6 +247,14 @@ module Packwerk
         end
 
         @reference_name
+      end
+    end
+
+    class DeprecatedInspector
+      T.unsafe(self).include(ConstantNameInspector)
+
+      def constant_name_from_node(node, ancestors:)
+        "Something"
       end
     end
 

--- a/test/unit/packwerk/reference_extractor_test.rb
+++ b/test/unit/packwerk/reference_extractor_test.rb
@@ -222,7 +222,7 @@ module Packwerk
         @expected_args = expected_args
       end
 
-      def constant_name_from_node(node, ancestors:)
+      def constant_name_from_node(node, ancestors:, relative_file:)
         return nil unless @association
         return nil unless NodeHelpers.method_call?(node)
 


### PR DESCRIPTION
## What are you trying to accomplish?

Fixes #370 

## What approach did you choose and why?

Other gems like ActiveModel::Serializers define association methods that reference serializers. We can ignore these files entirely with an exclude pattern.

## What should reviewers focus on?

The exclude pattern breaks public API, and we only get guarantees from Sorbet if the plugin package uses it (and they don't have to). So, I added an ArgumentError check to make sure all we still support the old signatures without `relative_file`. We could alternatively proceed without this precaution, so I can drop the commit if needed.

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
