### PR TITLE
Custom offenses formatter docs fix

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -264,7 +264,7 @@ You can also reference the name of a gem.
 
 While `packwerk` ships with its own offense formatter, you may specify a custom one in your configuration file via the `offenses_formatter:` key.  Your custom formatter will be used when `bin/packwerk check` is run.
 
-Firstly, you'll need to create an `OffensesFormatter` class that includes `Packwerk::OffensesFormatter`. You can use [`Packwerk::Formatters::OffensesFormatter`](lib/packwerk/formatters/offenses_formatter.rb) as a point of reference for this. Then, in the `require` directive described above, you'll want to tell `packwerk` about it:
+Firstly, you'll need to create an `OffensesFormatter` class that includes `Packwerk::OffensesFormatter`. You can use [`Packwerk::Formatters::DefaultOffensesFormatter`](lib/packwerk/formatters/default_offenses_formatter.rb) as a point of reference for this. Then, in the `require` directive described above, you'll want to tell `packwerk` about it:
 ```ruby
 # ./path/to/file.rb
 class MyOffensesFormatter


### PR DESCRIPTION
## What are you trying to accomplish?

Fix the docs!  More specifically a broken link in them

## What approach did you choose and why?

I updated the URL to what looked like the correct destination.  Why?  I just felt like it was the right thing to do.

## What should reviewers focus on?

The link to the DefaultOffensesFormatter in the Custom Offenses Formatter section

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
