### PR TITLE
feat: allow configuring load_paths for non-Rails (Zeitwerk) apps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
       rexml (>= 3.2.6)
       sorbet-static-and-runtime (>= 0.5.10187)
       thor (>= 0.19.2)
-    spring (4.0.0)
+    spring (4.7.0)
     stringio (3.1.7)
     tapioca (0.19.1)
       benchmark

--- a/USAGE.md
+++ b/USAGE.md
@@ -82,6 +82,19 @@ Packwerk reads from the `packwerk.yml` configuration file in the root directory.
 | parallel             | true                                      | when true, fork code parsing out to subprocesses |
 | cache                | false                                     | when true, caches the results of parsing files |
 | cache_directory      | tmp/cache/packwerk                        | the directory that will hold the packwerk cache |
+| load_paths           | N/A                                       | list of Zeitwerk root directories, for non-Rails applications (see below) |
+
+### Using Packwerk without Rails
+
+By default Packwerk boots your Rails application to discover its autoload paths from `Rails.autoloaders`. Applications that use [Zeitwerk](https://github.com/fxn/zeitwerk) directly (without Rails) can instead declare their load paths explicitly with the `load_paths` key:
+
+```yaml
+load_paths:
+  - app
+  - lib
+```
+
+Each entry is a directory relative to `packwerk.yml`, and should mirror the `push_dir` calls your application makes when configuring its `Zeitwerk::Loader`. Globs are supported (e.g. `packs/*/app/models`). Custom root namespaces (`push_dir(dir, namespace: SomeModule)`) are not yet supported through this configuration.
 
 ### Using a custom ERB parser
 

--- a/lib/packwerk.rb
+++ b/lib/packwerk.rb
@@ -9,6 +9,8 @@ require "stringio"
 require "active_support/core_ext/string"
 # Provides Object#to_json
 require "active_support/core_ext/object/json"
+# Provides Object#present?/#blank?
+require "active_support/core_ext/object/blank"
 
 module Packwerk
   extend ActiveSupport::Autoload

--- a/lib/packwerk/configuration.rb
+++ b/lib/packwerk/configuration.rb
@@ -77,6 +77,7 @@ module Packwerk
       @config_path = config_path
 
       @offenses_formatter_identifier = configs["offenses_formatter"] || Formatters::DefaultOffensesFormatter::IDENTIFIER #: String
+      @config_load_paths = parse_config_load_paths(configs["load_paths"]) #: Array[String]
 
       if configs.key?("require")
         configs["require"].each do |require_directive|
@@ -87,7 +88,7 @@ module Packwerk
 
     #: -> Hash[String, Module[top]]
     def load_paths
-      @load_paths ||= RailsLoadPaths.for(@root_path, environment: "test") #: Hash[String, Module[top]]?
+      @load_paths ||= resolve_load_paths #: Hash[String, Module[top]]?
     end
 
     #: -> bool
@@ -103,6 +104,60 @@ module Packwerk
     #: -> bool
     def cache_enabled?
       @cache_enabled
+    end
+
+    private
+
+    #: -> Hash[String, Module[top]]
+    def resolve_load_paths
+      if @config_load_paths.any? # non-Rails app
+        load_paths_from_config
+      elsif File.file?(File.join(@root_path, "config", "environment.rb")) # Rails app
+        RailsLoadPaths.for(@root_path, environment: "test")
+      else
+        raise <<~MSG
+          Packwerk could not determine your application's load paths.
+
+          If this is a Rails application, run Packwerk from its root directory
+          (the one containing config/environment.rb).
+
+          Otherwise, list your Zeitwerk root directories explicitly in packwerk.yml, e.g.:
+
+            load_paths:
+              - app
+              - lib
+        MSG
+      end
+    end
+
+    #: -> Hash[String, Module[top]]
+    def load_paths_from_config
+      paths = @config_load_paths
+        .flat_map { |glob| Dir.glob(glob, base: @root_path) }
+        .select { |path| File.directory?(File.join(@root_path, path)) }
+        .uniq
+
+      if paths.empty?
+        raise <<~MSG
+          The `load_paths` configured in packwerk.yml did not match any directories:
+            #{@config_load_paths.inspect}
+
+          Packwerk will not work correctly without any load paths.
+        MSG
+      end
+
+      paths.to_h { |path| [path, Object] }
+    end
+
+    #: (untyped raw) -> Array[String]
+    def parse_config_load_paths(raw)
+      return [] if raw.nil?
+
+      unless raw.is_a?(Array) && raw.all?(String)
+        raise ArgumentError, "`load_paths` in packwerk.yml must be a list of strings, got: #{raw.inspect}"
+      end
+
+      raw
     end
   end
 end

--- a/lib/packwerk/generators/templates/packwerk.yml.erb
+++ b/lib/packwerk/generators/templates/packwerk.yml.erb
@@ -21,3 +21,10 @@
 
 # Where you want the cache to be stored (default below)
 # cache_directory: 'tmp/cache/packwerk'
+
+# For non-Rails applications: the list of Zeitwerk root directories, relative to
+# this file. Mirror your app's `Zeitwerk::Loader#push_dir` calls. Globs are supported.
+# When set, Packwerk will not attempt to boot a Rails application.
+# load_paths:
+# - "app"
+# - "lib"

--- a/test/unit/packwerk/configuration_test.rb
+++ b/test/unit/packwerk/configuration_test.rb
@@ -82,6 +82,74 @@ module Packwerk
       remove_extensions
     end
 
+    test "#load_paths uses explicitly configured load_paths and never boots Rails" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("packwerk.yml", { "load_paths" => ["components/sales/app/models"] })
+
+      RailsLoadPaths.expects(:for).never
+
+      configuration = Configuration.from_path(app_dir)
+
+      assert_equal({ "components/sales/app/models" => Object }, configuration.load_paths)
+    end
+
+    test "#load_paths expands globs in configured load_paths" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("packwerk.yml", { "load_paths" => ["components/*/app/models"] })
+
+      configuration = Configuration.from_path(app_dir)
+
+      assert_equal({ "components/sales/app/models" => Object }, configuration.load_paths)
+    end
+
+    test "#load_paths deduplicates paths matched by overlapping entries" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("packwerk.yml", {
+        "load_paths" => ["components/sales/app/models", "components/*/app/models"],
+      })
+
+      configuration = Configuration.from_path(app_dir)
+
+      assert_equal({ "components/sales/app/models" => Object }, configuration.load_paths)
+    end
+
+    test "#load_paths falls back to RailsLoadPaths when no load_paths are configured" do
+      use_template(:minimal)
+      expected = { "app" => Object }
+      RailsLoadPaths.expects(:for).with(app_dir, environment: "test").returns(expected)
+
+      configuration = Configuration.from_path(app_dir)
+
+      assert_equal(expected, configuration.load_paths)
+    end
+
+    test "#load_paths raises a helpful error when not a Rails app and no load_paths are configured" do
+      use_template(:blank)
+
+      configuration = Configuration.from_path(app_dir)
+
+      error = assert_raises(RuntimeError) { configuration.load_paths }
+      assert_match(/load_paths/, error.message)
+      assert_match(%r{config/environment\.rb}, error.message)
+    end
+
+    test "#load_paths raises when configured load_paths match no directories" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("packwerk.yml", { "load_paths" => ["does_not_exist/**"] })
+
+      configuration = Configuration.from_path(app_dir)
+
+      error = assert_raises(RuntimeError) { configuration.load_paths }
+      assert_match(/did not match any directories/, error.message)
+    end
+
+    test "raises when load_paths is not a list of strings" do
+      use_template(:minimal)
+      merge_into_app_yaml_file("packwerk.yml", { "load_paths" => "app" })
+
+      assert_raises(ArgumentError) { Configuration.from_path(app_dir) }
+    end
+
     test "require works when referencing a gem" do
       use_template(:extended)
 


### PR DESCRIPTION
## What are you trying to accomplish?

I want to use it in my non-Rails (but Zeitwerk) apps. Packwerk is like 99% there already. This adds the last missing piece to run the check without loading Railties.


## What approach did you choose and why?

There was actually just 1 part that blew up when running this on a non Rails app: file path resolution relied on the Rails load path. It now allows to define load paths in the `packwerk.yml` file.

I also noticed two other minor bugs that blew up when Rails wasn't present. See commit messages :)

=> POC here: https://github.com/swiknaba/kirei/pull/39


=> if #410 get's merged, my PR should be trivial to update. Would need to return a `Zeitwerk::LOader` object instead of the `Hash[String, Module]`.

=> #447 makes my PR obsolete if I see it right, since it also removes any hard dependency on Railties. Feel free to discard my PR if 447 gets merged soon anyway.

## What should reviewers focus on?

no clue what to write here. Tiny change I believe. Thanks for making this open source <3

## Type of Change

- [x] Bugfix <= two tiny 1-liner fixes snugged in
- [x] New feature <= main thing here
- [ ] Non-breaking change (a change that doesn't alter functionality - i.e., code refactor, configs, etc.)

### Additional Release Notes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Include any notes here to include in the release description. For example, if you selected "breaking change" above, leave notes on how users can transition to this version.

If no additional notes are necessary, delete this section or leave it unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] It is safe to rollback this change.


### Before

=> from my dummy test app, see link "POC" above

<img width="1619" height="1223" alt="before-failing" src="https://github.com/user-attachments/assets/5ad0369f-3376-494f-92d0-d88784a637f1" />

### After

=> from my dummy test app, see link "POC" above

<img width="1311" height="951" alt="after-works" src="https://github.com/user-attachments/assets/3ad77372-2dc8-4f79-8261-7aa4cdb9fc5e" />

