### PR TITLE
Don't report violations until told to do so

### DIFF
--- a/lib/packwerk/generators/templates/package.yml
+++ b/lib/packwerk/generators/templates/package.yml
@@ -2,8 +2,8 @@
 # Please validate the configuration using `packwerk validate` (for Rails applications) or running the auto generated
 # test case (for non-Rails projects). You can then use `packwerk check` to check your code.
 
-# Turn on dependency checks for this package
-enforce_dependencies: true
+# Change to `true` to turn on dependency checks for this package
+enforce_dependencies: false
 
 # A list of this package's dependencies
 # Note that packages in this list require their own `package.yml` file


### PR DESCRIPTION
## What are you trying to accomplish?

Packwerk is not opinionated about where you draw boundaries and which direction your dependencies have.

It's a tool that helps you enforce or move towards an architecture that you come up with.

So it shouldn't return errors unless a constraint specified by the user is violated.

Right now we set `enforce_dependencies: true` in the root package in `packwerk init`, with no list of dependencies (defaults to empty). This means that any newly introduced package may cause packwerk to report violations, even before the user has specified how this new package fits in with the application's architecture.

For example, see [my blog post about enforcing `lib/` to not have dependencies](https://simplexity.quest/posts/2023-12-23-lib-is-for-libraries.html#making-it-so).

## What approach did you choose and why?

Do not enforce anything on the root package by default. This is the simplest solution. Packwerk doesn't enforce anything by default. That means only user-specified constraints are enforced.

## What should reviewers focus on?

Is there any documentation I need to change along with this?

## Type of Change

- [X] Bugfix
  - I would call this a bugfix to `packwerk init`, but at the very least it's a breaking change to it. 
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - Not a breaking change for existing installs.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] It is safe to rollback this change.
