### PR TITLE
Add `benchmark` gem as a runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     packwerk (3.2.3)
       activesupport (>= 6.0)
       ast
+      benchmark
       better_html
       bundler
       constant_resolver (>= 0.3)

--- a/packwerk.gemspec
+++ b/packwerk.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.3"
 
   spec.add_dependency("activesupport", ">= 6.0")
+  spec.add_dependency("benchmark")
   spec.add_dependency("bundler")
   spec.add_dependency("constant_resolver", ">= 0.3")
   spec.add_dependency("parallel", "< 2")


### PR DESCRIPTION


## What are you trying to accomplish?

Allow to use `packwerk` on Ruby 4.0.


## What approach did you choose and why?

Add `benchmark` gem as a runtime dependency this is because since Ruby 4.0.0, `benchmark` gem is not part of the default gems. We need to add that to use on  Ruby 4.0+.

Fixes: https://github.com/Shopify/packwerk/issues/444

## What should reviewers focus on?


## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] It is safe to rollback this change.
