### PR TITLE
Improve dependency validator's performance

### DIFF
--- a/lib/packwerk/graph.rb
+++ b/lib/packwerk/graph.rb
@@ -4,79 +4,36 @@
 module Packwerk
   # A general implementation of a graph data structure with the ability to check for - and list - cycles.
   class Graph
+    include TSort
+
     extend T::Sig
     sig do
       params(
-        # The edges of the graph; An edge being represented as an Array of two nodes.
-        edges: T::Array[T::Array[T.any(String, Integer, NilClass)]]
+        # The edges of the graph; represented as an Hash of Arrays.
+        edges: T::Hash[T.any(String, Integer, NilClass), T::Array[T.any(String, Integer, NilClass)]]
       ).void
     end
     def initialize(edges)
-      @edges = edges.uniq
-      @cycles = Set.new
-      process
+      @edges = edges
     end
 
     def cycles
-      @cycles.dup
+      @cycles ||= strongly_connected_components.reject { _1.size == 1 }
     end
 
     def acyclic?
-      @cycles.empty?
+      cycles.empty?
     end
 
-    private
-
-    def nodes
-      @edges.flatten.uniq
+    private def tsort_each_node(&block)
+      @edges.each_key(&block)
     end
 
-    def process
-      # See https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search
-      @processed ||= begin
-        nodes.each { |node| visit(node) }
-        true
-      end
-    end
+    EMPTY_ARRAY = [].freeze
+    private_constant :EMPTY_ARRAY
 
-    def visit(node, visited_nodes: Set.new, path: [])
-      # Already visited, short circuit to avoid unnecessary processing
-      return if visited_nodes.include?(node)
-
-      # We've returned to a node that we've already visited, so we've found a cycle!
-      if path.include?(node)
-        # Filter out the part of the path that isn't a cycle. For example, with the following path:
-        #
-        #   a -> b -> c -> d -> b
-        #
-        # "a" isn't part of the cycle. The cycle should only appear once in the path, so we reject
-        # everything from the beginning to the first instance of the current node.
-        add_cycle(path.drop_while { |n| n != node })
-        return
-      end
-
-      path << node
-      neighbours(node).each do |neighbour|
-        visit(neighbour, visited_nodes: visited_nodes, path: path)
-      end
-      path.pop
-    ensure
-      visited_nodes << node
-    end
-
-    def neighbours(node)
-      @edges
-        .lazy
-        .select { |src, _dst| src == node }
-        .map { |_src, dst| dst }
-    end
-
-    def add_cycle(cycle)
-      # Ensure that the lexicographically smallest item is the first one labeled in a cycle
-      min_node = cycle.min
-      cycle.rotate! until cycle.first == min_node
-
-      @cycles << cycle
+    private def tsort_each_child(node, &block)
+      (@edges[node] || EMPTY_ARRAY).each(&block)
     end
   end
 

--- a/lib/packwerk/validators/dependency_validator.rb
+++ b/lib/packwerk/validators/dependency_validator.rb
@@ -65,10 +65,11 @@ module Packwerk
 
       sig { params(package_set: PackageSet).returns(Validator::Result) }
       def check_acyclic_graph(package_set)
-        edges = package_set.flat_map do |package|
-          package.dependencies.map do |dependency|
-            [package.name, package_set.fetch(dependency)&.name]
-          end
+        edges = package_set.to_h do |package|
+          [
+            package.name,
+            package.dependencies.map { |dependency| package_set.fetch(dependency)&.name },
+          ]
         end
 
         dependency_graph = Graph.new(edges)

--- a/test/unit/packwerk/dependency_validator_test.rb
+++ b/test/unit/packwerk/dependency_validator_test.rb
@@ -25,7 +25,7 @@ module Packwerk
 
       refute result.ok?
       assert_match(/Expected the package dependency graph to be acyclic/, result.error_value)
-      assert_match %r{components/sales → components/timeline → components/sales}, result.error_value
+      assert_match %r{components/timeline → components/sales → components/timeline}, result.error_value
     end
 
     test "returns error when config contains invalid package dependency" do

