### PR TITLE
Fix dependabot indent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Looks like the automated change from https://github.com/Shopify/packwerk/pull/435 broke the indent.
