### PR TITLE
Remove unused attribute from `NodeProcessorFactory`

### DIFF
--- a/lib/packwerk/node_processor_factory.rb
+++ b/lib/packwerk/node_processor_factory.rb
@@ -6,7 +6,6 @@ module Packwerk
     extend T::Sig
 
     const :root_path, String
-    const :context_provider, ConstantDiscovery
     const :constant_name_inspectors, T::Array[ConstantNameInspector]
 
     sig { params(relative_file: String, node: AST::Node).returns(NodeProcessor) }

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -107,7 +107,6 @@ module Packwerk
     sig { returns(NodeProcessorFactory) }
     def node_processor_factory
       NodeProcessorFactory.new(
-        context_provider: context_provider,
         root_path: @root_path,
         constant_name_inspectors: constant_name_inspectors
       )


### PR DESCRIPTION
## What are you trying to accomplish?

The `context_provider` attribute of `NodeProcessorFactory` seems to be unused so I want to delete it.

## What approach did you choose and why?

I just deleted it. Both typecheck and test passed.

That attribute was initially added by https://github.com/Shopify/packwerk/pull/63. At that time, `ReferenceExtractor` requires `context_provider` . But in #169, `context_provider` was removed from the argument of `ReferenceExtractor.new` .

## What should reviewers focus on?

If `context_provider` is used in some way or will be used in the future, please close this PR.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