--- a/test/unit/packwerk/graph_test.rb
+++ b/test/unit/packwerk/graph_test.rb
@@ -6,13 +6,13 @@ require "test_helper"
 module Packwerk
   class GraphTest < Minitest::Test
     test "#acyclic? returns true for a directed acyclic graph" do
-      graph = Graph.new([[1, 2], [1, 3], [2, 4], [3, 4]])
+      graph = Graph.new({ 1 => [2, 3], 2 => [4], 3 => [4] })
 
       assert_predicate graph, :acyclic?
     end
 
     test "#acyclic? returns false for a cyclic graph" do
-      graph = Graph.new([[1, 2], [2, 3], [3, 1]])
+      graph = Graph.new({ 1 => [2], 2 => [3], 3 => [1] })
 
       refute_predicate graph, :acyclic?
     end
@@ -27,23 +27,23 @@ module Packwerk
       #       |      |
       #       +- 6 <-
       #
-      graph = Graph.new([[1, 2], [2, 3], [3, 2], [1, 4], [4, 5], [5, 6], [6, 4]])
+      graph = Graph.new({ 1 => [2, 4], 2 => [3], 3 => [2], 4 => [5], 5 => [6], 6 => [4] })
 
       assert_equal [[2, 3], [4, 5, 6]], graph.cycles.sort
     end
 
     test "#cycles returns overlapping cycles in a graph" do
-      graph = Graph.new([[1, 2], [2, 3], [1, 4], [4, 3], [3, 1]])
+      graph = Graph.new({ 1 => [2, 4], 2 => [3], 3 => [1], 4 => [3] })
 
-      assert_equal [[1, 2, 3], [1, 4, 3]], graph.cycles.sort
+      assert_equal [[1, 2, 3, 4]], graph.cycles.sort
     end
 
     test "#cycles returns cycles in a graph with disjoint subgraphs" do
-      graph = Graph.new([
-        [1, 2], [2, 3], [3, 1],
-        [4, 5], [4, 6], [5, 7], [6, 7],
-        [8, 9], [9, 8], [8, 10], [10, 11], [8, 11],
-      ])
+      graph = Graph.new({
+        1 => [2], 2 => [3], 3 => [1],
+        4 => [5, 6], 5 => [7], 6 => [7],
+        8 => [9, 10, 11], 9 => [8], 10 => [11],
+      })
 
       assert_equal [[1, 2, 3], [8, 9]], graph.cycles.sort
     end


### PR DESCRIPTION
## What are you trying to accomplish?

`Packwerk::Graph` has its own implementation of the topological sorting algorithm. Ruby has stdlib module `TSort` that does the same thing (by the way, `rails` use it). I replace own implementation with TSort

## What approach did you choose and why?

`TSort` works much faster (benchmarks attached) with almost same output results. And it does not require attention for support own implementation.

## What should reviewers focus on?

The cycles shown in the test `#cycles returns overlapping cycles in a graph` differ from the original results. But the meaning remains the same (all cyclic dependencies are listed). Only the output format has changed. I suppose that can be sacrificed in favour of performance

## Type of Change

Basic functionality is intact, but there is a slight difference in the output of the results of dependency validator

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.

## Benchmarks

