### PR TITLE
Change recommended drawing library

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Read [USAGE.md](USAGE.md) for usage once Packwerk is installed on your project.
 
 Various third parties have built tooling on top of packwerk. Here's a selection of some that might prove useful:
 
-- https://github.com/bellroy/graphwerk draws a graph of your package dependencies
+- https://github.com/rubyatscale/visualize_packs draws a graph of your package dependencies
 - https://github.com/rubyatscale/packwerk-vscode integrates packwerk into Visual Studio Code so you can see violations right in your editor
 - https://github.com/vinted/packwerk-intellij integrates packwerk into RubyMine so you can see violations right in your editor
 - https://github.com/rubyatscale/packs-rails sets up Rails autoloading, as well as `rspec` and `FactoryBot` integration, for packages arranged in a flat list. packs-rails is quite convenient, but for autoloading we recommend to use `Rails::Engine`s instead.


### PR DESCRIPTION
## What are you trying to accomplish?

Change the drawing library introduced as the packwerk ecosystem from [graphwerk](https://github.com/samuelgiles/graphwerk) gem to [visualize_packs](https://github.com/rubyatscale/visualize_packs) gem.

## What approach did you choose and why?

The graphwerk gem is introduced as part of the ecosystem, but the graphwerk gem has not been maintained recently.

Since the visualize_packs gem is more actively maintained, I thought it would be appropriate to introduce the visualize_packs gem as part of the ecosystem.

## What should reviewers focus on?

Please determine if the visualize_packs gem is appropriate as a recommended drawing library.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
