### PR TITLE
Use hash-literal in package_test over kwarg

### DIFF
--- a/test/unit/packwerk/package_test.rb
+++ b/test/unit/packwerk/package_test.rb
@@ -34,7 +34,7 @@ module Packwerk
 
     test "#<=> does not compare against different class" do
       assert_nil(@package <=> "boop")
-      assert_nil(@package <=> Hash.new(name: "boop"))
+      assert_nil(@package <=> Hash.new({ name: "boop" }))
     end
 
     test "logical object equality is respected" do


### PR DESCRIPTION
It is deprecated in Ruby 3.3 and removed in 3.4.

## What are you trying to accomplish?

I am building and packaging Packwerk internally for Ruby 3.4.

This will be necessary in the future for upstream and so I am
contributing this minor change back.

## What approach did you choose and why?

Hash-literal

## What should reviewers focus on?

N/A

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [x] I have updated the documentation accordingly. (N/A)
- [x] I have added tests to cover my changes. (N/A)
- [x] It is safe to rollback this change.
