### PR TITLE
We should not ship the contents of the `sorbet` folder in the gem

### DIFF
--- a/packwerk.gemspec
+++ b/packwerk.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables << "packwerk"
 
-  spec.files = Dir["CHANGELOG.md", "LICENSE.md", "README.md", "lib/**/*", "sorbet/**/*"]
+  spec.files = Dir["CHANGELOG.md", "LICENSE.md", "README.md", "lib/**/*"]
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 3.3"


### PR DESCRIPTION
The contents of the `sorbet` folder are only used for typechecking the project internally and is not useful for any of the consumers.
