### PR TITLE
Add minitest-mock gem for minitest 6 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem("railties")
 
 gem("byebug")
 gem("minitest-focus")
+gem("minitest-mock")
 
 gem("m")
 gem("rake")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     minitest (5.25.5)
     minitest-focus (1.3.1)
       minitest (>= 4, < 6)
+    minitest-mock (5.27.0)
     mocha (2.5.0)
       ruby2_keywords (>= 0.0.5)
     netrc (0.11.0)
@@ -220,6 +221,7 @@ DEPENDENCIES
   constant_resolver
   m
   minitest-focus
+  minitest-mock
   mocha
   packwerk!
   railties

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ require "packwerk"
 
 require "minitest/autorun"
 require "minitest/focus"
+require "minitest/mock"
 require "mocha/minitest"
 require "support/packwerk/application_fixture_helper"
 require "support/packwerk/factory_helper"


### PR DESCRIPTION
## Summary

* minitest 6 extracted `Object#stub` into a separate `minitest-mock` gem
* Add `minitest-mock` to the Gemfile and require it in the test helper to restore `stub` functionality
* Fixes 4 test errors on Ruby 3.2 CI
