### PR TITLE
stricter gemspec file include

### DIFF
--- a/packwerk.gemspec
+++ b/packwerk.gemspec
@@ -33,9 +33,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables << "packwerk"
 
-  spec.files = Dir.chdir(__dir__) do
-    %x(git ls-files -z).split("\x0").reject { |f| f.match(%r{^(test|spec|features|static)/}) }
-  end
+  spec.files = Dir["CHANGELOG.md", "LICENSE.md", "README.md", "lib/**/*", "sorbet/**/*"]
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.7"


### PR DESCRIPTION
## What are you trying to accomplish?

Reduce gemfile size by not including unnecessary files during packaging

### Size reduction: -19.5%

```shell
du -k packwerk-3.2.0*
1764    packwerk-3.2.0-new.gem
2164    packwerk-3.2.0.gem
```

## What approach did you choose and why?

Followed common pattern to explicitly define files and directories to include in the gem. The pattern is described in the The [Packaging Style Guide](https://packaging.rubystyle.guide/) from [Rubocop](https://packaging.rubystyle.guide/).

## What should reviewers focus on?

Any missing required file in the gem.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
