### PR TITLE
Bump Sorbet to 0.6.13184

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,5 +23,5 @@ gem("minitest-mock")
 
 gem("m")
 gem("rake")
-gem("sorbet-static-and-runtime", "< 0.6") # Sorbet 0.6+ has stricter type checking, bumped separately
+gem("sorbet-static-and-runtime")
 gem("zeitwerk")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,15 +182,15 @@ GEM
     rubydex (0.2.0-x86_64-linux)
     securerandom (0.4.1)
     smart_properties (1.17.0)
-    sorbet (0.5.12443)
-      sorbet-static (= 0.5.12443)
-    sorbet-runtime (0.5.12443)
-    sorbet-static (0.5.12443-aarch64-linux)
-    sorbet-static (0.5.12443-universal-darwin)
-    sorbet-static (0.5.12443-x86_64-linux)
-    sorbet-static-and-runtime (0.5.12443)
-      sorbet (= 0.5.12443)
-      sorbet-runtime (= 0.5.12443)
+    sorbet (0.6.13184)
+      sorbet-static (= 0.6.13184)
+    sorbet-runtime (0.6.13184)
+    sorbet-static (0.6.13184-aarch64-linux)
+    sorbet-static (0.6.13184-universal-darwin)
+    sorbet-static (0.6.13184-x86_64-linux)
+    sorbet-static-and-runtime (0.6.13184)
+      sorbet (= 0.6.13184)
+      sorbet-runtime (= 0.6.13184)
     spoom (1.7.13)
       erubi (>= 1.10.0)
       prism (>= 0.28.0)
@@ -246,7 +246,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-shopify
   rubocop-sorbet
-  sorbet-static-and-runtime (< 0.6)
+  sorbet-static-and-runtime
   spring
   tapioca
   zeitwerk

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -96,11 +96,11 @@ module Packwerk
       end
     end
 
-    sig { returns(T::Hash[String, Module]) }
+    sig { returns(T::Hash[String, T::Module[T.anything]]) }
     def load_paths
       @load_paths ||= T.let(
         RailsLoadPaths.for(@root_path, environment: "test"),
-        T.nilable(T::Hash[String, Module]),
+        T.nilable(T::Hash[String, T::Module[T.anything]]),
       )
     end
 

--- a/lib/packwerk/rails_load_paths.rb
+++ b/lib/packwerk/rails_load_paths.rb
@@ -11,7 +11,7 @@ module Packwerk
     class << self
       extend T::Sig
 
-      sig { params(root: String, environment: String).returns(T::Hash[String, Module]) }
+      sig { params(root: String, environment: String).returns(T::Hash[String, T::Module[T.anything]]) }
       def for(root, environment:)
         require_application(root, environment)
         all_paths = extract_application_autoload_paths
@@ -22,7 +22,7 @@ module Packwerk
 
       private
 
-      sig { returns(T::Hash[String, Module]) }
+      sig { returns(T::Hash[String, T::Module[T.anything]]) }
       def extract_application_autoload_paths
         Rails.autoloaders.inject({}) do |h, loader|
           h.merge(loader.dirs(namespaces: true))
@@ -30,8 +30,8 @@ module Packwerk
       end
 
       sig do
-        params(all_paths: T::Hash[String, Module], bundle_path: Pathname, rails_root: Pathname)
-          .returns(T::Hash[Pathname, Module])
+        params(all_paths: T::Hash[String, T::Module[T.anything]], bundle_path: Pathname, rails_root: Pathname)
+          .returns(T::Hash[Pathname, T::Module[T.anything]])
       end
       def filter_relevant_paths(all_paths, bundle_path: Bundler.bundle_path, rails_root: Rails.root)
         bundle_path_match = bundle_path.join("**")
@@ -43,7 +43,7 @@ module Packwerk
           .reject { |path| path.fnmatch(bundle_path_match.to_s) } # reject paths from vendored gems
       end
 
-      sig { params(load_paths: T::Hash[Pathname, Module], rails_root: Pathname).returns(T::Hash[String, Module]) }
+      sig { params(load_paths: T::Hash[Pathname, T::Module[T.anything]], rails_root: Pathname).returns(T::Hash[String, T::Module[T.anything]]) }
       def relative_path_strings(load_paths, rails_root: Rails.root)
         load_paths.transform_keys { |path| Pathname.new(path).relative_path_from(rails_root).to_s }
       end
@@ -61,7 +61,7 @@ module Packwerk
         end
       end
 
-      sig { params(paths: T::Hash[T.untyped, Module]).void }
+      sig { params(paths: T::Hash[T.untyped, T::Module[T.anything]]).void }
       def assert_load_paths_present(paths)
         if paths.empty?
           raise <<~EOS

--- a/lib/packwerk/run_context.rb
+++ b/lib/packwerk/run_context.rb
@@ -33,7 +33,7 @@ module Packwerk
     sig do
       params(
         root_path: String,
-        load_paths: T::Hash[String, Module],
+        load_paths: T::Hash[String, T::Module[T.anything]],
         inflector: T.class_of(ActiveSupport::Inflector),
         cache_directory: Pathname,
         config_path: T.nilable(String),

--- a/test/support/stub_const.rb
+++ b/test/support/stub_const.rb
@@ -6,7 +6,7 @@ module StubConst
 
   sig do
     params(
-      mod: Module,
+      mod: T::Module[T.anything],
       const: T.any(Symbol, String),
       value: Object,
       block: T.proc.void


### PR DESCRIPTION
## Summary

* Bump `sorbet-static-and-runtime` from 0.5.x to 0.6.13184
* Replace `Module` with `T::Module[T.anything]` in type signatures to satisfy Sorbet 0.6's stricter generic type argument requirements (4 files)