```ruby
# frozen_string_literal: true

require "bundler/inline"
require "tsort"

gemfile do
  source "https://rubygems.org"

  gem "benchmark-ips", require: "benchmark/ips"
  gem "packwerk"
end

def arr_to_hsh(arr)
  arr.group_by(&:first).transform_values { |arr_list| arr_list.map(&:last) }
end

module Packwerk
  class GraphWithTsort
    include TSort

    extend T::Sig
    sig do
      params(
        # The edges of the graph; represented as an Hash of Arrays.
        edges: T::Hash[T.any(String, Integer, NilClass), T::Array[T.any(String, Integer, NilClass)]]
      ).void
    end
    def initialize(edges)
      @edges = edges
    end

    def cycles
      @cycles ||= strongly_connected_components.reject { _1.size == 1 }
    end

    def acyclic?
      cycles.empty?
    end

    private def tsort_each_node(&block)
      @edges.each_key(&block)
    end

    EMPTY_ARRAY = [].freeze
    private_constant :EMPTY_ARRAY

    private def tsort_each_child(node, &block)
      (@edges[node] || EMPTY_ARRAY).each(&block)
    end
  end

  private_constant :GraphWithTsort

  arr = [[1, 2], [1, 3], [2, 4], [3, 4]]
  hsh = arr_to_hsh(arr)

  Benchmark.ips do |x|
    x.report("[original] test acyclic graph") do
      Graph.new(arr).acyclic?
    end

    x.report("[tsort] test acyclic graph") do
      GraphWithTsort.new(hsh).acyclic?
    end

    x.compare!
  end

  # Warming up --------------------------------------
  # [original] test acyclic graph     3.167k i/100ms
  #    [tsort] test acyclic graph    21.181k i/100ms
  #
  # Calculating -------------------------------------
  # [original] test acyclic graph    30.041k (± 1.2%) i/s   (33.29 μs/i) -    152.016k in   5.060974s
  #    [tsort] test acyclic graph   197.479k (± 1.3%) i/s    (5.06 μs/i) -    995.507k in   5.041948s
  #
  # Comparison:
  #    [tsort] test acyclic graph:   197479.2 i/s
  # [original] test acyclic graph:    30041.5 i/s - 6.57x  slower

  arr = [[1, 2], [2, 3], [3, 1]]
  hsh = arr_to_hsh(arr)

  Benchmark.ips do |x|
    x.report("[original] test cyclic graph") do
      Graph.new(arr).acyclic?
    end

    x.report("[tsort] test cyclic graph") do
      GraphWithTsort.new(hsh).acyclic?
    end

    x.compare!
  end

  # Warming up --------------------------------------
  # [original] test cyclic graph
  #            3.076k i/100ms
  #    [tsort] test cyclic graph
  #            30.150k i/100ms
  # Calculating -------------------------------------
  # [original] test cyclic graph
  #            29.158k (± 4.3%) i/s   (34.30 μs/i) -    147.648k in   5.074331s
  #    [tsort] test cyclic graph
  #            251.707k (±12.1%) i/s   (3.97 μs/i) -      1.266M in   5.103329s
  #
  # Comparison:
  #    [tsort] test cyclic graph:   251707.4 i/s
  # [original] test cyclic graph:    29157.8 i/s - 8.63x  slower

  arr = [
    [1, 2], [2, 3], [3, 1],
    [4, 5], [4, 6], [5, 7], [6, 7],
    [8, 9], [9, 8], [8, 10], [10, 11], [8, 11],
  ]
  hsh = arr_to_hsh(arr)

  Benchmark.ips do |x|
    x.report("[original] test cycles in a graph with disjoint subgraphs") do
      Graph.new(arr).cycles
    end

    x.report("[tsort] test cycles in a graph with disjoint subgraphs") do
      GraphWithTsort.new(hsh).cycles
    end

    x.compare!
  end

  # Warming up --------------------------------------
  # [original] test cycles in a graph with disjoint subgraphs
  #            756.000 i/100ms
  #    [tsort] test cycles in a graph with disjoint subgraphs
  #            7.294k i/100ms
  # Calculating -------------------------------------
  # [original] test cycles in a graph with disjoint subgraphs
  #            7.031k (±11.0%) i/s  (142.24 μs/i) -   34.776k in   5.010366s
  #    [tsort] test cycles in a graph with disjoint subgraphs
  #            85.352k (±10.6%) i/s  (11.72 μs/i) -  423.052k in   5.016072s
  #
  # Comparison:
  #    [tsort] test cycles in a graph with disjoint subgraphs:    85351.8 i/s
  # [original] test cycles in a graph with disjoint subgraphs:     7030.5 i/s - 12.14x  slower
end
```
