### PR TITLE
Handle upcoming prism deprecations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       constant_resolver (>= 0.3)
       parallel (< 2)
       parser
-      prism (>= 0.25.0)
+      prism (>= 1.4.0)
       sorbet-runtime (>= 0.5.9914)
       zeitwerk (>= 2.6.1)
 

--- a/packwerk.gemspec
+++ b/packwerk.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   # For Ruby parsing
   spec.add_dependency("ast")
   spec.add_dependency("parser")
-  spec.add_dependency("prism", ">= 0.25.0")
+  spec.add_dependency("prism", ">= 1.4.0")
 
   # For ERB parsing
   spec.add_dependency("better_html")


### PR DESCRIPTION
## What are you trying to accomplish?

Avoid prism deprecation warnings:
* https://github.com/ruby/prism/issues/3524
* https://github.com/ruby/prism/pull/3501

## What approach did you choose and why?

Use the non-deprecated classes. `Parser34` is available since 0.24.0 and can be used without concern. The builder is somewhat new, so I use `defined?` to check it and left a note for when it can be removed.

## What should reviewers focus on?

I left more context in the two commit messages.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
