### PR TITLE
don't associate a file with a different package that matches a prefix

### DIFF
--- a/lib/packwerk/package.rb
+++ b/lib/packwerk/package.rb
@@ -42,7 +42,7 @@ module Packwerk
     def package_path?(path)
       return true if root?
 
-      path.start_with?(@name)
+      path.start_with?(@name + "/")
     end
 
     sig { params(other: T.untyped).returns(T.nilable(Integer)) }

--- a/test/unit/packwerk/package_test.rb
+++ b/test/unit/packwerk/package_test.rb
@@ -22,6 +22,10 @@ module Packwerk
       assert_equal(true, root_package.package_path?("components/unknown"))
     end
 
+    test "#package_path? returns false for different path with matching prefix" do
+      assert_equal(false, @package.package_path?("components/timeline_ui/something.rb"))
+    end
+
     test "#<=> compares against name" do
       assert_equal(-1, @package <=> Package.new(name: "components/xyz", config: {}))
       assert_equal(0, @package <=> Package.new(name: "components/timeline", config: {}))


### PR DESCRIPTION
## What are you trying to accomplish?
Fix https://github.com/Shopify/packwerk/issues/297

## What approach did you choose and why?
I think technically we shouldn't do string comparison for this, but the fix was so easy, and swapping in Pathname everywhere quite a bit of work, so I opted for this variant

## What should reviewers focus on?


## Type of Change

- [X] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [X] Breaking change (fix or feature that would cause existing functionality to change)
This may reattribute files to other packages (the correct packages) and thus add or remove violations.

## Checklist

- [x] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] It is safe to rollback this change.

## Additional Notes

This work is sponsored by https://www.onemedical.com/
